### PR TITLE
fix: remove build section for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@
 x-common-settings:
   &common-settings
   image: freqtradeorg/freqtrade:stable
-  build:
-    context: .
-    dockerfile: "./docker/Dockerfile.custom"
   restart: unless-stopped
   volumes:
     - "./user_data:/freqtrade/user_data"


### PR DESCRIPTION
docker compose will ignore any build section in docker-compose.yml if image section is specified, unlike the deprecated docker-compose. And the build section is not needed anyway.

The docker-compose.test.yml will very likely not work with docker compose because of image and build section specified together. That PR does not remove the wrong image section in it.