### PR TITLE
Speed up X7 empty candle counts

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3994,7 +3994,6 @@ class NostalgiaForInfinityX7(IStrategy):
     low_np = df["low"].to_numpy(copy=False)
     open_np = df["open"].to_numpy(copy=False)
     volume_np = df["volume"].to_numpy(copy=False)
-    volume = df["volume"]
 
     # =========================================================================
     # CORE INDICATORS
@@ -4093,7 +4092,7 @@ class NostalgiaForInfinityX7(IStrategy):
     close_min_6 = ta.MIN(close_np, timeperiod=6)
     close_min_12 = ta.MIN(close_np, timeperiod=12)
     close_min_48 = ta.MIN(close_np, timeperiod=48)
-    num_empty_288 = (volume <= 0).rolling(window=288, min_periods=288).sum().to_numpy()
+    num_empty_288 = ta.SUM((volume_np <= 0).astype(np.float64), timeperiod=288)
 
     new_cols = pd.DataFrame(
       {


### PR DESCRIPTION
## Summary

- replace the pandas rolling sum for `num_empty_288` with TA-Lib `SUM`
- reuse the existing `volume_np` array and remove the temporary `volume` Series variable
- keeps the 288-candle warmup behavior and count values unchanged

## Why it is safe

The current expression counts candles where `volume <= 0` over a 288-candle window:

```python
(volume <= 0).rolling(window=288, min_periods=288).sum()
```

TA-Lib `SUM` over the same boolean mask produces the same NaN warmup and the same counts:

```python
ta.SUM((volume_np <= 0).astype(np.float64), timeperiod=288)
```

## Local timing smoke

80 local feather files, 20 loops each:

- pandas rolling count: `1.189s`
- TA-Lib SUM count: `0.267s`

This is a small indicator-path micro-optimization, not a full backtest benchmark.

## Checks

- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git diff --check`
- 25-file 5m feather parity check (`nan_equal=True`, `max_abs_diff=0.0`)

## Not tested

- No full Freqtrade backtest timing benchmark in this PR.
