### PR TITLE
Reuse X7 entry string parsing

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12130,8 +12130,9 @@ class NostalgiaForInfinityX7(IStrategy):
     }
 
     # Mode Validation
+    entry_tags = entry_tag.split()
     for mode, config in mode_configs.items():
-      if all(c in config["tags"] for c in entry_tag.split()):
+      if all(c in config["tags"] for c in entry_tags):
         if mode == "grind":
           return self._handle_grind_mode(pair, config, current_time)
         elif mode == "top_coins":
@@ -12522,8 +12523,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if not is_backtest:
       current_free_slots = self.config["max_open_trades"] - Trade.get_open_trade_count()
     # Grind mode
+    pair_coin = metadata["pair"].split("/")[0]
     num_open_long_grind_mode = 0
-    is_pair_long_grind_mode = metadata["pair"].split("/")[0] in self.grind_mode_coins
+    is_pair_long_grind_mode = pair_coin in self.grind_mode_coins
     if not is_backtest:
       open_trades = Trade.get_trades_proxy(is_open=True)
       for open_trade in open_trades:
@@ -12533,8 +12535,8 @@ class NostalgiaForInfinityX7(IStrategy):
           if all(c in self.long_grind_mode_tags for c in enter_tags):
             num_open_long_grind_mode += 1
     # Top Coins mode
-    is_pair_long_top_coins_mode = metadata["pair"].split("/")[0] in self.top_coins_mode_coins
-    is_pair_short_top_coins_mode = metadata["pair"].split("/")[0] in self.top_coins_mode_coins
+    is_pair_long_top_coins_mode = pair_coin in self.top_coins_mode_coins
+    is_pair_short_top_coins_mode = pair_coin in self.top_coins_mode_coins
     # if BTC/ETH stake
     is_btc_stake = self.config["stake_currency"] in self.btc_stakes
     allowed_empty_candles_288 = 144 if is_btc_stake else 60


### PR DESCRIPTION
## Summary
- split `entry_tag` once in `confirm_trade_entry()` before checking the mode configs
- split the pair symbol once in `populate_entry_trend()` before the grind/top-coins membership checks
- keep the same membership checks and mode branching unchanged

## Why this is safe
- This reuses the exact same `split()` results that were already being computed repeatedly.
- No indicator values, entry conditions, exit conditions, orders, or stake calculations are changed.
- A small equivalence check over representative entry tags and spot/futures pair formats found no mode/pair-flag differences.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git diff --check origin/main...HEAD`
- entry string parsing equivalence check:
  - entry tag samples: 10
  - pair samples: 6
  - mode mismatches: 0
  - pair mismatches: 0
  - `all_equal: True`
- string parsing microbenchmark, 2,000,000 loops, best of 5:
  - repeated split path: 3.162359s
  - reused parse path: 2.334687s
  - ~1.36x faster for this string parsing microbenchmark

## Notes
- This does not claim a full strategy-level speedup.
- I did not run a full backtest because this only reuses identical string parsing results before the same checks.
