### PR TITLE
Fixed a random FTX BEAR/BULL blacklist issue

### DIFF
--- a/configs/blacklist-ftx.json
+++ b/configs/blacklist-ftx.json
@@ -6,7 +6,7 @@
             // Major Crypto
             "(BTC|ETH)/.*",
             // Leverage tokens
-            ".*(BULL|BEAR|HALF|HEDGE|-PERP)/.*",
+            ".*(BULL|BEAR|HALF|HEDGE|-PERP).*/.*",
             "(BVOL|IBVOL)/.*",
             // Fiat
             "(AUD|EUR|GBP|CHF|CAD|JPY)/.*",


### PR DESCRIPTION
Sometimes instead of ...BEAR/USD showed BEAR.../USD which was not blacklisted with this regex. Putting another .* fixes the issue. (for example SHIT token has it switched isnted of  SHITBEAR it is BEARSHIT and I dont think anyone want to trade shit XD)