### PR TITLE
Add backtest result comparison helper

### DIFF
--- a/tests/tools/test_compare_backtest_results.py
+++ b/tests/tools/test_compare_backtest_results.py
@@ -1,0 +1,132 @@
+import json
+import zipfile
+
+import pytest
+
+from tools.compare_backtest_results import build_report
+from tools.compare_backtest_results import main
+
+
+def result_data(strategy_name="Strategy", trades=None):
+  if trades is None:
+    trades = [
+      {
+        "pair": "ETH/USDT",
+        "is_short": False,
+        "open_date": "2026-01-01 00:00:00+00:00",
+        "close_date": "2026-01-01 01:00:00+00:00",
+        "enter_tag": "entry_a",
+        "exit_reason": "exit_a",
+        "profit_ratio": 0.012345678901,
+        "profit_abs": 1.23456789012,
+      }
+    ]
+  return {
+    "strategy": {
+      strategy_name: {
+        "trades": trades,
+        "total_trades": len(trades),
+        "profit_total": 0.012345678901,
+        "profit_total_abs": 1.23456789012,
+        "profit_factor": 2.0,
+        "winrate": 1.0,
+        "max_drawdown_abs": 0.0,
+      }
+    }
+  }
+
+
+def write_json(path, data):
+  path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def write_zip(path, data):
+  with zipfile.ZipFile(path, "w") as zip_file:
+    zip_file.writestr("backtest-result-2026-01-01.json", json.dumps(data))
+    zip_file.writestr("backtest-result-2026-01-01.meta.json", "{}")
+    zip_file.writestr("backtest-result-2026-01-01_config.json", "{}")
+
+
+def test_compare_equal_json_results(tmp_path):
+  left = tmp_path / "left.json"
+  right = tmp_path / "right.json"
+  write_json(left, result_data("Original"))
+  write_json(right, result_data("Candidate"))
+
+  report = build_report(left, right, None, None, 10)
+
+  assert report["trade_surface_equal"] is True
+  assert report["first_difference"] is None
+  assert report["left_strategy"] == "Original"
+  assert report["right_strategy"] == "Candidate"
+
+
+def test_compare_zip_results(tmp_path):
+  left = tmp_path / "left.zip"
+  right = tmp_path / "right.zip"
+  write_zip(left, result_data("Original"))
+  write_zip(right, result_data("Candidate"))
+
+  report = build_report(left, right, None, None, 10)
+
+  assert report["trade_surface_equal"] is True
+
+
+def test_compare_reports_first_trade_difference(tmp_path):
+  left = tmp_path / "left.json"
+  right = tmp_path / "right.json"
+  write_json(left, result_data("Original"))
+  right_data = result_data("Candidate")
+  right_data["strategy"]["Candidate"]["trades"][0]["exit_reason"] = "different_exit"
+  write_json(right, right_data)
+
+  report = build_report(left, right, None, None, 10)
+
+  assert report["trade_surface_equal"] is False
+  assert report["first_difference"]["index"] == 0
+  assert report["first_difference"]["left"]["exit_reason"] == "exit_a"
+  assert report["first_difference"]["right"]["exit_reason"] == "different_exit"
+
+
+def test_compare_reports_trade_count_difference(tmp_path):
+  left = tmp_path / "left.json"
+  right = tmp_path / "right.json"
+  write_json(left, result_data("Original"))
+  write_json(right, result_data("Candidate", trades=[]))
+
+  report = build_report(left, right, None, None, 10)
+
+  assert report["trade_surface_equal"] is False
+  assert report["first_difference"] == {"left_count": 1, "right_count": 0}
+
+
+def test_strategy_name_can_be_selected_when_result_has_multiple_strategies(tmp_path):
+  path = tmp_path / "results.json"
+  data = result_data("Original")
+  data["strategy"]["Candidate"] = result_data("Candidate")["strategy"]["Candidate"]
+  write_json(path, data)
+
+  report = build_report(path, path, "Original", "Candidate", 10)
+
+  assert report["left_strategy"] == "Original"
+  assert report["right_strategy"] == "Candidate"
+  assert report["trade_surface_equal"] is True
+
+
+def test_cli_returns_nonzero_when_trade_surface_differs(tmp_path):
+  left = tmp_path / "left.json"
+  right = tmp_path / "right.json"
+  write_json(left, result_data("Original"))
+  write_json(right, result_data("Candidate", trades=[]))
+
+  assert main([str(left), str(right)]) == 1
+
+
+def test_multiple_strategy_result_requires_selection(tmp_path):
+  path = tmp_path / "results.json"
+  data = result_data("Original")
+  data["strategy"]["Candidate"] = result_data("Candidate")["strategy"]["Candidate"]
+  write_json(path, data)
+
+  with pytest.raises(RuntimeError, match="Use --left-strategy/--right-strategy"):
+    build_report(path, path, None, None, 10)

