### PR TITLE
fix symlink inside docker by mounting an actual file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: freqtrade-backtesting
     volumes:
       - "./user_data:/freqtrade/user_data"
+      - "./NostalgiaForInfinityNext.py:/freqtrade/NostalgiaForInfinityNext.py"
     command: >
       backtesting
       --strategy-list NostalgiaForInfinityNext

--- a/user_data/pairlists.json
+++ b/user_data/pairlists.json
@@ -6,7 +6,7 @@
   "fiat_display_currency": "USD",
   "timeframe": "5m",
   "dry_run": false,
-  "dry_run_wallet": 112,
+  "dry_run_wallet": 1000,
   "cancel_open_orders_on_exit": false,
   "bid_strategy": {
       "price_side": "ask",

--- a/user_data/pairlists.json
+++ b/user_data/pairlists.json
@@ -6,7 +6,7 @@
   "fiat_display_currency": "USD",
   "timeframe": "5m",
   "dry_run": false,
-  "dry_run_wallet": 1000,
+  "dry_run_wallet": 112,
   "cancel_open_orders_on_exit": false,
   "bid_strategy": {
       "price_side": "ask",


### PR DESCRIPTION
actions are broken right now with
 
freqtrade - ERROR - Impossible to load Strategy 'NostalgiaForInfinityNext'. This class does not exist or contains Python code errors.

 this seem to fixes it.
