### PR TITLE
fix(config): updated deprecated config

### DIFF
--- a/configs/exampleconfig-rebuy.json
+++ b/configs/exampleconfig-rebuy.json
@@ -16,11 +16,11 @@
         "unit": "minutes"
     },
     "order_types": {
-        "buy": "limit",
-        "sell": "limit",
-        "emergencysell": "limit",
-        "forcebuy": "limit",
-        "forcesell": "limit",
+        "entry": "limit",
+        "exit": "limit",
+        "emergency_exit": "limit",
+        "force_entry": "limit",
+        "force_exit": "limit",
         "stoploss": "limit",
         "stoploss_on_exchange": false,
         "stoploss_on_exchange_interval": 60

--- a/configs/exampleconfig.json
+++ b/configs/exampleconfig.json
@@ -15,11 +15,11 @@
         "unit": "minutes"
     },
     "order_types": {
-        "buy": "limit",
-        "sell": "limit",
-        "emergencysell": "limit",
-        "forcebuy": "limit",
-        "forcesell": "limit",
+        "entry": "limit",
+        "exit": "limit",
+        "emergency_exit": "limit",
+        "force_entry": "limit",
+        "force_exit": "limit",
         "stoploss": "limit",
         "stoploss_on_exchange": false,
         "stoploss_on_exchange_interval": 60


### PR DESCRIPTION
Hi guys!

I wish you're all doing great! 

Since freqtrade had [a recent update](https://github.com/freqtrade/freqtrade/releases) I was thinking you will need one too soon. To help you a bit I found out some interesting files that could already be changed like config files.

You might also consider this PR: https://github.com/iterativv/NostalgiaForInfinity/pull/217 that includes the update into your `.py` files and avoid such messages in logs:

> WARNING - DEPRECATED: Using 'buy' and 'sell' for unfilledtimeout is deprecated.Please migrate your unfilledtimeout settings to use 'entry' and 'exit' wording.

Thanks for all the work done!