### PR TITLE
Patch: Change min days listed of age filter to maximum days Gateio supports.

### DIFF
--- a/configs/pairlist-volume-gateio-btc.json
+++ b/configs/pairlist-volume-gateio-btc.json
@@ -6,7 +6,7 @@
 			"sort_key": "quoteVolume",
 			"refresh_period": 1800
 		},
-		{"method": "AgeFilter", "min_days_listed": 30},
+		{"method": "AgeFilter", "min_days_listed": 28},
 		{
 			"method": "RangeStabilityFilter",
 			"lookback_days": 3,

--- a/configs/pairlist-volume-gateio-usdt.json
+++ b/configs/pairlist-volume-gateio-usdt.json
@@ -6,7 +6,7 @@
 			"sort_key": "quoteVolume",
 			"refresh_period": 1800
 		},
-		{"method": "AgeFilter", "min_days_listed": 30},
+		{"method": "AgeFilter", "min_days_listed": 28},
 		{
 			"method": "RangeStabilityFilter",
 			"lookback_days": 3,


### PR DESCRIPTION
Sometime during the last 24-48 hours Gate.io API changed the amount days they consider a month to be 28. 

This patch updates the gateio configs accordingly. And fixes the warnings: 

```
2022-09-09 10:09:50 - freqtrade.exchange.common - WARNING - _async_get_candle_history() returned exception: "Could not fetch historical candle (OHLCV) data for pair BTT/USDT due to BadRequest. Message: gateio {"label":"INVALID_PARAM_VALUE","message":"Candlestick range too broad. from time is limit one month"}". Retrying still for 2 times.
```

[Discord#bugs-and-support](https://discord.com/channels/864473885969350666/872462117633134623/1017738767857090601)

