### PR TITLE
Update tests.yml v3 -> v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binance-testrun-artifacts-${{ matrix.runs-on }}
+          name: binance-testrun-artifacts-${{ matrix.timerange }}
           path: artifacts/
 
   Kucoin-Backtests:
@@ -243,7 +243,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: kucoin-testrun-artifacts-${{ matrix.runs-on }}
+          name: kucoin-testrun-artifacts-${{ matrix.timerange }}
           path: artifacts/
 
   # OKX-Backtests:
@@ -324,7 +324,7 @@ jobs:
   #     - name: Upload Artifacts
   #       uses: actions/upload-artifact@v4
   #       with:
-  #         name: okx-testrun-artifacts-${{ matrix.runs-on }}
+  #         name: okx-testrun-artifacts-${{ matrix.timerange }}
   #         path: artifacts/
 
   Backest-CI-Stats:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,6 +148,16 @@ jobs:
           name: binance-testrun-artifacts-${{ matrix.timerange }}
           path: artifacts/
 
+  Merge-Binance:
+    runs-on: ubuntu-latest
+    needs: Binance-Backtests
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: binance-testrun-artifacts
+          pattern: binance-testrun-artifacts-*
+
   Kucoin-Backtests:
     runs-on: ubuntu-latest
     needs:
@@ -246,6 +256,16 @@ jobs:
           name: kucoin-testrun-artifacts-${{ matrix.timerange }}
           path: artifacts/
 
+  Merge-Kucoin:
+    runs-on: ubuntu-latest
+    needs: Kucoin-Backtests
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: kucoin-testrun-artifacts
+          pattern: kucoin-testrun-artifacts-*
+
   # OKX-Backtests:
   #   runs-on: ubuntu-latest
   #   needs:
@@ -326,6 +346,15 @@ jobs:
   #       with:
   #         name: okx-testrun-artifacts-${{ matrix.timerange }}
   #         path: artifacts/
+  #  Merge-Backtests:
+  #    runs-on: ubuntu-latest
+  #    needs: OKX-Backtests
+  #    steps:
+  #      - name: Merge Artifacts
+  #        uses: actions/upload-artifact/merge@v4
+  #        with:
+  #          name: okx-testrun-artifacts
+  #          pattern: okx-testrun-artifacts-*
 
   Backest-CI-Stats:
     runs-on: ubuntu-latest
@@ -382,23 +411,20 @@ jobs:
       - name: Download Current Binance CI Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern:: binance-testrun-artifacts-*
+          pattern:: binance-testrun-artifacts
           path: downloaded-results/current
-          merge-multiple: true
 
       - name: Download Current Kucoin CI Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: kucoin-testrun-artifacts-*
+          pattern: kucoin-testrun-artifacts
           path: downloaded-results/current
-          merge-multiple: true
 
       # - name: Download Current OKX CI Artifacts
       #   uses: actions/download-artifact@v4
       #   with:
-      #     pattern: okx-testrun-artifacts-*
+      #     pattern: okx-testrun-artifacts
       #     path: downloaded-results/current
-      #     merge-multiple: true
 
       - name: Pre Format Backtest Results
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,9 +143,9 @@ jobs:
           cat artifacts/backtest-output-binance-spot-${{ matrix.timerange }}.txt
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: binance-testrun-artifacts
+          name: binance-testrun-artifacts-${{ matrix.runs-on }}
           path: artifacts/
 
   Kucoin-Backtests:
@@ -241,9 +241,9 @@ jobs:
           cat artifacts/backtest-output-kucoin-spot-${{ matrix.timerange }}.txt
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: kucoin-testrun-artifacts
+          name: kucoin-testrun-artifacts-${{ matrix.runs-on }}
           path: artifacts/
 
   # OKX-Backtests:
@@ -322,9 +322,9 @@ jobs:
   #         cat artifacts/backtest-output-okx-spot-${{ matrix.timerange }}.txt
 
   #     - name: Upload Artifacts
-  #       uses: actions/upload-artifact@v3
+  #       uses: actions/upload-artifact@v4
   #       with:
-  #         name: okx-testrun-artifacts
+  #         name: okx-testrun-artifacts-${{ matrix.runs-on }}
   #         path: artifacts/
 
   Backest-CI-Stats:
@@ -380,22 +380,25 @@ jobs:
       #       --name=okx-testrun-artifacts downloaded-results
 
       - name: Download Current Binance CI Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: binance-testrun-artifacts
+          pattern:: binance-testrun-artifacts-*
           path: downloaded-results/current
+          merge-multiple: true
 
       - name: Download Current Kucoin CI Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: kucoin-testrun-artifacts
+          pattern: kucoin-testrun-artifacts-*
           path: downloaded-results/current
+          merge-multiple: true
 
       # - name: Download Current OKX CI Artifacts
-      #   uses: actions/download-artifact@v3
+      #   uses: actions/download-artifact@v4
       #   with:
-      #     name: okx-testrun-artifacts
+      #     pattern: okx-testrun-artifacts-*
       #     path: downloaded-results/current
+      #     merge-multiple: true
 
       - name: Pre Format Backtest Results
         run: |


### PR DESCRIPTION
artifacts v3 was deprecated at Jan 30

https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

Docs I used
https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md