### PR TITLE
Test adjust trade position

### DIFF
--- a/tests/unit/test_NFIX5.py
+++ b/tests/unit/test_NFIX5.py
@@ -1,6 +1,7 @@
 import pytest
 from NostalgiaForInfinityX5 import NostalgiaForInfinityX5
 
+
 @pytest.fixture
 def mock_config(tmp_path):
   class RunModeMock:
@@ -27,11 +28,13 @@ def mock_config(tmp_path):
     "runmode": RunModeMock("backtest"),  # Simulate the execution mode
   }
 
+
 # Define a mock trade object
 class MockTrade:
   def __init__(self, is_short, enter_tag):
     self.is_short = is_short
     self.enter_tag = enter_tag
+
 
 @pytest.mark.parametrize(
   "trade, expected_function",
@@ -39,7 +42,6 @@ class MockTrade:
     # Rebuy and grind only tags
     (MockTrade(False, "61"), "long_rebuy_adjust_trade_position"),  # Long rebuy tag
     (MockTrade(False, "120"), "long_grind_adjust_trade_position"),  # Long grind tag
-    
     # Other tags
     (MockTrade(True, "620"), "short_grind_adjust_trade_position"),  # Short grind tag
     (MockTrade(False, "161"), "long_grind_adjust_trade_position"),  # Long derisk tag
@@ -49,15 +51,12 @@ class MockTrade:
     (MockTrade(False, "101"), "long_grind_adjust_trade_position"),  # Long rapid tag
     (MockTrade(False, "141"), "long_grind_adjust_trade_position"),  # Long top coins tag
     (MockTrade(False, "999"), "long_grind_adjust_trade_position"),  # Long unknown tag
-    
     # Rebuy + grind tags
     (MockTrade(False, "61 120"), "long_rebuy_adjust_trade_position"),  # Long rebuy + long grind tags
     (MockTrade(False, "120 61"), "long_rebuy_adjust_trade_position"),  # Long grind + long rebuy tags
-    
     # (Rebuy or grind) + other tags
     (MockTrade(False, "120 6"), "long_grind_adjust_trade_position"),  # Long grind + long normal tag
     (MockTrade(False, "61 6"), "long_grind_adjust_trade_position"),  # Long rebuy + long normal tag
-    
     # No tags!
     (MockTrade(False, ""), "long_rebuy_adjust_trade_position"),  # Empty enter_tags
   ],

--- a/tests/unit/test_NFIX5.py
+++ b/tests/unit/test_NFIX5.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest.mock import MagicMock
 from NostalgiaForInfinityX5 import NostalgiaForInfinityX5
 
 @pytest.fixture

--- a/tests/unit/test_NFIX5.py
+++ b/tests/unit/test_NFIX5.py
@@ -35,36 +35,35 @@ class MockTrade:
         self.enter_tag = enter_tag
 
 @pytest.mark.parametrize(
-    "trade, enter_tags, expected_function",
+    "trade, expected_function",
     [
         # Rebuy and grind only tags
-        (MockTrade(False, "61"), ["61"], "long_rebuy_adjust_trade_position"),  # Long rebuy tag
-        (MockTrade(False, "120"), ["120"], "long_grind_adjust_trade_position"),  # Long grind tag
+        (MockTrade(False, "61"), "long_rebuy_adjust_trade_position"),  # Long rebuy tag
+        (MockTrade(False, "120"), "long_grind_adjust_trade_position"),  # Long grind tag
         
         # Other tags
-        (MockTrade(True, "620"), ["620"], "short_grind_adjust_trade_position"),  # Short grind tag
-        (MockTrade(False, "161"), ["161"], "long_grind_adjust_trade_position"),  # Long derisk tag
-        (MockTrade(False, "6"), ["6"], "long_grind_adjust_trade_position"),  # Long normal tag
-        (MockTrade(False, "81"), ["81"], "long_grind_adjust_trade_position"),  # Long high profit tag
-        (MockTrade(False, "41"), ["41"], "long_grind_adjust_trade_position"),  # Long quick tag
-        (MockTrade(False, "101"), ["101"], "long_grind_adjust_trade_position"),  # Long rapid tag
-        (MockTrade(False, "141"), ["141"], "long_grind_adjust_trade_position"),  # Long top coins tag
-        (MockTrade(False, "999"), ["999"], "long_grind_adjust_trade_position"),  # Long unkown tag
+        (MockTrade(True, "620"), "short_grind_adjust_trade_position"),  # Short grind tag
+        (MockTrade(False, "161"), "long_grind_adjust_trade_position"),  # Long derisk tag
+        (MockTrade(False, "6"), "long_grind_adjust_trade_position"),  # Long normal tag
+        (MockTrade(False, "81"), "long_grind_adjust_trade_position"),  # Long high profit tag
+        (MockTrade(False, "41"), "long_grind_adjust_trade_position"),  # Long quick tag
+        (MockTrade(False, "101"), "long_grind_adjust_trade_position"),  # Long rapid tag
+        (MockTrade(False, "141"), "long_grind_adjust_trade_position"),  # Long top coins tag
+        (MockTrade(False, "999"), "long_grind_adjust_trade_position"),  # Long unknown tag
         
         # Rebuy + grind tags
-        (MockTrade(False, "61 120"), ["61", "120"], "long_rebuy_adjust_trade_position"),  # Long rebuy + long grind tags
-        (MockTrade(False, "120 61"), ["120", "61"], "long_rebuy_adjust_trade_position"),  # Long grind + long rebuy tags
+        (MockTrade(False, "61 120"), "long_rebuy_adjust_trade_position"),  # Long rebuy + long grind tags
+        (MockTrade(False, "120 61"), "long_rebuy_adjust_trade_position"),  # Long grind + long rebuy tags
         
         # (Rebuy or grind) + other tags
-        (MockTrade(False, "120 6"), ["120", "6"], "long_grind_adjust_trade_position"),  # Long grind + long normal tag
-        (MockTrade(False, "61 6"), ["61", "6"], "long_grind_adjust_trade_position"),  # Long rebuy + long normal tag
+        (MockTrade(False, "120 6"), "long_grind_adjust_trade_position"),  # Long grind + long normal tag
+        (MockTrade(False, "61 6"), "long_grind_adjust_trade_position"),  # Long rebuy + long normal tag
         
         # No tags!
-        (MockTrade(False, ""), [], "long_rebuy_adjust_trade_position"),  # Empty enter_tags
+        (MockTrade(False, ""), "long_rebuy_adjust_trade_position"),  # Empty enter_tags
     ],
 )
