### PR TITLE
Centralize X7 STOCHRSI calculation

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3124,6 +3124,15 @@ class NostalgiaForInfinityX7(IStrategy):
     return out
 
   @staticmethod
+  def stochrsi_k(rsi_14: np.ndarray) -> np.ndarray:
+    rsi_min = ta.MIN(rsi_14, timeperiod=14)
+    rsi_max = ta.MAX(rsi_14, timeperiod=14)
+    denom = rsi_max - rsi_min
+    denom = np.where(denom == 0, np.nan, denom)
+    stochrsi = ((rsi_14 - rsi_min) / denom) * 100.0
+    return ta.SMA(stochrsi, timeperiod=3)
+
+  @staticmethod
   def validate_indicators(df: pd.DataFrame, columns: list[str], pair: str, timeframe: str) -> None:
     expected_len = len(df)
     for col in columns:
@@ -3211,12 +3220,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH RSI
     # =========================================================================
-    rsi_min = ta.MIN(rsi_14, timeperiod=14)
-    rsi_max = ta.MAX(rsi_14, timeperiod=14)
-    denom = rsi_max - rsi_min
-    denom = np.where(denom == 0, np.nan, denom)
-    stochrsi = ((rsi_14 - rsi_min) / denom) * 100.0
-    stochrsi_k = ta.SMA(stochrsi, timeperiod=3)
+    stochrsi_k = self.stochrsi_k(rsi_14)
 
     # =========================================================================
     # MONEY FLOW
@@ -3408,12 +3412,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH RSI
     # =========================================================================
-    rsi_min = ta.MIN(rsi_14, timeperiod=14)
-    rsi_max = ta.MAX(rsi_14, timeperiod=14)
-    denom = rsi_max - rsi_min
-    denom = np.where(denom == 0, np.nan, denom)
-    stochrsi = ((rsi_14 - rsi_min) / denom) * 100.0
-    stochrsi_k = ta.SMA(stochrsi, timeperiod=3)
+    stochrsi_k = self.stochrsi_k(rsi_14)
 
     # =========================================================================
     # KST
@@ -3656,12 +3655,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH RSI
     # =========================================================================
-    rsi_min = ta.MIN(rsi_14, timeperiod=14)
-    rsi_max = ta.MAX(rsi_14, timeperiod=14)
-    denom = rsi_max - rsi_min
-    denom = np.where(denom == 0, np.nan, denom)
-    stochrsi = ((rsi_14 - rsi_min) / denom) * 100.0
-    stochrsi_k = ta.SMA(stochrsi, timeperiod=3)
+    stochrsi_k = self.stochrsi_k(rsi_14)
 
     # =========================================================================
     # KST
@@ -3873,12 +3867,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH RSI
     # =========================================================================
-    rsi_min = ta.MIN(rsi_14, timeperiod=14)
-    rsi_max = ta.MAX(rsi_14, timeperiod=14)
-    denom = rsi_max - rsi_min
-    denom = np.where(denom == 0, np.nan, denom)
-    stochrsi = ((rsi_14 - rsi_min) / denom) * 100.0
-    stochrsi_k = ta.SMA(stochrsi, timeperiod=3)
+    stochrsi_k = self.stochrsi_k(rsi_14)
 
     # =========================================================================
     # MONEY FLOW
@@ -4031,12 +4020,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     # STOCH RSI
     # =========================================================================
-    rsi_min = ta.MIN(rsi_14, timeperiod=14)
-    rsi_max = ta.MAX(rsi_14, timeperiod=14)
-    denom = rsi_max - rsi_min
-    denom = np.where(denom == 0, np.nan, denom)
-    stochrsi = ((rsi_14 - rsi_min) / denom) * 100.0
-    stochrsi_k = ta.SMA(stochrsi, timeperiod=3)
+    stochrsi_k = self.stochrsi_k(rsi_14)
 
     # =========================================================================
     # KST


### PR DESCRIPTION
## Summary

- extract the existing manual `STOCHRSIk_14_14_3_3` formula into a shared `stochrsi_k()` helper
- reuse that helper in the 1d, 4h, 1h, 15m, and 5m indicator paths
- keep the current RSI-range / NaN behavior unchanged

## Why it changed

The first version of this PR used TA-Lib `STOCHRSI` directly. After rechecking with timeframe detail, that shortcut was not parity-safe: TA-Lib can return finite values where the current manual formula returns `NaN` when the RSI range is zero.

This updated version keeps the original formula exactly and only removes the duplicated inline block.

## Validation

- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git diff --check`
- 400-file local feather parity check across timeframes:

```text
timeframe,files,fail,max_abs
5m,80,0,0
15m,80,0,0
1h,80,0,0
4h,80,0,0
1d,80,0,0
```

## Not tested

- No full Freqtrade backtest timing benchmark in this PR.

## Additional validation - p!mp futures setup, current main

Reran after rebasing/testing against current upstream `main` (which already includes merged #711).

Setup:

```text
Config     : p!mp config_backtest.json equivalent
Mode       : Binance isolated futures
Pairlist   : p!mp static Binance futures USDT, 343 pairs
Timerange  : 20260101-20260501
Warmup     : pre-roll data included so the effective run starts on 2026-01-01
Backtest   : regular 5m strategy, --breakdown day, no --timeframe-detail
Effective  : 2026-01-01 00:00:00 -> 2026-04-30 23:55:00
```

Current `origin/main` result in the same run:

```text
80 trades / 6832.09638947 USDT / 0.6832096389469999
```

Before/after trade-surface comparison in that same run:

```text
#704-current trade_surface_equal: true
#709-current trade_surface_equal: true
```

The absolute profit can differ from older screenshots due to data/version/current-main differences, so I am only using the same-run before/after comparison as the safety signal.

