### PR TITLE
Optimize X7 stoch k calculation

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3088,6 +3088,12 @@ class NostalgiaForInfinityX7(IStrategy):
     return mfv_sum / vol_sum
 
   @staticmethod
+  def stoch_k(high, low, close):
+    stoch_k = ta.STOCHF(high, low, close, fastk_period=14, fastd_period=3, fastd_matype=0)[1]
+    stoch_k[:17] = np.nan
+    return stoch_k
+
+  @staticmethod
   def fast_pct_change(arr: np.ndarray) -> np.ndarray:
     out = np.empty_like(arr)
     out[0] = np.nan
@@ -3179,9 +3185,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH
     # =========================================================================
-    stoch_k, _ = ta.STOCH(
-      high_np, low_np, close_np, fastk_period=14, slowk_period=3, slowk_matype=0, slowd_period=3, slowd_matype=0
-    )
+    stoch_k = self.stoch_k(high_np, low_np, close_np)
 
     # =========================================================================
     # STOCH RSI
@@ -3378,9 +3382,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH
     # =========================================================================
-    stoch_k, _ = ta.STOCH(
-      high_np, low_np, close_np, fastk_period=14, slowk_period=3, slowk_matype=0, slowd_period=3, slowd_matype=0
-    )
+    stoch_k = self.stoch_k(high_np, low_np, close_np)
 
     # =========================================================================
     # STOCH RSI
@@ -3628,9 +3630,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH
     # =========================================================================
-    stoch_k, _ = ta.STOCH(
-      high_np, low_np, close_np, fastk_period=14, slowk_period=3, slowk_matype=0, slowd_period=3, slowd_matype=0
-    )
+    stoch_k = self.stoch_k(high_np, low_np, close_np)
 
     # =========================================================================
     # STOCH RSI
@@ -3847,9 +3847,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH
     # =========================================================================
-    stoch_k, _ = ta.STOCH(
-      high_np, low_np, close_np, fastk_period=14, slowk_period=3, slowk_matype=0, slowd_period=3, slowd_matype=0
-    )
+    stoch_k = self.stoch_k(high_np, low_np, close_np)
 
     # =========================================================================
     # STOCH RSI


### PR DESCRIPTION
## Summary

- reuse a small `stoch_k()` helper for the repeated X7 stochastic slow-k calculation
- use the matching `STOCHF(...)[1]` fast-d output, not the STOCHF fast-k output
- preserve the original 17-candle NaN warmup

## Safety checks

Rebased onto current upstream `main` after an earlier stale branch could include unrelated strategy changes in the merge ref.

Local value check over 80 pairs x 5 timeframes:

```text
files 400 fail 0 max_abs 0 max_rel 0 neq 0
timeframe,files,fail,max_abs,neq
15m,80,0,0,0
1d,80,0,0,0
1h,80,0,0,0
4h,80,0,0,0
5m,80,0,0,0
```

## Validation

```text
ruff format --check NostalgiaForInfinityX7.py
ruff check NostalgiaForInfinityX7.py
PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
git diff --check
```

Not tested: full Freqtrade backtest in this local WSL environment.

## Additional validation - p!mp futures setup, current main

Reran after rebasing/testing against current upstream `main` (which already includes merged #711).

Setup:

```text
Config     : p!mp config_backtest.json equivalent
Mode       : Binance isolated futures
Pairlist   : p!mp static Binance futures USDT, 343 pairs
Timerange  : 20260101-20260501
Warmup     : pre-roll data included so the effective run starts on 2026-01-01
Backtest   : regular 5m strategy, --breakdown day, no --timeframe-detail
Effective  : 2026-01-01 00:00:00 -> 2026-04-30 23:55:00
```

Current `origin/main` result in the same run:

```text
80 trades / 6832.09638947 USDT / 0.6832096389469999
```

Before/after trade-surface comparison in that same run:

```text
#704-current trade_surface_equal: true
#709-current trade_surface_equal: true
```

The absolute profit can differ from older screenshots due to data/version/current-main differences, so I am only using the same-run before/after comparison as the safety signal.

