### PR TITLE
Trim X7 CMF money-flow sums

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3072,6 +3072,16 @@ class NostalgiaForInfinityX7(IStrategy):
     return list(informative_pairs)
 
   @staticmethod
+  def rolling_sum(arr: np.ndarray, timeperiod: int) -> np.ndarray:
+    arr = np.asarray(arr, dtype=np.float64)
+    out = np.full(arr.shape, np.nan, dtype=np.float64)
+    if arr.size < timeperiod:
+      return out
+
+    out[timeperiod - 1 :] = np.convolve(arr, np.ones(timeperiod, dtype=np.float64), mode="valid")
+    return out
+
+  @staticmethod
   def chaikin_money_flow(high, low, close, volume, timeperiod=20):
     hl_range = high - low
     mfm = np.divide(
@@ -3082,7 +3092,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     mfv = mfm * volume
-    mfv_sum = pd.Series(mfv, copy=False).rolling(timeperiod).sum().to_numpy(copy=False)
+    mfv_sum = __class__.rolling_sum(mfv, timeperiod)
     vol_sum = ta.SUM(volume, timeperiod=timeperiod)
 
     return mfv_sum / vol_sum


### PR DESCRIPTION
## Summary

- replace the remaining pandas rolling sum in X7 CMF money-flow volume with a small NumPy rolling-sum helper
- keep the existing TA-Lib volume sum from #711
- preserve pandas-style full-window NaN behavior for the CMF money-flow sum

## Safety checks

Our standard 80-pair spot backtest, current main vs this branch:

```text
Config     : user_data/config-test-x7.example.json + user_data/config-original-x7-80pairs.example.json
Mode       : spot / 80 pairs
Timerange  : 20250101-20260401
Effective  : 2025-01-03 18:40:00 -> 2026-03-30 23:55:00 (451 days)
Backtest   : regular 5m strategy, --cache none, export trades

trade_surface_equal : True
first_difference    : None
origin trades/profit : 317 / 2216.08558628 USDT / 2.2160855862799997
variant trades/profit: 317 / 2216.08558628 USDT / 2.2160855862799997
```

Value check over the same local spot candle data:

```text
files 400
nan_mask_mismatches 0
max_abs 1.4085954624931674e-13
threshold_flips 0
old_pandas_rolling_seconds 0.404613
new_numpy_window_seconds 0.348189
rolling_sum_speedup 1.162
```

I also ran the p!mp futures setup as an extra canary; it matched too, but the main evidence above is the standard 80-pair spot config.

## Validation

- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`

Not tested: full live/dry-run timing benchmark.
