### PR TITLE
Fix: Add explicit value parameter to fillna() calls

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -17126,17 +17126,17 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["AROONU_14_15m"] < 90.0)
           long_entry_logic.append(df["STOCHRSIk_14_14_3_3_15m"] < 90.0)
           long_entry_logic.append(
-            (df["SMA_21"].shift(1) < df["SMA_200"].shift(1).infer_objects(copy=False).fillna(np.nan))
+            (df["SMA_21"].shift(1) < df["SMA_200"].shift(1).infer_objects(copy=False).fillna(value=np.nan))
             & df["SMA_200"].shift(1).notna()
           )
           long_entry_logic.append(
-            (df["SMA_21"] > df["SMA_200"].infer_objects(copy=False).fillna(np.nan)) & df["SMA_200"].notna()
+            (df["SMA_21"] > df["SMA_200"].infer_objects(copy=False).fillna(value=np.nan)) & df["SMA_200"].notna()
           )
           long_entry_logic.append(
-            (df["close"] > df["EMA_200_1h"].infer_objects(copy=False).fillna(np.nan)) & df["EMA_200_1h"].notna()
+            (df["close"] > df["EMA_200_1h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_1h"].notna()
           )
           long_entry_logic.append(
-            (df["close"] > df["EMA_200_4h"].infer_objects(copy=False).fillna(np.nan)) & df["EMA_200_4h"].notna()
+            (df["close"] > df["EMA_200_4h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_4h"].notna()
           )
           long_entry_logic.append(df["BBB_20_2.0"] > 1.5)
           long_entry_logic.append(df["BBB_20_2.0_1h"] > 6.0)


### PR DESCRIPTION
Fixes ValueError: Must specify a fill 'value' or 'method' error that occurs with newer pandas versions when fillna() is called without explicit parameter.

Changes .fillna(np.nan) to .fillna(value=np.nan) in four locations within the populate_entry_trend method for condition #161 (Long entry logic).

Fixes issue where pandas requires explicit value= or method= parameter when calling fillna() after infer_objects() operations.