### PR TITLE
Fix X7: Remove redundant infer_objects().fillna(np.nan) calls

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -17669,19 +17669,10 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["RSI_14"] < 50.0)
           long_entry_logic.append(df["AROONU_14_15m"] < 90.0)
           long_entry_logic.append(df["STOCHRSIk_14_14_3_3_15m"] < 90.0)
-          long_entry_logic.append(
-            (df["SMA_21"].shift(1) < df["SMA_200"].shift(1).infer_objects(copy=False).fillna(np.nan))
-            & df["SMA_200"].shift(1).notna()
-          )
-          long_entry_logic.append(
-            (df["SMA_21"] > df["SMA_200"].infer_objects(copy=False).fillna(np.nan)) & df["SMA_200"].notna()
-          )
-          long_entry_logic.append(
-            (df["close"] > df["EMA_200_1h"].infer_objects(copy=False).fillna(np.nan)) & df["EMA_200_1h"].notna()
-          )
-          long_entry_logic.append(
-            (df["close"] > df["EMA_200_4h"].infer_objects(copy=False).fillna(np.nan)) & df["EMA_200_4h"].notna()
-          )
+          long_entry_logic.append((df["SMA_21"].shift(1) < df["SMA_200"].shift(1)) & df["SMA_200"].shift(1).notna())
+          long_entry_logic.append((df["SMA_21"] > df["SMA_200"]) & df["SMA_200"].notna())
+          long_entry_logic.append((df["close"] > df["EMA_200_1h"]) & df["EMA_200_1h"].notna())
+          long_entry_logic.append((df["close"] > df["EMA_200_4h"]) & df["EMA_200_4h"].notna())
           long_entry_logic.append(df["BBB_20_2.0"] > 1.5)
           long_entry_logic.append(df["BBB_20_2.0_1h"] > 6.0)
 


### PR DESCRIPTION
- Fixes 'Must specify a fill value or method' error in candle analysis
- Removes unnecessary infer_objects().fillna(np.nan) pattern from 4 instances
- fillna(np.nan) was redundant (filling NaN with NaN does nothing)
- infer_objects() is unnecessary for simple numeric comparisons
- Maintains optimal memory efficiency by avoiding any data copying
- .notna() checks properly handle NaN values without additional operations

<img width="1542" height="119" alt="image" src="https://github.com/user-attachments/assets/e8a77ecb-e594-4712-959d-980fc305852b" />

