### PR TITLE
test pairlists kucoin delisted BUX/USDT

### DIFF
--- a/tests/backtests/pairs-available-kucoin-spot-usdt-2021.json
+++ b/tests/backtests/pairs-available-kucoin-spot-usdt-2021.json
@@ -100,7 +100,6 @@
       "GALAX/USDT",
       "GAS/USDT",
       "GEEQ/USDT",
-      "GENS/USDT",
       "GHX/USDT",
       "GLM/USDT",
       "GLQ/USDT",

--- a/tests/backtests/pairs-available-kucoin-spot-usdt-2021.json
+++ b/tests/backtests/pairs-available-kucoin-spot-usdt-2021.json
@@ -37,7 +37,6 @@
       "BONDLY/USDT",
       "BOSON/USDT",
       "BURGER/USDT",
-      "BUX/USDT",
       "C98/USDT",
       "CAKE/USDT",
       "CELO/USDT",

--- a/tests/backtests/pairs-available-kucoin-spot-usdt-2022.json
+++ b/tests/backtests/pairs-available-kucoin-spot-usdt-2022.json
@@ -155,7 +155,6 @@
       "UPO/USDT",
       "VISION/USDT",
       "VOXEL/USDT",
-      "WAL/USDT",
       "WELL/USDT",
       "WEMIX/USDT",
       "WMT/USDT",


### PR DESCRIPTION
modified:   tests/backtests/pairs-available-kucoin-spot-usdt-2021.json