### PR TITLE
Skip X7 open-order adjust work

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43991,16 +43991,16 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ):
     is_backtest = self.is_backtest_mode()
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     min_stake = self.correct_min_stake(min_stake)
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -46400,16 +46400,16 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ):
     is_backtest = self.is_backtest_mode()
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     min_stake = self.correct_min_stake(min_stake)
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -48343,16 +48343,16 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ):
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt"]
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     min_stake = self.correct_min_stake(min_stake)
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -52015,16 +52015,16 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> Optional[float]:
     # min/max stakes include leverage. The return amounts is before leverage.
     min_stake /= trade.leverage
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     max_stake /= trade.leverage
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -52202,16 +52202,16 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> Optional[float]:
     # min/max stakes include leverage. The return amounts is before leverage.
     min_stake /= trade.leverage
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     max_stake /= trade.leverage
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -70469,16 +70469,16 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ):
     is_backtest = self.is_backtest_mode()
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     min_stake = self.correct_min_stake(min_stake)
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -72860,16 +72860,16 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ):
     is_backtest = self.is_backtest_mode()
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     min_stake = self.correct_min_stake(min_stake)
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -74481,16 +74481,16 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ):
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt"]
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     min_stake = self.correct_min_stake(min_stake)
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -78091,16 +78091,16 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> Optional[float]:
     # min/max stakes include leverage. The return amounts is before leverage.
     min_stake /= trade.leverage
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     max_stake /= trade.leverage
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(
@@ -78268,16 +78268,16 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> Optional[float]:
     # min/max stakes include leverage. The return amounts is before leverage.
     min_stake /= trade.leverage
+    # we already waiting for an order to get filled
+    if trade.has_open_orders:
+      return None
+
     max_stake /= trade.leverage
     df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
     previous_candle = df.iloc[-2]
-
-    # we already waiting for an order to get filled
-    if trade.has_open_orders:
-      return None
 
     exit_rate = current_rate
     filled_orders, filled_entries, filled_exits, profit_values = self.profit_or_order_snapshot(


### PR DESCRIPTION
## Summary
- move the `trade.has_open_orders` guard earlier in the X7 adjust-position paths
- skip analyzed-dataframe lookup and candle row reads when the function will return `None` anyway
- keep the existing return behavior unchanged for open-order and non-open-order paths

## Why this is safe
- The moved guard already returned `None` before any stake/order/profit calculation.
- When `trade.has_open_orders` is false, the same dataframe lookup and candle checks still run as before.
- When `trade.has_open_orders` is true, the result remains `None`; this only avoids unnecessary work before that return.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git diff --check`
- open-order guard equivalence check:
  - cases: 8
  - return mismatches: 0
- synthetic open-order guard microbenchmark, 2,000,000 loops, best of 5:
  - old guard-after-dataframe path: 0.614261s
  - new guard-before-dataframe path: 0.100200s
  - ~6.13x faster for this synthetic open-order guard path

## Notes
- This does not claim a full strategy-level speedup.
- I did not run a full backtest because the PR only moves an existing early `None` return before unused dataframe/candle work.
