### PR TITLE
Skip redundant X7 candle row squeeze

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1861,12 +1861,12 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
     if len(df) < 6:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle_1 = df.iloc[-2].squeeze()
-    previous_candle_2 = df.iloc[-3].squeeze()
-    previous_candle_3 = df.iloc[-4].squeeze()
-    previous_candle_4 = df.iloc[-5].squeeze()
-    previous_candle_5 = df.iloc[-6].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle_1 = df.iloc[-2]
+    previous_candle_2 = df.iloc[-3]
+    previous_candle_3 = df.iloc[-4]
+    previous_candle_4 = df.iloc[-5]
+    previous_candle_5 = df.iloc[-6]
 
     enter_tag = "empty"
     if hasattr(trade, "enter_tag") and trade.enter_tag is not None:
@@ -12159,7 +12159,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Slippage Validation
     df, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
     if len(df) >= 1:
-      last_candle = df.iloc[-1].squeeze()
+      last_candle = df.iloc[-1]
       if (side == "long" and rate > last_candle["close"]) or (side == "short" and rate < last_candle["close"]):
         slippage = (rate / last_candle["close"]) - 1.0
         if (side == "long" and slippage < self.max_slippage) or (side == "short" and slippage > -self.max_slippage):
@@ -44009,8 +44009,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -46418,8 +46418,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -48361,8 +48361,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -52033,8 +52033,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -52220,8 +52220,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -70487,8 +70487,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -72878,8 +72878,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -74499,8 +74499,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -78109,8 +78109,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -78286,8 +78286,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
-    last_candle = df.iloc[-1].squeeze()
-    previous_candle = df.iloc[-2].squeeze()
+    last_candle = df.iloc[-1]
+    previous_candle = df.iloc[-2]
 
     # we already waiting for an order to get filled
     if trade.has_open_orders:


### PR DESCRIPTION
## Summary
- remove redundant `.squeeze()` calls after `df.iloc[-n]` candle row lookups
- keep the existing row access shape and all candle field reads unchanged

## Why this is safe
- `df.iloc[-n]` already returns a Series for these multi-column analyzed dataframes.
- A row-equivalence check over real 5m data found no value/index/name differences.
- Spot and isolated-futures backtest comparisons matched exactly on the trade surface.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git diff --check origin/main...HEAD`
- Row equivalence: 80 real 5m feather files, positions 1..6, 480 checks, 0 mismatches
- Row-access microbenchmark: 80,000 row reads, 12.981s with `.squeeze()` vs 6.566s direct `iloc` (~1.98x faster for this row-access microbenchmark)
- 80-pair spot backtest parity, `20250101-20260401`, standard public TestX7 config pairlist:
  - base `NFIX7RowBase`: 317 trades, 2206.67665376 USDT profit
  - patched `NFIX7RowDirect`: 317 trades, 2206.67665376 USDT profit
  - `trade_surface_equal: true`
- Isolated futures backtest parity, `20250101-20260401`, 68 Binance futures pairs matched from the public 80-pair config:
  - base `NFIX7RowBaseFutures`: 299 trades, 29932.95460869 USDT profit
  - patched `NFIX7RowDirectFutures`: 299 trades, 29932.95460869 USDT profit
  - `trade_surface_equal: true`

## Notes
- This is a narrow hot-path cleanup only; it does not claim a full strategy-level speedup.
- The futures run used the available Binance isolated-futures matches from the public 80-pair set; pairs unavailable as Binance futures were excluded from that check.
