### PR TITLE
Kucoin backtesting pairlist ARRR/USDT delisted

### DIFF
--- a/tests/backtests/pairs-available-kucoin-spot-usdt-2021.json
+++ b/tests/backtests/pairs-available-kucoin-spot-usdt-2021.json
@@ -21,7 +21,6 @@
       "APL/USDT",
       "AR/USDT",
       "ARKER/USDT",
-      "ARRR/USDT",
       "ASD/USDT",
       "ATA/USDT",
       "AUDIO/USDT",


### PR DESCRIPTION
modified:   tests/backtests/pairs-available-kucoin-spot-usdt-2021.json