### PR TITLE
Create delete-old-github-actions-runs.yml

### DIFF
--- a/.github/workflows/delete-old-github-actions-runs.yml
+++ b/.github/workflows/delete-old-github-actions-runs.yml
@@ -1,0 +1,12 @@
+name: Cleanup old Actions
+on:
+  workflow_dispatch:
+jobs:
+  delete-old-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: yanovation/delete-old-actions@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          days-ago: 60


### PR DESCRIPTION
This will delete all the workflow actions that is older than 60 days. The idea of this is it will maybe fix the "Previous" inconsistency in backtest comments.