### PR TITLE
Add margin mode to .env variables for futures

### DIFF
--- a/live-account-example.env
+++ b/live-account-example.env
@@ -10,6 +10,7 @@ FREQTRADE__BOT_NAME=Example_Test_Account
 # FREQTRADE__LOGFILE=user_data/logs/Example_Test_Account.log
 
 FREQTRADE__TRADING_MODE=futures
+FREQTRADE__MARGIN_MODE=isolated
 
 FREQTRADE__EXCHANGE__NAME=binance
 FREQTRADE__EXCHANGE__KEY=Put_Your_Exchange_Key_Here


### PR DESCRIPTION
This will prevent an error `Configuration error: Freqtrade does not support '' 'futures' on ...` for futures and won't affect spot setting.