### PR TITLE
fix: enter_tages UnboundLocalError

### DIFF
--- a/NostalgiaForInfinityX2.py
+++ b/NostalgiaForInfinityX2.py
@@ -4124,7 +4124,7 @@ class NostalgiaForInfinityX2(IStrategy):
         enter_tag = 'empty'
         if hasattr(trade, 'enter_tag') and trade.enter_tag is not None:
             enter_tag = trade.enter_tag
-            enter_tags = enter_tag.split()
+        enter_tags = enter_tag.split()
 
         # Rebuy mode, bull
         if all(c in self.rebuy_mode_bull_tags for c in enter_tags):


### PR DESCRIPTION
`2023-01-22 21:06:29,648 - freqtrade.commands.trade_commands - ERROR - local variable 'enter_tags' referenced before assignment
2023-01-22 21:06:29,649 - freqtrade.commands.trade_commands - ERROR - Fatal exception!
Traceback (most recent call last):
  File "/opt/freqtrade/freqtrade/freqtrade/strategy/strategy_wrapper.py", line 27, in wrapper
    return f(*args, **kwargs)
  File "/opt/freqtrade/freqtrade/user_data/strategies/NostalgiaForInfinityX2.py", line 4130, in adjust_trade_position
    if all(c in self.rebuy_mode_bull_tags for c in enter_tags):
UnboundLocalError: local variable 'enter_tags' referenced before assignment
`