### PR TITLE
Optimize filled order reuse in X7

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1705,6 +1705,19 @@ class NostalgiaForInfinityX7(IStrategy):
 
     return False, None
 
+  # Filled Order Snapshot
+  # ---------------------------------------------------------------------------------------------
+  def filled_order_snapshot(self, trade: "Trade") -> tuple:
+    filled_orders = trade.select_filled_orders()
+    filled_entries = []
+    filled_exits = []
+    for order in filled_orders:
+      if order.ft_order_side == trade.entry_side:
+        filled_entries.append(order)
+      elif order.ft_order_side == trade.exit_side:
+        filled_exits.append(order)
+    return filled_orders, filled_entries, filled_exits
+
   # Calc Total Profit
   # ---------------------------------------------------------------------------------------------
   def calc_total_profit(
@@ -1779,8 +1792,7 @@ class NostalgiaForInfinityX7(IStrategy):
       enter_tag = trade.enter_tag
     enter_tags = enter_tag.split()
 
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
+    _, filled_entries, filled_exits = self.filled_order_snapshot(trade)
 
     profit_stake = 0.0
     profit_ratio = 0.0
@@ -44122,11 +44134,8 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_exits = len(filled_exits)
 
     exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
@@ -46532,11 +46541,8 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_exits = len(filled_exits)
 
     exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
@@ -48489,11 +48495,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_entries = len(filled_entries)
+    count_of_exits = len(filled_exits)
 
     if count_of_entries == 0:
       return None
@@ -52161,11 +52165,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_entries = len(filled_entries)
+    count_of_exits = len(filled_exits)
 
     if count_of_entries == 0:
       return None
@@ -52348,11 +52350,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_entries = len(filled_entries)
+    count_of_exits = len(filled_exits)
 
     if count_of_entries == 0:
       return None
@@ -70615,11 +70615,8 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_exits = len(filled_exits)
 
     exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
@@ -73007,11 +73004,8 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_exits = len(filled_exits)
 
     exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
@@ -74629,11 +74623,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_entries = len(filled_entries)
+    count_of_exits = len(filled_exits)
 
     if count_of_entries == 0:
       return None
@@ -78239,11 +78231,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_entries = len(filled_entries)
+    count_of_exits = len(filled_exits)
 
     if count_of_entries == 0:
       return None
@@ -78416,11 +78406,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders = trade.select_filled_orders()
-    filled_entries = trade.select_filled_orders(trade.entry_side)
-    filled_exits = trade.select_filled_orders(trade.exit_side)
-    count_of_entries = trade.nr_of_successful_entries
-    count_of_exits = trade.nr_of_successful_exits
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    count_of_entries = len(filled_entries)
+    count_of_exits = len(filled_exits)
 
     if count_of_entries == 0:
       return None

--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3003,7 +3003,6 @@ class NostalgiaForInfinityX7(IStrategy):
   def chaikin_money_flow(
     high: np.ndarray, low: np.ndarray, close: np.ndarray, volume: np.ndarray, timeperiod: int = 20
   ) -> np.ndarray:
-
     hl_range = high - low
     hl_range = np.where(hl_range == 0, np.nan, hl_range)
     mfm = ((close - low) - (high - close)) / hl_range
@@ -4374,7 +4373,6 @@ class NostalgiaForInfinityX7(IStrategy):
   # BTC Indicators
   # ---------------------------------------------------------------------------------------------
   def _btc_info_indicators(self, btc_info_pair: str, btc_info_timeframe: str, metadata: dict) -> DataFrame:
-
     tik = time.perf_counter()
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a `filled_order_snapshot()` helper for X7 trade order state.
- Reuse the snapshot in `custom_exit()` and long/short grind/rebuy position adjustment hooks.
- Keep the existing profit math, stake logic, grind rules, and exit conditions unchanged while avoiding repeated filled-order scans on the same trade.

## Validation

- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- AST scan of the targeted hooks: each now calls `filled_order_snapshot()` once and has zero direct `select_filled_orders()` / `nr_of_successful_*` calls.
- Full local 80-pair backtest with the identical `NostalgiaForInfinityX7.py` blob: 317 trades, 2162.902 USDT profit, 99.4% win rate.
- Compared against the existing baseline backtest: `trade_surface_equal=true`, `first_difference=null`.
