### PR TITLE
backtests.yml fix ratelimit

### DIFF
--- a/.github/workflows/backtests.yml
+++ b/.github/workflows/backtests.yml
@@ -107,6 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         TIMERANGE:
           - 20250601-20250701
@@ -189,6 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 4
       matrix:
         TIMERANGE:
           - 20250601-20250701


### PR DESCRIPTION
Temporary solution by adjusting max parallel matrix per job.