### PR TITLE
Defer X7 debug log formatting

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3168,7 +3168,7 @@ class NostalgiaForInfinityX7(IStrategy):
         if nan_pct > 50.0:
           log.warning(f"[{pair}] [{timeframe}] {col} has {nan_pct:.1f}% NaN")
         else:
-          log.debug(f"[{pair}] [{timeframe}] {col} NaNs: {nan_count} ({nan_pct:.1f}%)")
+          log.debug("[%s] [%s] %s NaNs: %s (%.1f%%)", pair, timeframe, col, nan_count, nan_pct)
 
   # Informative 1d Timeframe Indicators
   # ---------------------------------------------------------------------------------------------
@@ -3363,7 +3363,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug(f"[{metadata['pair']}] informative_1d_indicators took: {tok - tik:0.4f} seconds.")
+    log.debug("[%s] informative_1d_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
 
     return informative_1d
 
@@ -3608,7 +3608,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug(f"[{metadata['pair']}] informative_4h_indicators took: {tok - tik:0.4f} seconds.")
+    log.debug("[%s] informative_4h_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
 
     return informative_4h
 
@@ -3827,7 +3827,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug(f"[{metadata['pair']}] informative_1h_indicators took: {tok - tik:0.4f} seconds.")
+    log.debug("[%s] informative_1h_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
 
     return informative_1h
 
@@ -3996,7 +3996,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug(f"[{metadata['pair']}] informative_15m_indicators took: {tok - tik:0.4f} seconds.")
+    log.debug("[%s] informative_15m_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
 
     return informative_15m
 
@@ -4249,7 +4249,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug(f"[{metadata['pair']}] base_tf_5m_indicators took: {tok - tik:0.4f} seconds.")
+    log.debug("[%s] base_tf_5m_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
 
     return df
 
@@ -4302,7 +4302,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug(f"[{metadata['pair']}] btc_info_{btc_info_timeframe}_indicators took: {tok - tik:0.4f} seconds.")
+    log.debug("[%s] btc_info_%s_indicators took: %.4f seconds.", metadata["pair"], btc_info_timeframe, tok - tik)
 
     return df
 
@@ -12087,7 +12087,7 @@ class NostalgiaForInfinityX7(IStrategy):
       f"{tok_total - tik:0.4f}s"
     )
     tok = time.perf_counter()
-    log.debug(f"[{metadata['pair']}] Populate indicators took a total of: {tok - tik:0.4f} seconds.")
+    log.debug("[%s] Populate indicators took a total of: %.4f seconds.", metadata["pair"], tok - tik)
 
     return df
 


### PR DESCRIPTION
## Summary
- replace eager `log.debug(f"...")` formatting with logging's lazy `%` formatting
- keep the emitted debug messages equivalent when DEBUG logging is enabled
- avoid building these debug strings on the normal non-DEBUG path

## Why this is safe
- This only changes debug logging calls; no indicator, entry, exit, order, or stake logic is touched.
- The replacement uses Python logging's standard lazy formatting, so arguments are formatted only if the debug message is emitted.
- Sample output checks matched the old f-string output.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git diff --check origin/main...HEAD`
- debug-message formatting equivalence sample: `all_equal: True`
- disabled-debug microbenchmark, 8 representative debug calls, 1,000,000 loops, best of 5:
  - eager f-string formatting: 3.793803s
  - lazy logging formatting: 1.417937s
  - ~2.68x faster for this disabled-debug logging microbenchmark

## Notes
- This does not claim a full strategy-level speedup.
- I did not run a full backtest for this PR because the change is debug logging only and does not touch trading calculations.
