### PR TITLE
Add exchange information to strategy messages

### DIFF
--- a/NostalgiaForInfinityX6.py
+++ b/NostalgiaForInfinityX6.py
@@ -2438,6 +2438,7 @@ class NostalgiaForInfinityX6(IStrategy):
         Example:
         ```
         ✅ **Grinding entry:** `(dl1)`
+        🏦 **Exchange:** `Binance`
         🪙 **Pair:** `BTC/USDT`
         〽️ **Rate:** `20000.0`
         💰 **Stake amount:** `100.00 USDT`
@@ -2473,6 +2474,12 @@ class NostalgiaForInfinityX6(IStrategy):
 
     # Start with the header
     msg = headers.get(msg_type, None)
+
+    # Add exchange information
+    exchange_name = getattr(self, "config", {}).get("exchange", {}).get("name", "Unknown").capitalize()
+    msg += (
+      f"🏦 **Exchange:** `{exchange_name}`\n"
+    )
 
     # Common fields
     msg += (


### PR DESCRIPTION
Include exchange name in notification messages to provide additional context for users.