### PR TITLE
Disable ccxt rate limit on proxy binance to try fix Binance actions

### DIFF
--- a/configs/proxy-binance.json
+++ b/configs/proxy-binance.json
@@ -1,8 +1,12 @@
 {
   "exchange": {
     "name": "binance",
+    "ccxt_config": {
+      "enableRateLimit": false
+    },
     "ccxt_async_config": {
-      "aiohttp_trust_env": true
+      "aiohttp_trust_env": true,
+      "enableRateLimit": false
     }
   }
 }


### PR DESCRIPTION
Disable ccxt rate limit on proxy binance config file to try fix Binance actions