### PR TITLE
Fix: Temporary fix to issue on Freqtrade stable docker image

### DIFF
--- a/.github/workflows/scripts/download-necessary-exchange-market-data-for-backtests.sh
+++ b/.github/workflows/scripts/download-necessary-exchange-market-data-for-backtests.sh
@@ -9,7 +9,7 @@ URL="https://github.com/iterativv/NostalgiaForInfinityData.git"
 
 rm PAIRS_FOR_DOWNLOAD.txt
 # docker run -v ".:/running_config" --rm --env-file .github/workflows/scripts/ci-proxy.env \
-#     freqtradeorg/freqtrade:stable test-pairlist -c /running_config/configs/trading_mode-$TRADING_MODE.json \
+#     freqtradeorg/freqtrade:2025.5 test-pairlist -c /running_config/configs/trading_mode-$TRADING_MODE.json \
 #     -c /running_config/configs/pairlist-backtest-static-$EXCHANGE-$TRADING_MODE-usdt.json \
 #     -c /running_config/configs/exampleconfig.json -1 --exchange $EXCHANGE \
 #     -c /running_config/configs/blacklist-$EXCHANGE.json|sed -e 's+/+_+g'>>PAIRS_FOR_DOWNLOAD.txt

--- a/docker-compose.tests.yml
+++ b/docker-compose.tests.yml
@@ -1,7 +1,7 @@
 ---
 services:
   tests:
-    image: freqtradeorg/freqtrade:stable
+    image: freqtradeorg/freqtrade:2025.5
     build:
       context: .
       dockerfile: "./docker/Dockerfile.custom"
@@ -83,7 +83,7 @@ services:
           > user_data/backtest_results/${STRATEGY_NAME:-NostalgiaForInfinityX6}-${STRATEGY_VERSION:-latest}-${EXCHANGE:-binance}-${TRADING_MODE:-spot}-${TIMERANGE:-20230101-}.txt
 
   plot-dataframe:
-    image: freqtradeorg/freqtrade:stable_plot
+    image: freqtradeorg/freqtrade:2025.5_plot
     container_name: ${EXCHANGE:-binance}-${TRADING_MODE:-spot}-plot-dataframe
     volumes:
       - "./user_data:/freqtrade/user_data"
@@ -103,7 +103,7 @@ services:
 
 
   plot-profit:
-    image: freqtradeorg/freqtrade:stable_plot
+    image: freqtradeorg/freqtrade:2025.5_plot
     container_name: ${EXCHANGE:-binance}-${TRADING_MODE:-spot}-plot-profit
     volumes:
       - "./user_data:/freqtrade/user_data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 
 x-common-settings:
   &common-settings
-  image: freqtradeorg/freqtrade:stable
+  image: freqtradeorg/freqtrade:2025.5
   build:
     context: .
     dockerfile: "./docker/Dockerfile.custom"

--- a/docker/Dockerfile.custom
+++ b/docker/Dockerfile.custom
@@ -1,5 +1,5 @@
 ARG sourceimage=freqtradeorg/freqtrade
-ARG sourcetag=stable
+ARG sourcetag=2025.5
 FROM ${sourceimage}:${sourcetag}
 USER root
 

--- a/tools/update_nfx_docker_compose.sh
+++ b/tools/update_nfx_docker_compose.sh
@@ -8,7 +8,7 @@
 NFI_PATH=
 ENV_PATH=$NFI_PATH
 FREQTRADE_IMAGE_UPDATE=false
-FREQTRADE_IMAGE="freqtradeorg/freqtrade:stable"
+FREQTRADE_IMAGE="freqtradeorg/freqtrade:2025.5"
 
 ### Simple script that does the following:
 ## 1. Pull NFIX repo


### PR DESCRIPTION
Fixed Freqtrade Image from stable to 2025.5 while 2025.6 is not fix that issue

```
/home/ftuser/.local/lib/python3.13/site-packages/pandas_ta/__init__.py:7: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html.⁠ The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.


from pkg_resources import get_distribution, DistributionNotFound


2025-07-04 18:42:02,473 - freqtrade.resolvers.iresolver - WARNING - Could not import /freqtrade/NostalgiaForInfinityX6.py due to 'cannot import name 'NaN' from 'numpy' (/home/ftuser/.local/lib/python3.13/site-packages/numpy/__init__.py)'


2025-07-04 18:42:03,877 - freqtrade.resolvers.iresolver - WARNING - Could not import /freqtrade/user_data/strategies/NostalgiaForInfinityX6-10x.py due to 'cannot import name 'NaN' from 'numpy'


(/home/ftuser/.local/lib/python3.13/site-packages/numpy/__init__.py)'


2025-07-04 18:42:03,879 - freqtrade - ERROR - Impossible to load Strategy 'NostalgiaForInfinityX6'. This class does not exist or contains Python code errors.
```