### PR TITLE
Trim X7 CMF volume sums

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3083,7 +3083,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     mfv = mfm * volume
     mfv_sum = pd.Series(mfv, copy=False).rolling(timeperiod).sum().to_numpy(copy=False)
-    vol_sum = pd.Series(volume, copy=False).rolling(timeperiod).sum().to_numpy(copy=False)
+    vol_sum = ta.SUM(volume, timeperiod=timeperiod)
 
     return mfv_sum / vol_sum
 


### PR DESCRIPTION
## Summary

- use TA-Lib for the finite volume rolling sum inside X7 CMF
- keep the money-flow rolling sum on pandas to preserve the parity-sensitive NaN behavior
- keep the change scoped to the existing CMF helper only

## Safety checks

Local 400-feather CMF check over 80 pairs x 5 timeframes:

```text
candidate,fail_nan,files_with_any_diff,max_abs,max_rel,neq_values
denom_talib,0,305,1.9428902930940239e-12,5.8853634305042915e-12,10157585
```

Current X7 CMF threshold check over the same local data:

```text
flips 0 checked_values 23873160 max_abs 1.9428902930940239e-12 worst ZBT_USDT-5m.feather
```

Timing smoke for the CMF helper over the same local frames:

```text
summary cur runs 5 median 0.583612 mean 0.584542 min 0.578517 max 0.590853
summary cand runs 5 median 0.557251 mean 0.558977 min 0.555721 max 0.564675
speedup_median 1.0473x
```

## Validation

```text
ruff format --check NostalgiaForInfinityX7.py
ruff check NostalgiaForInfinityX7.py
PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
git diff --check
```

Not tested: full Freqtrade backtest in this local WSL environment.
