### PR TITLE
Update pairlist-volume-binance-usdt.json

### DIFF
--- a/configs/pairlist-volume-binance-usdt.json
+++ b/configs/pairlist-volume-binance-usdt.json
@@ -1,29 +1,27 @@
 {
-    "exchange": {
-        "pairlists": [
-            {
-                "method": "VolumePairList",
-                "number_assets": 80,
-                "sort_key": "quoteVolume",
-                "refresh_period": 1800
-            },
-            {"method": "AgeFilter", "min_days_listed": 3},
-            {"method": "SpreadFilter", "max_spread_ratio": 0.005},
-            {"method": "PriceFilter", "min_price": 0.0001},
-            {
-                "method": "RangeStabilityFilter",
-                "lookback_days": 3,
-                "min_rate_of_change": 0.1,
-                "refresh_period": 1440
-            },
-            {
-                "method": "VolatilityFilter",
-                "lookback_days": 4,
-                "min_volatility": 0.02,
-                "max_volatility": 0.75,
-                "refresh_period": 86400
-            },
-            {"method": "ShuffleFilter"}
-        ],
-    }
+    "pairlists": [
+        {
+            "method": "VolumePairList",
+            "number_assets": 80,
+            "sort_key": "quoteVolume",
+            "refresh_period": 1800
+        },
+        {"method": "AgeFilter", "min_days_listed": 3},
+        {"method": "SpreadFilter", "max_spread_ratio": 0.005},
+        {"method": "PriceFilter", "min_price": 0.0001},
+        {
+            "method": "RangeStabilityFilter",
+            "lookback_days": 3,
+            "min_rate_of_change": 0.1,
+            "refresh_period": 1440
+        },
+        {
+            "method": "VolatilityFilter",
+            "lookback_days": 4,
+            "min_volatility": 0.02,
+            "max_volatility": 0.75,
+            "refresh_period": 86400
+        },
+        {"method": "ShuffleFilter"}
+    ]
 }


### PR DESCRIPTION
If I try to use "configs/pairlist-volume-binance-usdt.json" file in
"freqtrade trade" command as follows,
freqtrade trade --config configs/pairlist-volume-binance-usdt.json [other command options here]

I get the following error:
ERROR - No Pairlist Handlers defined

To fix this, Updated pairlist-volume-binance-usdt.json to remove nesting under extra "exchange" key.

More info: https://www.freqtrade.io/en/stable/plugins/#pairlists-and-pairlist-handlers