### PR TITLE
Optimize X7 profit snapshot reuse across adjust paths

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1780,6 +1780,14 @@ class NostalgiaForInfinityX7(IStrategy):
 
     return None
 
+  def profit_or_order_snapshot(self, trade: "Trade", current_time: "datetime", exit_rate: float) -> tuple:
+    profit_snapshot = self.backtest_profit_snapshot(trade, current_time, exit_rate)
+    if profit_snapshot is not None:
+      return profit_snapshot
+
+    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
+    return filled_orders, filled_entries, filled_exits, None
+
   # Calc Total Profit
   # ---------------------------------------------------------------------------------------------
   def calc_total_profit(
@@ -26406,7 +26414,6 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
-
     mode_name = self.long_pump_mode_name
 
     sell = False
@@ -26651,7 +26658,6 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
-
     mode_name = self.long_quick_mode_name
 
     sell = False
@@ -26955,7 +26961,6 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
-
     mode_name = self.long_rebuy_mode_name
     stoploss_doom = f"exit_{mode_name}_stoploss_doom"
     stoploss_u_e = f"exit_{mode_name}_stoploss_u_e"
@@ -27217,7 +27222,6 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
-
     mode_name = self.long_high_profit_mode_name
 
     stoploss_doom = f"exit_{mode_name}_stoploss_doom"
@@ -44142,10 +44146,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_exits = len(filled_exits)
-
     exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_exits = trade.nr_of_successful_exits
+
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -44158,9 +44164,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     current_stake_amount = trade.amount * exit_rate
     slice_amount = filled_entries[0].cost
@@ -46550,12 +46556,10 @@ class NostalgiaForInfinityX7(IStrategy):
       return None
 
     exit_rate = current_rate
-    profit_snapshot = self.backtest_profit_snapshot(trade, current_time, exit_rate)
-    if profit_snapshot is not None:
-      filled_orders, filled_entries, filled_exits, profit_values = profit_snapshot
-    else:
-      filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_exits = len(filled_exits)
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_exits = trade.nr_of_successful_exits
 
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
@@ -46569,7 +46573,7 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    if profit_snapshot is None:
+    if profit_values is None:
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
@@ -48507,9 +48511,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_entries = len(filled_entries)
-    count_of_exits = len(filled_exits)
+    exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_entries = trade.nr_of_successful_entries
+    count_of_exits = trade.nr_of_successful_exits
 
     if count_of_entries == 0:
       return None
@@ -48520,7 +48527,6 @@ class NostalgiaForInfinityX7(IStrategy):
     if hasattr(filled_orders[0], "ft_order_tag"):
       has_order_tags = True
 
-    exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -48533,9 +48539,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
@@ -52177,9 +52183,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_entries = len(filled_entries)
-    count_of_exits = len(filled_exits)
+    exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_entries = trade.nr_of_successful_entries
+    count_of_exits = trade.nr_of_successful_exits
 
     if count_of_entries == 0:
       return None
@@ -52204,7 +52213,6 @@ class NostalgiaForInfinityX7(IStrategy):
         current_exit_profit,
       )
 
-    exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -52217,9 +52225,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
@@ -52362,9 +52370,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_entries = len(filled_entries)
-    count_of_exits = len(filled_exits)
+    exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_entries = trade.nr_of_successful_entries
+    count_of_exits = trade.nr_of_successful_exits
 
     if count_of_entries == 0:
       return None
@@ -52389,7 +52400,6 @@ class NostalgiaForInfinityX7(IStrategy):
         current_exit_profit,
       )
 
-    exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -52402,9 +52412,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
@@ -70627,10 +70637,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_exits = len(filled_exits)
-
     exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_exits = trade.nr_of_successful_exits
+
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -70643,9 +70655,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     current_stake_amount = trade.amount * exit_rate
     slice_amount = filled_entries[0].cost
@@ -73017,12 +73029,10 @@ class NostalgiaForInfinityX7(IStrategy):
       return None
 
     exit_rate = current_rate
