### PR TITLE
fix(configs): increase max_rate_of_change to 2.00 for stability filters

### DIFF
--- a/configs/pairlist-volume-binance-btc.json
+++ b/configs/pairlist-volume-binance-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-binance-busd.json
+++ b/configs/pairlist-volume-binance-busd.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-binance-usdc.json
+++ b/configs/pairlist-volume-binance-usdc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-binance-usdt.json
+++ b/configs/pairlist-volume-binance-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitget-btc.json
+++ b/configs/pairlist-volume-bitget-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitget-usdt.json
+++ b/configs/pairlist-volume-bitget-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitmart-btc.json
+++ b/configs/pairlist-volume-bitmart-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitmart-usdt.json
+++ b/configs/pairlist-volume-bitmart-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitvavo-eur.json
+++ b/configs/pairlist-volume-bitvavo-eur.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bybit-btc.json
+++ b/configs/pairlist-volume-bybit-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bybit-usdt.json
+++ b/configs/pairlist-volume-bybit-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-gateio-btc.json
+++ b/configs/pairlist-volume-gateio-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-gateio-usdt.json
+++ b/configs/pairlist-volume-gateio-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-htx-btc.json
+++ b/configs/pairlist-volume-htx-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-htx-usdt.json
+++ b/configs/pairlist-volume-htx-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-hyperliquid-usdc.json
+++ b/configs/pairlist-volume-hyperliquid-usdc.json
@@ -16,7 +16,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-kraken-usd.json
+++ b/configs/pairlist-volume-kraken-usd.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-kucoin-btc.json
+++ b/configs/pairlist-volume-kucoin-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-kucoin-usdt.json
+++ b/configs/pairlist-volume-kucoin-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-mexc-btc.json
+++ b/configs/pairlist-volume-mexc-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-mexc-usdt.json
+++ b/configs/pairlist-volume-mexc-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-okx-btc.json
+++ b/configs/pairlist-volume-okx-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-okx-futures.json
+++ b/configs/pairlist-volume-okx-futures.json
@@ -21,7 +21,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-okx-usdt.json
+++ b/configs/pairlist-volume-okx-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 0.95,
+      "max_rate_of_change": 2.00,
       "refresh_period": 1800
     },
     // {


### PR DESCRIPTION
Update max_rate_of_change parameter from 0.95 to 2.00 across all exchange pairlist configurations to allow for greater price volatility in trading pairs