### PR TITLE
backtest pairlist okx delisted ENJ/USDT

### DIFF
--- a/configs/pairlist-backtest-static-okx-futures-usdt.json
+++ b/configs/pairlist-backtest-static-okx-futures-usdt.json
@@ -44,7 +44,6 @@
       "DOT/USDT:USDT",
       "DYDX/USDT:USDT",
       "EGLD/USDT:USDT",
-      "ENJ/USDT:USDT",
       "ENS/USDT:USDT",
       "EOS/USDT:USDT",
       "ETC/USDT:USDT",

--- a/tests/backtests/pairs-available-okx-futures-usdt-2021.json
+++ b/tests/backtests/pairs-available-okx-futures-usdt-2021.json
@@ -14,7 +14,6 @@
       "CRO/USDT:USDT",
       "CSPR/USDT:USDT",
       "DYDX/USDT:USDT",
-      "ENJ/USDT:USDT",
       "ENS/USDT:USDT",
       "FTM/USDT:USDT",
       "GALA/USDT:USDT",


### PR DESCRIPTION
modified:   configs/pairlist-backtest-static-okx-futures-usdt.json
modified:   tests/backtests/pairs-available-okx-futures-usdt-2021.json