### PR TITLE
Better backtest results on github comments

### DIFF
--- a/.github/workflows/scripts/comment-ci-results.py
+++ b/.github/workflows/scripts/comment-ci-results.py
@@ -136,7 +136,7 @@ def comment_results(options, results_data):
             )
             comment_body += "\n<details>\n"
             comment_body += f"<summary>Detailed Backest Output (click to see details)</summary>\n"
-            comment_body += f"<pre>{ft_output.read_text().strip()}</pre>\n"
+            comment_body += f"{ft_output.read_text().strip()}\n"
             comment_body += "</details>\n"
             comment_body += "\n\n"
             comment = commit.create_comment(comment_body.rstrip())

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,8 @@ jobs:
   Pre-Commit:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - name: Fetch Source Code
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python
@@ -16,7 +17,7 @@ jobs:
         python-version: '3.10'
     - name: Install black
       run: |
-        pip install black==22.3.0
+        pip install black==23.7.0
     - id: changed-files
       name: Get Changed Files
       uses: dorny/paths-filter@v2
@@ -51,34 +52,34 @@ jobs:
   #     fail-fast: false
   #     matrix:
   #       timerange:
-  #         # - 20210101-20210201
-  #         # - 20210201-20210301
-  #         # - 20210301-20210401
-  #         # - 20210401-20210501
-  #         # - 20210501-20210601
-  #         # - 20210601-20210701
-  #         # - 20210701-20210801
-  #         # - 20210801-20210901
-  #         # - 20210901-20211001
-  #         # - 20211001-20211101
-  #         # - 20211101-20211201
-  #         # - 20211201-20220101
-  #         # - 20220101-20220201
-  #         # - 20220201-20220301
-  #         # - 20220301-20220401
-  #         # - 20220401-20220501
-  #         # - 20220501-20220601
-  #         # - 20220601-20220701
-  #         # - 20220701-20220801
-  #         # - 20220801-20220901
-  #         # - 20220901-20221001
-  #         # - 20221001-20221101
-  #         # - 20221101-20221201
-  #         # - 20221201-20230101
-  #         # - 20230101-20230201
-  #         # - 20230201-20230301
-  #         # - 20230301-20230401
-  #         # - 20230401-20230501
+  #         - 20210101-20210201
+  #         - 20210201-20210301
+  #         - 20210301-20210401
+  #         - 20210401-20210501
+  #         - 20210501-20210601
+  #         - 20210601-20210701
+  #         - 20210701-20210801
+  #         - 20210801-20210901
+  #         - 20210901-20211001
+  #         - 20211001-20211101
+  #         - 20211101-20211201
+  #         - 20211201-20220101
+  #         - 20220101-20220201
+  #         - 20220201-20220301
+  #         - 20220301-20220401
+  #         - 20220401-20220501
+  #         - 20220501-20220601
+  #         - 20220601-20220701
+  #         - 20220701-20220801
+  #         - 20220801-20220901
+  #         - 20220901-20221001
+  #         - 20221001-20221101
+  #         - 20221101-20221201
+  #         - 20221201-20230101
+  #         - 20230101-20230201
+  #         - 20230201-20230301
+  #         - 20230301-20230401
+  #         - 20230401-20230501
   #         - 20230501-20230601
   #         - 20230601-20230701
 
@@ -163,13 +164,13 @@ jobs:
           - 20230701-20230801
 
     steps:
-      - name: Checkout Code
+      - name: Fetch Source Code
         uses: actions/checkout@v3
 
       - name: Build Tests Image
         run: docker-compose build tests
 
-      - name: Checkout historical trading data for backtests
+      - name: Fetch data for backtests from https://github.com/DigiTuccar/HistoricalDataForTradeBacktest
         env:
           EXCHANGE: kucoin
           TRADING_MODE: spot
@@ -257,6 +258,17 @@ jobs:
           name: kucoin-testrun-artifacts
           path: downloaded-results/current
 
+      - name: Pre Format Backtest Results
+        run: |
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/+/|/g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/=//g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/ BACKTESTING REPORT /\n## BACKTESTING REPORT\n/g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/ LEFT OPEN TRADES REPORT /\n## LEFT OPEN TRADES REPORT\n/g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/ ENTER TAG STATS /\n## ENTER TAG STATS\n/g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/ EXIT REASON STATS /\n## EXIT REASON STATS\n/g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/ SUMMARY METRICS /\n## SUMMARY METRICS\n/g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/ STRATEGY SUMMARY /\n## STRATEGY SUMMARY\n/g' {} +
+          find downloaded-results/ -type f -iname *.txt -exec sed -i 's/-|/:|/g' {} +
       - name: Show Environ
         run: |
           env


### PR DESCRIPTION
With markdown tables it will be shown line formatted tables
	modified:   .github/workflows/scripts/comment-ci-results.py
	modified:   .github/workflows/tests.yml

Now the backtest results will be shown like this :


## SUMMARY METRICS

| Metric                      | Value               |
|----------------------------:|--------------------:|
| Backtesting from            | 2022-12-01 00:00:00 |
| Backtesting to              | 2023-01-01 00:00:00 |
| Max open trades             | 6                   |
|                             |                     |
| Total/Daily Avg Trades      | 20 / 0.65           |
| Starting balance            | 1000 USDT           |
| Final balance               | 1017.945 USDT       |
| Absolute profit             | 17.945 USDT         |
| Total profit %              | 1.79%               |
| CAGR %                      | 23.30%              |
| Sortino                     | 3.04                |
| Sharpe                      | 1.99                |
| Calmar                      | 39.96               |
| Profit factor               | 1.62                |
| Expectancy (Ratio)          | 0.90 (0.06)         |
| Trades per day              | 0.65                |
| Avg. daily profit %         | 0.06%               |
| Expectancy (Ratio)          | 0.90 (0.06)         |
| Avg. stake amount           | 160.804 USDT        |
| Total trade volume          | 3216.084 USDT       |
|                             |                     |
| Best Pair                   | KLAY/USDT 4.45%     |
| Worst Pair                  | PHB/USDT -8.51%     |
| Best trade                  | KLAY/USDT 4.45%     |
| Worst trade                 | PHB/USDT -8.51%     |
| Best day                    | 29.781 USDT         |
| Worst day                   | -28.971 USDT        |
| Days win/draw/lose          | 5 / 24 / 1          |
| Avg. Duration Winners       | 4:50:00             |
| Avg. Duration Loser         | 8 days, 15:30:00    |
| Max Consecutive Wins / Loss | 18 / 2              |
| Rejected Entry signals      | 6                   |
| Entry/Exit Timeouts         | 0 / 0               |
|                             |                     |
| Min balance                 | 1000.255 USDT       |
| Max balance                 | 1046.917 USDT       |
| Max % of account underwater | 2.77%               |
| Absolute Drawdown (Account) | 2.77%               |
| Absolute Drawdown           | 28.971 USDT         |
| Drawdown high               | 46.917 USDT         |
| Drawdown low                | 17.945 USDT         |
| Drawdown Start              | 2022-12-17 23:30:00 |
| Drawdown End                | 2023-01-01 00:00:00 |
| Market change               | -14.55%             |