-
-def test_adjust_trade_position(mock_config, mocker, trade, enter_tags, expected_function):
+def test_adjust_trade_position(mock_config, mocker, trade, expected_function):
     """Test that adjust_trade_position calls the correct function."""
     strategy = NostalgiaForInfinityX5(mock_config)
     strategy.position_adjustment_enable = True
@@ -73,6 +72,9 @@ def test_adjust_trade_position(mock_config, mocker, trade, enter_tags, expected_
     strategy.long_rebuy_adjust_trade_position = mocker.MagicMock()
     strategy.long_grind_adjust_trade_position = mocker.MagicMock()
     strategy.short_grind_adjust_trade_position = mocker.MagicMock()
+
+    # Derive enter_tags from trade.enter_tag
+    enter_tags = trade.enter_tag.split()
 
     # Call adjust_trade_position
     strategy.adjust_trade_position(

--- a/tests/unit/test_NFIX5.py
+++ b/tests/unit/test_NFIX5.py
@@ -23,7 +23,7 @@ def mock_config(tmp_path):
     "stake_amount": 10,
     "dry_run": True,
     "timeframe": "5m",
-    "max_open_trades": 5,
+    "max_open_trades": 10,
     "user_data_dir": tmp_path,  # Use pytest's temporary directory
     "runmode": RunModeMock("backtest"),  # Simulate the execution mode
   }
@@ -37,11 +37,30 @@ class MockTrade:
 @pytest.mark.parametrize(
     "trade, enter_tags, expected_function",
     [
-        (MockTrade(False, "61"), ["61"], "long_rebuy_adjust_trade_position"),  # Rebuy
-        (MockTrade(False, "120"), ["120"], "long_grind_adjust_trade_position"),  # Grind
-        (MockTrade(True, "620"), ["620"], "short_grind_adjust_trade_position"),  # Short Grind
-        (MockTrade(False, "999"), ["999"], None),  # No match
-        (MockTrade(False, ""), [], None),  # Empty enter_tags
+        # Rebuy and grind only tags
+        (MockTrade(False, "61"), ["61"], "long_rebuy_adjust_trade_position"),  # Long rebuy tag
+        (MockTrade(False, "120"), ["120"], "long_grind_adjust_trade_position"),  # Long grind tag
+        
+        # Other tags
+        (MockTrade(True, "620"), ["620"], "short_grind_adjust_trade_position"),  # Short grind tag
+        (MockTrade(False, "161"), ["161"], "long_grind_adjust_trade_position"),  # Long derisk tag
+        (MockTrade(False, "6"), ["6"], "long_grind_adjust_trade_position"),  # Long normal tag
+        (MockTrade(False, "81"), ["81"], "long_grind_adjust_trade_position"),  # Long high profit tag
+        (MockTrade(False, "41"), ["41"], "long_grind_adjust_trade_position"),  # Long quick tag
+        (MockTrade(False, "101"), ["101"], "long_grind_adjust_trade_position"),  # Long rapid tag
+        (MockTrade(False, "141"), ["141"], "long_grind_adjust_trade_position"),  # Long top coins tag
+        (MockTrade(False, "999"), ["999"], "long_grind_adjust_trade_position"),  # Long unkown tag
+        
+        # Rebuy + grind tags
+        (MockTrade(False, "61 120"), ["61", "120"], "long_rebuy_adjust_trade_position"),  # Long rebuy + long grind tags
+        (MockTrade(False, "120 61"), ["120", "61"], "long_rebuy_adjust_trade_position"),  # Long grind + long rebuy tags
+        
+        # (Rebuy or grind) + other tags
+        (MockTrade(False, "120 6"), ["120", "6"], "long_grind_adjust_trade_position"),  # Long grind + long normal tag
+        (MockTrade(False, "61 6"), ["61", "6"], "long_grind_adjust_trade_position"),  # Long rebuy + long normal tag
+        
+        # No tags!
+        (MockTrade(False, ""), [], "long_rebuy_adjust_trade_position"),  # Empty enter_tags
     ],
 )
 

--- a/tests/unit/test_NFIX5.py
+++ b/tests/unit/test_NFIX5.py
@@ -29,93 +29,93 @@ def mock_config(tmp_path):
 
 # Define a mock trade object
 class MockTrade:
-    def __init__(self, is_short, enter_tag):
-        self.is_short = is_short
-        self.enter_tag = enter_tag
+  def __init__(self, is_short, enter_tag):
+    self.is_short = is_short
+    self.enter_tag = enter_tag
 
 @pytest.mark.parametrize(
-    "trade, expected_function",
-    [
-        # Rebuy and grind only tags
-        (MockTrade(False, "61"), "long_rebuy_adjust_trade_position"),  # Long rebuy tag
-        (MockTrade(False, "120"), "long_grind_adjust_trade_position"),  # Long grind tag
-        
-        # Other tags
-        (MockTrade(True, "620"), "short_grind_adjust_trade_position"),  # Short grind tag
-        (MockTrade(False, "161"), "long_grind_adjust_trade_position"),  # Long derisk tag
-        (MockTrade(False, "6"), "long_grind_adjust_trade_position"),  # Long normal tag
-        (MockTrade(False, "81"), "long_grind_adjust_trade_position"),  # Long high profit tag
-        (MockTrade(False, "41"), "long_grind_adjust_trade_position"),  # Long quick tag
-        (MockTrade(False, "101"), "long_grind_adjust_trade_position"),  # Long rapid tag
-        (MockTrade(False, "141"), "long_grind_adjust_trade_position"),  # Long top coins tag
-        (MockTrade(False, "999"), "long_grind_adjust_trade_position"),  # Long unknown tag
-        
-        # Rebuy + grind tags
-        (MockTrade(False, "61 120"), "long_rebuy_adjust_trade_position"),  # Long rebuy + long grind tags
-        (MockTrade(False, "120 61"), "long_rebuy_adjust_trade_position"),  # Long grind + long rebuy tags
-        
-        # (Rebuy or grind) + other tags
-        (MockTrade(False, "120 6"), "long_grind_adjust_trade_position"),  # Long grind + long normal tag
-        (MockTrade(False, "61 6"), "long_grind_adjust_trade_position"),  # Long rebuy + long normal tag
-        
-        # No tags!
-        (MockTrade(False, ""), "long_rebuy_adjust_trade_position"),  # Empty enter_tags
-    ],
+  "trade, expected_function",
+  [
+    # Rebuy and grind only tags
+    (MockTrade(False, "61"), "long_rebuy_adjust_trade_position"),  # Long rebuy tag
+    (MockTrade(False, "120"), "long_grind_adjust_trade_position"),  # Long grind tag
+    
+    # Other tags
+    (MockTrade(True, "620"), "short_grind_adjust_trade_position"),  # Short grind tag
+    (MockTrade(False, "161"), "long_grind_adjust_trade_position"),  # Long derisk tag
+    (MockTrade(False, "6"), "long_grind_adjust_trade_position"),  # Long normal tag
+    (MockTrade(False, "81"), "long_grind_adjust_trade_position"),  # Long high profit tag
+    (MockTrade(False, "41"), "long_grind_adjust_trade_position"),  # Long quick tag
+    (MockTrade(False, "101"), "long_grind_adjust_trade_position"),  # Long rapid tag
+    (MockTrade(False, "141"), "long_grind_adjust_trade_position"),  # Long top coins tag
+    (MockTrade(False, "999"), "long_grind_adjust_trade_position"),  # Long unknown tag
+    
+    # Rebuy + grind tags
+    (MockTrade(False, "61 120"), "long_rebuy_adjust_trade_position"),  # Long rebuy + long grind tags
+    (MockTrade(False, "120 61"), "long_rebuy_adjust_trade_position"),  # Long grind + long rebuy tags
+    
+    # (Rebuy or grind) + other tags
+    (MockTrade(False, "120 6"), "long_grind_adjust_trade_position"),  # Long grind + long normal tag
+    (MockTrade(False, "61 6"), "long_grind_adjust_trade_position"),  # Long rebuy + long normal tag
+    
+    # No tags!
+    (MockTrade(False, ""), "long_rebuy_adjust_trade_position"),  # Empty enter_tags
+  ],
 )
 def test_adjust_trade_position(mock_config, mocker, trade, expected_function):
-    """Test that adjust_trade_position calls the correct function."""
-    strategy = NostalgiaForInfinityX5(mock_config)
-    strategy.position_adjustment_enable = True
+  """Test that adjust_trade_position calls the correct function."""
+  strategy = NostalgiaForInfinityX5(mock_config)
+  strategy.position_adjustment_enable = True
 
-    # Mock adjustment functions
-    strategy.long_rebuy_adjust_trade_position = mocker.MagicMock()
-    strategy.long_grind_adjust_trade_position = mocker.MagicMock()
-    strategy.short_grind_adjust_trade_position = mocker.MagicMock()
+  # Mock adjustment functions
+  strategy.long_rebuy_adjust_trade_position = mocker.MagicMock()
+  strategy.long_grind_adjust_trade_position = mocker.MagicMock()
+  strategy.short_grind_adjust_trade_position = mocker.MagicMock()
 
-    # Derive enter_tags from trade.enter_tag
-    enter_tags = trade.enter_tag.split()
+  # Derive enter_tags from trade.enter_tag
+  enter_tags = trade.enter_tag.split()
 
-    # Call adjust_trade_position
-    strategy.adjust_trade_position(
-        trade,
-        current_time=None,
-        current_rate=0.0,
-        current_profit=0.0,
-        min_stake=None,
-        max_stake=10.0,
-        current_entry_rate=0.0,
-        current_exit_rate=0.0,
-        current_entry_profit=0.0,
-        current_exit_profit=0.0,
+  # Call adjust_trade_position
+  strategy.adjust_trade_position(
+    trade,
+    current_time=None,
+    current_rate=0.0,
+    current_profit=0.0,
+    min_stake=None,
+    max_stake=10.0,
+    current_entry_rate=0.0,
+    current_exit_rate=0.0,
+    current_entry_profit=0.0,
+    current_exit_profit=0.0,
+  )
+
+  # Verify correct function call
+  if expected_function:
+    getattr(strategy, expected_function).assert_called_once_with(
+      trade,
+      enter_tags,
+      None,
+      0.0,
+      0.0,
+      None,
+      10.0,
+      0.0,
+      0.0,
+      0.0,
+      0.0,
     )
+  else:
+    called_functions = []
+    for func_name, func in [
+      ("long_rebuy_adjust_trade_position", strategy.long_rebuy_adjust_trade_position),
+      ("long_grind_adjust_trade_position", strategy.long_grind_adjust_trade_position),
+      ("short_grind_adjust_trade_position", strategy.short_grind_adjust_trade_position),
+    ]:
+      if func.called:
+        called_functions.append(f"{func_name} called with: {func.call_args_list}")
 
-    # Verify correct function call
-    if expected_function:
-        getattr(strategy, expected_function).assert_called_once_with(
-            trade,
-            enter_tags,
-            None,
-            0.0,
-            0.0,
-            None,
-            10.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-        )
-    else:
-        called_functions = []
-        for func_name, func in [
-            ("long_rebuy_adjust_trade_position", strategy.long_rebuy_adjust_trade_position),
-            ("long_grind_adjust_trade_position", strategy.long_grind_adjust_trade_position),
-            ("short_grind_adjust_trade_position", strategy.short_grind_adjust_trade_position),
-        ]:
-            if func.called:
-                called_functions.append(f"{func_name} called with: {func.call_args_list}")
-
-        if called_functions:
-            pytest.fail(f"Unexpected function calls: {called_functions}")
+    if called_functions:
+      pytest.fail(f"Unexpected function calls: {called_functions}")
 
 
 def test_update_signals_from_config(mock_config):


### PR DESCRIPTION
This test ensures that the adjust_trade_position function calls the correct adjustment method based on the trade's attributes (is_short, enter_tag) and the provided enter_tags. It validates various scenarios, including specific tag combinations, rebuy and grind tags, and cases with no tags, ensuring the function behaves as expected across all defined conditions.