### PR TITLE
Hold trade pairs support

### DIFF
--- a/configs/hold-trades.json
+++ b/configs/hold-trades.json
@@ -1,1 +1,0 @@
-{"trade_ids": [], "profit_ratio": 0.005}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -370,7 +370,7 @@ def get_default_conf(testdatadir):
         "datadir": str(testdatadir),
         "initial_state": "running",
         "db_url": "sqlite://",
-        "user_data_dir": Path("user_data"),
+        "user_data_dir": testdatadir,
         "verbosity": 3,
         "strategy_path": str(testdatadir / "strategies"),
         "strategy": "NostalgiaForInfinityNext",

--- a/tests/unit/test_hold_config_loading.py
+++ b/tests/unit/test_hold_config_loading.py
@@ -40,13 +40,13 @@ def v2_syntax_hold_file(testdatadir, initial_trade):
 def test_hold_support_v1_syntax(strategy, v1_syntax_hold_file):
     assert strategy.get_hold_trades_config_file() == v1_syntax_hold_file
     strategy.load_hold_trades_config()
-    assert strategy.hold_trades_cache.data == {1: 0.0025}
+    assert strategy.hold_trades_cache.data == {"trade_ids": {1: 0.0025}}
 
 
 def test_hold_support_v2_syntax(strategy, v2_syntax_hold_file):
     assert strategy.get_hold_trades_config_file() == v2_syntax_hold_file
     strategy.load_hold_trades_config()
-    assert strategy.hold_trades_cache.data == {1: 0.0035}
+    assert strategy.hold_trades_cache.data == {"trade_ids": {1: 0.0035}}
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ def symlink_strat(testdatadir, strategy, initial_trade):
 def test_symlinked_strat_hold_config_file(symlink_strat, testdatadir):
     assert testdatadir.joinpath("strategies", "NostalgiaForInfinityNext.py").is_symlink()
     symlink_strat.load_hold_trades_config()
-    assert symlink_strat.hold_trades_cache.data == {1: 0.0025}
+    assert symlink_strat.hold_trades_cache.data == {"trade_ids": {1: 0.0025}}
 
 
 def test_missing_hold_trades(strategy, caplog, testdatadir):
@@ -104,7 +104,7 @@ def test_missing_hold_trades_symlinked_strat(symlink_strat_no_config, caplog, te
 def test_hold_caches_save_raises_exception(strategy, v2_syntax_hold_file):
     assert strategy.get_hold_trades_config_file() == v2_syntax_hold_file
     strategy.load_hold_trades_config()
-    assert strategy.hold_trades_cache.data == {1: 0.0035}
-    strategy.hold_trades_cache.data[2] = 0.0035
+    assert strategy.hold_trades_cache.data == {"trade_ids": {1: 0.0035}}
+    strategy.hold_trades_cache.data["trade_ids"][2] = 0.0035
     with pytest.raises(RuntimeError):
         strategy.hold_trades_cache.save()

--- a/tests/unit/test_hold_config_loading.py
+++ b/tests/unit/test_hold_config_loading.py
@@ -37,6 +37,13 @@ def v2_syntax_hold_file(testdatadir, initial_trade):
     return hold_trade_file
 
 
+@pytest.fixture
+def trade_pairs_hold_file(testdatadir, initial_trade):
+    hold_trade_file = testdatadir / "strategies" / "hold-trades.json"
+    hold_trade_file.write_text(json.dumps({"trade_pairs": {"BTC/USDT": 0.0035}}))
+    return hold_trade_file
+
+
 def test_hold_support_v1_syntax(strategy, v1_syntax_hold_file):
     assert strategy.get_hold_trades_config_file() == v1_syntax_hold_file
     strategy.load_hold_trades_config()
@@ -47,6 +54,12 @@ def test_hold_support_v2_syntax(strategy, v2_syntax_hold_file):
     assert strategy.get_hold_trades_config_file() == v2_syntax_hold_file
     strategy.load_hold_trades_config()
     assert strategy.hold_trades_cache.data == {"trade_ids": {1: 0.0035}}
+
+
+def test_trade_paits_hold_support_pairs(strategy, trade_pairs_hold_file):
+    assert strategy.get_hold_trades_config_file() == trade_pairs_hold_file
+    strategy.load_hold_trades_config()
+    assert strategy.hold_trades_cache.data == {"trade_pairs": {"BTC/USDT": 0.0035}}
 
 
 @pytest.fixture


### PR DESCRIPTION
* The holds file is now named `nfi-hold-trades.json` and is expected to be in the `user_data` directory. This will solve the symlink problem and is a better place to put these kind of files.
A log warning is issued for the old paths, and these old paths still work, at least until we remove those checks from the strat.
* Trade pairs holding is now supported too. Check the strat README section.