-    profit_snapshot = self.backtest_profit_snapshot(trade, current_time, exit_rate)
-    if profit_snapshot is not None:
-      filled_orders, filled_entries, filled_exits, profit_values = profit_snapshot
-    else:
-      filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_exits = len(filled_exits)
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_exits = trade.nr_of_successful_exits
 
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
@@ -73036,7 +73046,7 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    if profit_snapshot is None:
+    if profit_values is None:
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
@@ -74639,9 +74649,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_entries = len(filled_entries)
-    count_of_exits = len(filled_exits)
+    exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_entries = trade.nr_of_successful_entries
+    count_of_exits = trade.nr_of_successful_exits
 
     if count_of_entries == 0:
       return None
@@ -74652,7 +74665,6 @@ class NostalgiaForInfinityX7(IStrategy):
     if hasattr(filled_orders[0], "ft_order_tag"):
       has_order_tags = True
 
-    exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -74665,9 +74677,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
@@ -78247,9 +78259,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_entries = len(filled_entries)
-    count_of_exits = len(filled_exits)
+    exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_entries = trade.nr_of_successful_entries
+    count_of_exits = trade.nr_of_successful_exits
 
     if count_of_entries == 0:
       return None
@@ -78274,7 +78289,6 @@ class NostalgiaForInfinityX7(IStrategy):
         current_exit_profit,
       )
 
-    exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -78287,9 +78301,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
@@ -78422,9 +78436,12 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    filled_orders, filled_entries, filled_exits = self.filled_order_snapshot(trade)
-    count_of_entries = len(filled_entries)
-    count_of_exits = len(filled_exits)
+    exit_rate = current_rate
+    filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
+      trade, current_time, exit_rate
+    )
+    count_of_entries = trade.nr_of_successful_entries
+    count_of_exits = trade.nr_of_successful_exits
 
     if count_of_entries == 0:
       return None
@@ -78433,7 +78450,6 @@ class NostalgiaForInfinityX7(IStrategy):
     if hasattr(filled_orders[0], "ft_order_tag"):
       has_order_tags = True
 
-    exit_rate = current_rate
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
       if ("bid" in ticker) and ("ask" in ticker):
@@ -78446,9 +78462,9 @@ class NostalgiaForInfinityX7(IStrategy):
             if ticker["bid"] is not None:
               exit_rate = ticker["bid"]
 
-    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-      trade, filled_entries, filled_exits, exit_rate
-    )
+    if profit_values is None:
+      profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
+    profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price


### PR DESCRIPTION
## Summary

- Add a shared helper that reuses the cached backtest profit/order snapshot when the same trade/time/rate/order state reaches adjust logic after `custom_exit()`.
- Apply the helper across X7 long/short grind and rebuy adjust paths, including older v2/current paths that still repeated order scans and profit calculation.
- Use the trade successful entry/exit counters for local counts where the order lists are already available.

## Validation

- `ruff format --check NostalgiaForInfinityX7.py` with the repo pinned `ruff` version (`0.12.5`)
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- GitHub Actions `Pre-Commit` passed

Backtest parity smoke:

- Docker image: `freqtradeorg/freqtrade:stable` / Freqtrade `2026.4`
- baseline `BenchX7Base` vs patched `BenchX7Opt`
- spot / Binance / 5m / `20260115-20260201`
- pairs: `BTC/USDT ETH/USDT SOL/USDT XRP/USDT DOGE/USDT ADA/USDT BNB/USDT AVAX/USDT LINK/USDT LTC/USDT`
- `trade_surface_equal=True`, total trades `1` vs `1`

Grind-heavy Docker parity and timing smoke:

- Docker image: `freqtradeorg/freqtrade:stable` / Freqtrade `2026.4`
- baseline `BenchX7Base` vs patched `BenchX7Opt`
- spot / Binance / 5m / `20250101-20260301`
- pairs: `DASH/USDT ZEC/USDT ADA/USDT FIL/USDT SUI/USDT SOL/USDT GALA/USDT ICP/USDT LTC/USDT TIA/USDT`
- `trade_surface_equal=True`, total trades `154` vs `154`
- single-run wall time: baseline `7:36.99`, patched `7:19.44`
