### PR TITLE
Fix codemod parsing issue

### DIFF
--- a/codemods/ho_to_raw_codemod.py
+++ b/codemods/ho_to_raw_codemod.py
@@ -1,8 +1,7 @@
 import ast
 import re
-
 pattern = re.compile(
-    r"(CategoricalParameter|DecimalParameter|IntParameter|RealParameter).*(default=)(?P<value>.+?)[,|\)].*"
+    r"(CategoricalParameter|DecimalParameter|IntParameter|RealParameter).*((default=)(?P<value>.+?),.*\)|(default=)(?P<edge_value>.+?)\))"
 )
 
 
@@ -13,7 +12,7 @@ def validate_syntax(src: str):
 def transform_code(src: str):
     def repl(matchobj):
         groupdict = matchobj.groupdict()
-        return groupdict["value"]
+        return groupdict["value"] or groupdict["edge_value"]
 
     return pattern.sub(repl, src)
 

--- a/tests/unit/test_ho_to_raw_codemod.py
+++ b/tests/unit/test_ho_to_raw_codemod.py
@@ -72,24 +72,24 @@ buy_protection_params = {
     expected_output = """
 buy_protection_params = {
     1: {
-            "enable"                    : True
-            "ema_fast"                  : False
-            "ema_fast_len"              : "26"
-            "ema_slow"                  : True
-            "ema_slow_len"              : "100"
-            "close_above_ema_fast"      : False
-            "close_above_ema_fast_len"  : "200"
-            "close_above_ema_slow"      : False
-            "close_above_ema_slow_len"  : "200"
-            "sma200_rising"             : True
-            "sma200_rising_val"         : "28"
-            "sma200_1h_rising"          : False
-            "sma200_1h_rising_val"      : "50"
-            "safe_dips"                 : True
-            "safe_dips_type"            : "80"
-            "safe_pump"                 : True
-            "safe_pump_type"            : "70"
-            "safe_pump_period"          : "24"
+            "enable"                    : True,
+            "ema_fast"                  : False,
+            "ema_fast_len"              : "26",
+            "ema_slow"                  : True,
+            "ema_slow_len"              : "100",
+            "close_above_ema_fast"      : False,
+            "close_above_ema_fast_len"  : "200",
+            "close_above_ema_slow"      : False,
+            "close_above_ema_slow_len"  : "200",
+            "sma200_rising"             : True,
+            "sma200_rising_val"         : "28",
+            "sma200_1h_rising"          : False,
+            "sma200_1h_rising_val"      : "50",
+            "safe_dips"                 : True,
+            "safe_dips_type"            : "80",
+            "safe_pump"                 : True,
+            "safe_pump_type"            : "70",
+            "safe_pump_period"          : "24",
             "btc_1h_not_downtrend"      : False
     }
 }

--- a/tests/unit/test_ho_to_raw_codemod.py
+++ b/tests/unit/test_ho_to_raw_codemod.py
@@ -1,7 +1,7 @@
-from codemods.ho_to_raw_codemod import transform_code
 import ast
 import traceback
 
+from codemods.ho_to_raw_codemod import transform_code
 from tests.unit.conftest import REPO_ROOT
 
 

--- a/tests/unit/test_ho_to_raw_codemod.py
+++ b/tests/unit/test_ho_to_raw_codemod.py
@@ -1,5 +1,4 @@
 import ast
-import traceback
 
 from codemods.ho_to_raw_codemod import transform_code
 from tests.unit.conftest import REPO_ROOT

--- a/tests/unit/test_ho_to_raw_codemod.py
+++ b/tests/unit/test_ho_to_raw_codemod.py
@@ -1,4 +1,8 @@
 from codemods.ho_to_raw_codemod import transform_code
+import ast
+import traceback
+
+from tests.unit.conftest import REPO_ROOT
 
 
 def test_transform_code_categorical_param():
@@ -95,3 +99,17 @@ buy_protection_params = {
 }
 """
     assert transform_code(code_input.strip()) == expected_output.strip()
+
+
+def test_transform_code_syntax():
+    source = ""
+    with open(REPO_ROOT.joinpath("NostalgiaForInfinityNext.py")) as f:
+        source = f.read()
+
+    is_valid = True
+    try:
+        ast.parse(transform_code(source))
+    except SyntaxError:
+        is_valid = False
+
+    assert is_valid is True


### PR DESCRIPTION
The codemod had an issue where it parses the whole line as opposed to the needed characters. This caused the parsing to remove commas unnecessarily, and thus the transformed file had syntax errors. This PR fixes that