### PR TITLE
Added message in dry run log when a new buy tag is created

### DIFF
--- a/NostalgiaForInfinityX.py
+++ b/NostalgiaForInfinityX.py
@@ -2358,6 +2358,12 @@ class NostalgiaForInfinityX(IStrategy):
             ):
                 return None
 
+        # Obtain pair dataframe
+        dataframe, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
+        last_candle = dataframe.iloc[-1].squeeze()
+        if last_candle['buy'] == 1 and self.dp.runmode.value in ('backtest','dry_run'):
+            log.info(f"dry run enabled, however a new buy tag is created for pair {trade.pair}")
+
         # Maximum 2 rebuys. Half the stake of the original.
         if 0 < count_of_buys <= self.max_rebuy_orders:
             try:


### PR DESCRIPTION
As was mentioned in the discord strategy ideas "would it be possible, without too much of a burden on you, to enable a dry-run like feature for the live bot to indicate re-buy opportunities regardless of whether any re-buy slots are available? As in you have your buy, and your two rebuys, can you expose a way (such as an optional debug feature we can turn on) where the bot would send a notification that it would intend a rebuy if it could. simply to give us the intention? Not that I want it to ignore the limit in actuality, i merely wish it to announce the intention"