### PR TITLE
Trim X7 regular grind stake churn

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -50563,35 +50563,31 @@ class NostalgiaForInfinityX7(IStrategy):
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt"]
 
     max_rebuy_sub_grinds = 0
-    regular_mode_rebuy_stakes = (
-      self.regular_mode_rebuy_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_rebuy_stakes_spot.copy()
+    regular_mode_rebuy_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_rebuy_stakes_futures if self.is_futures_mode else self.regular_mode_rebuy_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_rebuy_sub_thresholds = (
       self.regular_mode_rebuy_thresholds_futures if self.is_futures_mode else self.regular_mode_rebuy_thresholds_spot
     )
-    if (slice_amount * regular_mode_rebuy_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_rebuy_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_rebuy_stakes):
-        regular_mode_rebuy_stakes[i] *= multi
     max_rebuy_sub_grinds = len(regular_mode_rebuy_stakes)
 
     max_grind_1_sub_grinds = 0
-    regular_mode_grind_1_stakes = (
-      self.regular_mode_grind_1_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_1_stakes_spot.copy()
+    regular_mode_grind_1_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_1_stakes_futures if self.is_futures_mode else self.regular_mode_grind_1_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_1_sub_thresholds = (
       self.regular_mode_grind_1_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_1_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_1_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_1_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_1_stakes):
-        regular_mode_grind_1_stakes[i] *= multi
     max_grind_1_sub_grinds = len(regular_mode_grind_1_stakes)
     regular_mode_grind_1_stop_grinds = (
       self.regular_mode_grind_1_stop_grinds_futures
@@ -50605,20 +50601,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_2_sub_grinds = 0
-    regular_mode_grind_2_stakes = (
-      self.regular_mode_grind_2_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_2_stakes_spot.copy()
+    regular_mode_grind_2_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_2_stakes_futures if self.is_futures_mode else self.regular_mode_grind_2_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_2_sub_thresholds = (
       self.regular_mode_grind_2_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_2_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_2_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_2_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_2_stakes):
-        regular_mode_grind_2_stakes[i] *= multi
     max_grind_2_sub_grinds = len(regular_mode_grind_2_stakes)
     regular_mode_grind_2_stop_grinds = (
       self.regular_mode_grind_2_stop_grinds_futures
@@ -50632,20 +50626,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_3_sub_grinds = 0
-    regular_mode_grind_3_stakes = (
-      self.regular_mode_grind_3_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_3_stakes_spot.copy()
+    regular_mode_grind_3_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_3_stakes_futures if self.is_futures_mode else self.regular_mode_grind_3_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_3_sub_thresholds = (
       self.regular_mode_grind_3_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_3_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_3_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_3_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_3_stakes):
-        regular_mode_grind_3_stakes[i] *= multi
     max_grind_3_sub_grinds = len(regular_mode_grind_3_stakes)
     regular_mode_grind_3_stop_grinds = (
       self.regular_mode_grind_3_stop_grinds_futures
@@ -50659,20 +50651,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_4_sub_grinds = 0
-    regular_mode_grind_4_stakes = (
-      self.regular_mode_grind_4_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_4_stakes_spot.copy()
+    regular_mode_grind_4_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_4_stakes_futures if self.is_futures_mode else self.regular_mode_grind_4_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_4_sub_thresholds = (
       self.regular_mode_grind_4_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_4_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_4_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_4_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_4_stakes):
-        regular_mode_grind_4_stakes[i] *= multi
     max_grind_4_sub_grinds = len(regular_mode_grind_4_stakes)
     regular_mode_grind_4_stop_grinds = (
       self.regular_mode_grind_4_stop_grinds_futures
@@ -50686,20 +50676,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_5_sub_grinds = 0
-    regular_mode_grind_5_stakes = (
-      self.regular_mode_grind_5_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_5_stakes_spot.copy()
+    regular_mode_grind_5_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_5_stakes_futures if self.is_futures_mode else self.regular_mode_grind_5_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_5_sub_thresholds = (
       self.regular_mode_grind_5_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_5_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_5_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_5_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_5_stakes):
-        regular_mode_grind_5_stakes[i] *= multi
     max_grind_5_sub_grinds = len(regular_mode_grind_5_stakes)
     regular_mode_grind_5_stop_grinds = (
       self.regular_mode_grind_5_stop_grinds_futures
@@ -50713,20 +50701,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_6_sub_grinds = 0
-    regular_mode_grind_6_stakes = (
-      self.regular_mode_grind_6_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_6_stakes_spot.copy()
+    regular_mode_grind_6_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_6_stakes_futures if self.is_futures_mode else self.regular_mode_grind_6_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_6_sub_thresholds = (
       self.regular_mode_grind_6_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_6_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_6_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_6_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_6_stakes):
-        regular_mode_grind_6_stakes[i] *= multi
     max_grind_6_sub_grinds = len(regular_mode_grind_6_stakes)
     regular_mode_grind_6_stop_grinds = (
       self.regular_mode_grind_6_stop_grinds_futures
@@ -76632,35 +76618,31 @@ class NostalgiaForInfinityX7(IStrategy):
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt"]
 
     max_rebuy_sub_grinds = 0
-    regular_mode_rebuy_stakes = (
-      self.regular_mode_rebuy_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_rebuy_stakes_spot.copy()
+    regular_mode_rebuy_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_rebuy_stakes_futures if self.is_futures_mode else self.regular_mode_rebuy_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_rebuy_sub_thresholds = (
       self.regular_mode_rebuy_thresholds_futures if self.is_futures_mode else self.regular_mode_rebuy_thresholds_spot
     )
-    if (slice_amount * regular_mode_rebuy_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_rebuy_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_rebuy_stakes):
-        regular_mode_rebuy_stakes[i] *= multi
     max_rebuy_sub_grinds = len(regular_mode_rebuy_stakes)
 
     max_grind_1_sub_grinds = 0
-    regular_mode_grind_1_stakes = (
-      self.regular_mode_grind_1_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_1_stakes_spot.copy()
+    regular_mode_grind_1_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_1_stakes_futures if self.is_futures_mode else self.regular_mode_grind_1_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_1_sub_thresholds = (
       self.regular_mode_grind_1_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_1_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_1_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_1_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_1_stakes):
-        regular_mode_grind_1_stakes[i] *= multi
     max_grind_1_sub_grinds = len(regular_mode_grind_1_stakes)
     regular_mode_grind_1_stop_grinds = (
       self.regular_mode_grind_1_stop_grinds_futures
@@ -76674,20 +76656,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_2_sub_grinds = 0
-    regular_mode_grind_2_stakes = (
-      self.regular_mode_grind_2_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_2_stakes_spot.copy()
+    regular_mode_grind_2_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_2_stakes_futures if self.is_futures_mode else self.regular_mode_grind_2_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_2_sub_thresholds = (
       self.regular_mode_grind_2_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_2_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_2_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_2_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_2_stakes):
-        regular_mode_grind_2_stakes[i] *= multi
     max_grind_2_sub_grinds = len(regular_mode_grind_2_stakes)
     regular_mode_grind_2_stop_grinds = (
       self.regular_mode_grind_2_stop_grinds_futures
@@ -76701,20 +76681,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_3_sub_grinds = 0
-    regular_mode_grind_3_stakes = (
-      self.regular_mode_grind_3_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_3_stakes_spot.copy()
+    regular_mode_grind_3_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_3_stakes_futures if self.is_futures_mode else self.regular_mode_grind_3_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_3_sub_thresholds = (
       self.regular_mode_grind_3_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_3_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_3_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_3_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_3_stakes):
-        regular_mode_grind_3_stakes[i] *= multi
     max_grind_3_sub_grinds = len(regular_mode_grind_3_stakes)
     regular_mode_grind_3_stop_grinds = (
       self.regular_mode_grind_3_stop_grinds_futures
@@ -76728,20 +76706,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_4_sub_grinds = 0
-    regular_mode_grind_4_stakes = (
-      self.regular_mode_grind_4_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_4_stakes_spot.copy()
+    regular_mode_grind_4_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_4_stakes_futures if self.is_futures_mode else self.regular_mode_grind_4_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_4_sub_thresholds = (
       self.regular_mode_grind_4_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_4_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_4_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_4_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_4_stakes):
-        regular_mode_grind_4_stakes[i] *= multi
     max_grind_4_sub_grinds = len(regular_mode_grind_4_stakes)
     regular_mode_grind_4_stop_grinds = (
       self.regular_mode_grind_4_stop_grinds_futures
@@ -76755,20 +76731,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_5_sub_grinds = 0
-    regular_mode_grind_5_stakes = (
-      self.regular_mode_grind_5_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_5_stakes_spot.copy()
+    regular_mode_grind_5_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_5_stakes_futures if self.is_futures_mode else self.regular_mode_grind_5_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_5_sub_thresholds = (
       self.regular_mode_grind_5_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_5_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_5_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_5_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_5_stakes):
-        regular_mode_grind_5_stakes[i] *= multi
     max_grind_5_sub_grinds = len(regular_mode_grind_5_stakes)
     regular_mode_grind_5_stop_grinds = (
       self.regular_mode_grind_5_stop_grinds_futures
@@ -76782,20 +76756,18 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_6_sub_grinds = 0
-    regular_mode_grind_6_stakes = (
-      self.regular_mode_grind_6_stakes_futures.copy()
-      if self.is_futures_mode
-      else self.regular_mode_grind_6_stakes_spot.copy()
+    regular_mode_grind_6_stakes = self.scale_stakes_for_min_stake(
+      self.regular_mode_grind_6_stakes_futures if self.is_futures_mode else self.regular_mode_grind_6_stakes_spot,
+      slice_amount,
+      min_stake,
+      trade.leverage,
+      trade.leverage,
     )
     regular_mode_grind_6_sub_thresholds = (
       self.regular_mode_grind_6_thresholds_futures
       if self.is_futures_mode
       else self.regular_mode_grind_6_thresholds_spot
     )
-    if (slice_amount * regular_mode_grind_6_stakes[0] / trade.leverage) < min_stake:
-      multi = min_stake / slice_amount / regular_mode_grind_6_stakes[0] * trade.leverage
-      for i, _ in enumerate(regular_mode_grind_6_stakes):
-        regular_mode_grind_6_stakes[i] *= multi
     max_grind_6_sub_grinds = len(regular_mode_grind_6_stakes)
     regular_mode_grind_6_stop_grinds = (
       self.regular_mode_grind_6_stop_grinds_futures


### PR DESCRIPTION
## Summary
- reuse `scale_stakes_for_min_stake()` for long/short regular-mode rebuy and grind stake tables
- avoid copying the regular-mode stake lists when min-stake scaling is not needed
- keep the existing multiplier formula, thresholds, and stake values unchanged

## Safety
This uses the same helper pattern already used by the grind v2/v3 paths. When scaling is required the helper still copies first, then applies the existing multiplier. When scaling is not required the returned stake list is only read; I checked the long/short regular-mode paths do not mutate these lists after initialization.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- 2016-case equivalence check for old vs helper scaling: `mismatches=0`, `input_mutations=0`
- post-init mutation scan: `0` regular stake-list mutations in both long and short paths
- synthetic helper microbench: no-scale path ~1.32x faster; scaled path ~1.02x faster

No full backtest run; this is a formula-preserving stake table preparation change.
