### PR TITLE
Added Binance and FTX Blacklist

### DIFF
--- a/blacklist-binance.json
+++ b/blacklist-binance.json
@@ -1,0 +1,20 @@
+{
+  "exchange": {
+    "pair_blacklist": [
+      // Exchange Tokens
+      "BNB/.*",
+      // Major Crypto
+      "(BTC|ETH)/.*",
+      // Leverage tokens
+      ".*(UP|DOWN)/.*",
+      // Fiat
+      "(AUD|EUR|GBP|CHF|CAD|JPY)/.*",
+      // Stable tokens
+      "(BUSD|USDT|TUSD|USDC|CUSDT)/.*",
+      // FAN Tokens
+      "(ACM|AFA|ALA|ALL|APL|ASR|ATM|BAR|CAI|CITY|FOR|GAL|GOZ|IBFK|JUV|LEG|LOCK-1|NAVI|NMR|NOV|OG|PFL|PSG|ROUSH|STV|TH|TRA|UCH|UFC|YBO)/.*",
+      // Shit Coins
+      "(CHZ|CTXC|HBAR|NMR|SHIB|SLP|XVS|ZEN)/.*"
+    ]
+  }
+}

--- a/blacklist-ftx.json
+++ b/blacklist-ftx.json
@@ -1,0 +1,21 @@
+{
+  "exchange": {
+    "pair_blacklist": [
+      // Exchange Tokens
+      "FTT/.*",
+      // Major Crypto
+      "(BTC|ETH)/.*",
+      // Leverage tokens
+      ".*(BULL|BEAR|HALF|HEDGE|-PERP)/.*",
+      "(BVOL|IBVOL)/.*",
+      // Fiat
+      "(AUD|EUR|GBP|CHF|CAD|JPY)/.*",
+      // Stable tokens
+      "(BUSD|USDT|TUSD|USDC|CUSDT)/.*",
+      // FAN Tokens
+      "(ACM|AFA|ALA|ALL|APL|ASR|ATM|BAR|CAI|CITY|FOR|GAL|GOZ|IBFK|JUV|LEG|LOCK-1|NAVI|NMR|NOV|OG|PFL|PSG|ROUSH|STV|TH|TRA|UCH|UFC|YBO)/.*",
+      // Shit Coins
+      "(CHZ|CTXC|HBAR|NMR|SHIB|SLP|XVS|ZEN)/.*"
+    ]
+  }
+}


### PR DESCRIPTION
Separate config files for blacklists per exchange so it can be maintained in this git repository. 
Blacklist is stake independent because i think when you have a shitcoin on USDT, it will also be a shitcoin on BUSD :-) 
Simply copy these files to your user_data directory (or symlink to it) and append to your freqtrade command like you would do with the private file for your exchange keys.

If additional information is needed, don't hesitate to contact me.
 