### PR TITLE
Trim X7 live volume window check

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4232,7 +4232,7 @@ class NostalgiaForInfinityX7(IStrategy):
       df["bt_agefilter_ok"] = False
       df.loc[df.index > (12 * 24 * self.bt_min_age_days), "bt_agefilter_ok"] = True
     else:
-      df["live_data_ok"] = df["volume"].rolling(window=72, min_periods=72).min() > 0
+      df["live_data_ok"] = ta.MIN(volume_np, timeperiod=72) > 0
 
     # =========================================================================
     # LOGGING


### PR DESCRIPTION
## Summary
- replace the live/dry_run `live_data_ok` pandas rolling-min check with TA-Lib `MIN`
- reuse the existing `volume_np` array already built for base-timeframe indicators
- keep the 72-candle positive-volume truth table unchanged

## Safety
This only changes the live/dry_run volume-health gate calculation:

```py
# before
df["volume"].rolling(window=72, min_periods=72).min() > 0

# after
ta.MIN(volume_np, timeperiod=72) > 0
```

The first 71 candles remain false because TA-Lib returns NaN there and `NaN > 0` is false, matching pandas rolling with `min_periods=72`.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git diff --check origin/main...HEAD`
- expression value check over 80 real 5m feather files / 9,823,638 rows:
  - old pandas expression vs new TA-Lib expression
  - mismatches: 0
- direct `base_tf_5m_indicators()` dry_run-path check over the same 80 real 5m feather files / 9,823,638 rows:
  - `live_data_ok` mismatches: 0

## Notes
I did not use a full backtest as proof for this one because the changed branch is live/dry_run-only; backtesting uses the `bt_agefilter_ok` path instead.
