### PR TITLE
Skip extra X7 futures slot scans

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12122,30 +12122,21 @@ class NostalgiaForInfinityX7(IStrategy):
           return self._handle_scalp_mode(pair, config, current_time)
 
     # Long/Short Slot Validation (only in futures mode)
-    if self.is_futures_mode and (self.futures_max_open_trades_long != 0 or self.futures_max_open_trades_short != 0):
-      open_trades = Trade.get_trades_proxy(is_open=True)
-      long_trades = sum(1 for t in open_trades if t.trade_direction == "long")
-      short_trades = sum(1 for t in open_trades if t.trade_direction == "short")
+    if self.is_futures_mode:
+      max_side_trades = 0
+      if side == "long":
+        max_side_trades = self.futures_max_open_trades_long
+      elif side == "short":
+        max_side_trades = self.futures_max_open_trades_short
 
-      # Long trade limit validation
-      if (
-        side == "long" and self.futures_max_open_trades_long != 0 and long_trades >= self.futures_max_open_trades_long
-      ):
-        log.info(
-          f"[{current_time}] Cancelling entry for {pair} due to long trades reaching the max limit of {self.futures_max_open_trades_long}."
-        )
-        return False
-
-      # Short trade limit validation
-      if (
-        side == "short"
-        and self.futures_max_open_trades_short != 0
-        and short_trades >= self.futures_max_open_trades_short
-      ):
-        log.info(
-          f"[{current_time}] Cancelling entry for {pair} due to short trades reaching the max limit of {self.futures_max_open_trades_short}."
-        )
-        return False
+      if max_side_trades != 0:
+        open_trades = Trade.get_trades_proxy(is_open=True)
+        side_trades = sum(1 for t in open_trades if t.trade_direction == side)
+        if side_trades >= max_side_trades:
+          log.info(
+            f"[{current_time}] Cancelling entry for {pair} due to {side} trades reaching the max limit of {max_side_trades}."
+          )
+          return False
 
     # Slippage Validation
     df, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)


### PR DESCRIPTION
## Summary
- count only the current entry side when checking X7 futures slot limits
- avoid scanning open trades once for long and once for short on every entry confirmation
- keep the existing long/short limit behavior and cancellation message shape

## Validation
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- old/new slot-limit truth table: 162 equivalent cases

This is intentionally small and independent from the open STOCHk/order-check PRs.
