### PR TITLE
gate.io APRT/USDT and TWITFI/USDT delisted

### DIFF
--- a/tests/backtests/pairs-available-gateio-spot-usdt-2022.json
+++ b/tests/backtests/pairs-available-gateio-spot-usdt-2022.json
@@ -19,7 +19,6 @@
       "ANML/USDT",
       "AOG/USDT",
       "APE/USDT",
-      "APRT/USDT",
       "APT/USDT",
       "APX/USDT",
       "AQDC/USDT",

--- a/tests/backtests/pairs-available-gateio-spot-usdt-2023.json
+++ b/tests/backtests/pairs-available-gateio-spot-usdt-2023.json
@@ -236,7 +236,6 @@
       "TSUGT/USDT",
       "TURBO/USDT",
       "TURBOS/USDT",
-      "TWITFI/USDT",
       "TYPE/USDT",
       "UNIBOT/USDT",
       "UNT/USDT",


### PR DESCRIPTION
updated lists for backtests