### PR TITLE
Skip trailing_stop_loss too

### DIFF
--- a/NostalgiaForInfinityX.py
+++ b/NostalgiaForInfinityX.py
@@ -10673,7 +10673,7 @@ class NostalgiaForInfinityX(IStrategy):
         """
         if self._should_hold_trade(trade, rate, sell_reason):
             return False
-        if (sell_reason == 'stop_loss'):
+        if (sell_reason in ('stop_loss', 'trailing_stop_loss'):
             return False
         return True
 


### PR DESCRIPTION
if initial stoploss value not match with current stoploss value, it changes to trailing. This will happen when rebuy
https://github.com/freqtrade/freqtrade/blob/c63b5fbbbf22807526da4eb34411287eeb415be9/freqtrade/strategy/interface.py#L825

Due to the recent ccxt bug, as the average price is too high and reduced, it caused stoploss. As the trade was rebuy, and due to the above point, the trade was closed as trailing_stop_loss