### PR TITLE
Set default for variables into docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,10 @@ services:
     command: >
       backtesting
       --strategy-list NostalgiaForInfinityNext
-      --timerange ${TIMERANGE}
+      --timerange ${TIMERANGE:-20210601-20210701}
       --config user_data/pairlists.json
-      --max-open-trades
-      ${MAX_OPEN_TRADES}
-      --stake-amount ${STAKE_AMOUNT}
+      --max-open-trades ${MAX_OPEN_TRADES:-1}
+      --stake-amount ${STAKE_AMOUNT:-unlimited}
   download-data:
     image: freqtradeorg/freqtrade:develop
     container_name: download-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       --strategy-list NostalgiaForInfinityNext
       --timerange ${TIMERANGE:-20210601-20210701}
       --config user_data/pairlists.json
-      --max-open-trades ${MAX_OPEN_TRADES:-1}
+      --max-open-trades ${MAX_OPEN_TRADES:-5}
       --stake-amount ${STAKE_AMOUNT:-unlimited}
   download-data:
     image: freqtradeorg/freqtrade:develop


### PR DESCRIPTION
This way .env file is not required, but taken in account if present

That's another way to close #6 