--- a/tools/compare_backtest_results.py
+++ b/tools/compare_backtest_results.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Compare two Freqtrade backtest result exports.
+
+This is intentionally a small tooling helper. It does not import or execute any
+strategy code, and it does not change trading behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import zipfile
+
+
+TRADE_FIELDS = (
+  "pair",
+  "is_short",
+  "open_date",
+  "close_date",
+  "enter_tag",
+  "exit_reason",
+  "profit_ratio",
+  "profit_abs",
+)
+
+SUMMARY_FIELDS = (
+  "total_trades",
+  "profit_total",
+  "profit_total_abs",
+  "profit_factor",
+  "winrate",
+  "max_drawdown_account",
+  "max_relative_drawdown",
+  "max_drawdown_abs",
+  "best_pair",
+  "worst_pair",
+)
+
+
+def result_json_name(zip_file: zipfile.ZipFile) -> str:
+  candidates = [
+    name
+    for name in zip_file.namelist()
+    if name.endswith(".json") and not name.endswith("_config.json") and not name.endswith(".meta.json")
+  ]
+  if len(candidates) != 1:
+    raise RuntimeError(f"Expected one backtest result json in {zip_file.filename}, found {candidates}")
+  return candidates[0]
+
+
+def load_result_file(path: Path) -> dict:
+  if path.suffix == ".zip":
+    with zipfile.ZipFile(path) as zip_file:
+      return json.loads(zip_file.read(result_json_name(zip_file)))
+
+  if path.suffix == ".json":
+    return json.loads(path.read_text(encoding="utf-8"))
+
+  raise RuntimeError(f"Unsupported result file type: {path}")
+
+
+def strategy_result(data: dict, path: Path, strategy: str | None) -> tuple[str, dict]:
+  strategies = data.get("strategy")
+
+  if isinstance(strategies, dict):
+    if strategy is not None:
+      if strategy not in strategies:
+        raise RuntimeError(f"Strategy {strategy!r} not found in {path}. Available: {sorted(strategies)}")
+      return strategy, strategies[strategy]
+
+    if len(strategies) != 1:
+      raise RuntimeError(f"Expected one strategy in {path}. Use --left-strategy/--right-strategy.")
+
+    strategy_name = next(iter(strategies))
+    return strategy_name, strategies[strategy_name]
+
+  if isinstance(strategies, str):
+    strategy_name = strategy or strategies
+    if strategy_name not in data:
+      raise RuntimeError(f"Strategy {strategy_name!r} not found in top-level result data for {path}")
+    return strategy_name, data[strategy_name]
+
+  raise RuntimeError(f"Unsupported strategy result format in {path}")
+
+
+def normalize_value(value: object, float_digits: int) -> object:
+  if isinstance(value, float):
+    return round(value, float_digits)
+  return value
+
+
+def normalize_trade(trade: dict, float_digits: int) -> dict:
+  return {field: normalize_value(trade.get(field), float_digits) for field in TRADE_FIELDS}
+
+
+def compare_trades(left: dict, right: dict, float_digits: int) -> tuple[bool, dict | None]:
+  left_trades = [normalize_trade(trade, float_digits) for trade in left.get("trades", [])]
+  right_trades = [normalize_trade(trade, float_digits) for trade in right.get("trades", [])]
+
+  for index, (left_trade, right_trade) in enumerate(zip(left_trades, right_trades, strict=False)):
+    if left_trade != right_trade:
+      return False, {"index": index, "left": left_trade, "right": right_trade}
+
+  if len(left_trades) != len(right_trades):
+    return False, {"left_count": len(left_trades), "right_count": len(right_trades)}
+
+  return True, None
+
+
+def build_report(
+  left_path: Path,
+  right_path: Path,
+  left_strategy: str | None,
+  right_strategy: str | None,
+  float_digits: int,
+) -> dict:
+  left_name, left = strategy_result(load_result_file(left_path), left_path, left_strategy)
+  right_name, right = strategy_result(load_result_file(right_path), right_path, right_strategy)
+  equal, first_difference = compare_trades(left, right, float_digits)
+
+  return {
+    "left_strategy": left_name,
+    "right_strategy": right_name,
+    "trade_surface_equal": equal,
+    "left_summary": {field: left.get(field) for field in SUMMARY_FIELDS},
+    "right_summary": {field: right.get(field) for field in SUMMARY_FIELDS},
+    "first_difference": first_difference,
+  }
+
+
+def print_text_report(report: dict) -> None:
+  print(f"left_strategy={report['left_strategy']}")
+  print(f"right_strategy={report['right_strategy']}")
+  print(f"trade_surface_equal={report['trade_surface_equal']}")
+  print(f"left_total_trades={report['left_summary'].get('total_trades')}")
+  print(f"right_total_trades={report['right_summary'].get('total_trades')}")
+  if report["first_difference"] is not None:
+    print("first_difference=")
+    print(json.dumps(report["first_difference"], indent=2, sort_keys=True))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+    description="Compare the exported trade surface of two Freqtrade backtest result files."
+  )
+  parser.add_argument("left", type=Path, help="Left backtest result .zip or .json.")
+  parser.add_argument("right", type=Path, help="Right backtest result .zip or .json.")
+  parser.add_argument("--left-strategy", help="Strategy name to read from the left result when multiple exist.")
+  parser.add_argument("--right-strategy", help="Strategy name to read from the right result when multiple exist.")
+  parser.add_argument("--float-digits", type=int, default=10, help="Decimal places used for float comparison.")
+  parser.add_argument("--json", action="store_true", help="Print machine-readable JSON output.")
+  return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+  args = parse_args(argv)
+  report = build_report(
+    left_path=args.left,
+    right_path=args.right,
+    left_strategy=args.left_strategy,
+    right_strategy=args.right_strategy,
+    float_digits=args.float_digits,
+  )
+
+  if args.json:
+    print(json.dumps(report, indent=2, sort_keys=True))
+  else:
+    print_text_report(report)
+
+  return 0 if report["trade_surface_equal"] else 1
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
This is a small tooling-only draft PR.

It does not change strategy logic, signals, exits, protections, grinding, Docker runtime behavior, or configs.

What it adds:
- `tools/compare_backtest_results.py`
- tests for comparing Freqtrade backtest `.json` and `.zip` exports

Why:
- Makes it easier to compare two exported backtest result files when checking whether a candidate/rebased version produced the same trade surface.
- Returns a non-zero exit code when the exported trade surface differs, so it can be used in local checks or CI later if wanted.

Validation:
- `python3 -m py_compile tools/compare_backtest_results.py tests/tools/test_compare_backtest_results.py`
- `python3 -m pytest -o addopts='' tests/tools/test_compare_backtest_results.py`
- `python3 -m ruff check tools/compare_backtest_results.py tests/tools/test_compare_backtest_results.py`

I also tested it against the local X7/TestX7 exported backtest zips from the proof package:

```text
left_strategy=NostalgiaForInfinityX7
right_strategy=TestX7
trade_surface_equal=True
left_total_trades=317
right_total_trades=317
```

Opening as draft for scope review first.
