### PR TITLE
New configuration block for NFI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# VSCode
+.vscode/
+
 # Don't commit candle data
 user_data/data/*.json
 

--- a/NostalgiaForInfinityX6.py
+++ b/NostalgiaForInfinityX6.py
@@ -69,7 +69,7 @@ class NostalgiaForInfinityX6(IStrategy):
   INTERFACE_VERSION = 3
 
   def version(self) -> str:
-    return "v16.5.30"
+    return "v16.5.31"
 
   stoploss = -0.99
 
@@ -705,7 +705,7 @@ class NostalgiaForInfinityX6(IStrategy):
       "regular_mode_derisk_futures",
       "grind_mode_max_slots",
       "grind_mode_coins",
-      "max_slippage"
+      "max_slippage",
     ]:
       if config in self.config:
         setattr(self, config, self.config[config])


### PR DESCRIPTION
New configuration block  `nfi_parameters` specifically for NFI. 
An additional parameter `nfi_advanced_mode` that will allow changing any settings. 

Compatibility with the old configuration style is maintained.



Example of the new configuration variant:
```
"nfi_advanced_mode" : false,
  
  "nfi_parameters": {
    "grind_mode_max_slots": 0 ,
    "derisk_enable": true,
    "futures_max_open_trades_short": -1,
    "futures_max_open_trades_long": 10,
    "grinding_v2_derisk_level_1_enable" : true,
    "grinding_v2_derisk_level_2_enable" : true, 
    "grinding_v2_derisk_level_3_enable" : true,

    "long_entry_signal_params": {
      "long_entry_condition_1_enable": true,
      "long_entry_condition_6_enable": true
    
    },
```