### PR TITLE
Speed X7 stake scaling helper

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1847,11 +1847,8 @@ class NostalgiaForInfinityX7(IStrategy):
     if (slice_amount * stakes[0] / stake_leverage) >= min_stake:
       return stakes
 
-    scaled_stakes = stakes.copy()
-    multi = min_stake / slice_amount / scaled_stakes[0] * trade_leverage
-    for i, _ in enumerate(scaled_stakes):
-      scaled_stakes[i] *= multi
-    return scaled_stakes
+    multi = min_stake / slice_amount / stakes[0] * trade_leverage
+    return [stake * multi for stake in stakes]
 
   # Custom Exit
   # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `scale_stakes_for_min_stake()` build scaled stake tables with a list comprehension
- avoid the extra `copy()` plus in-place loop when min-stake scaling is required
- leave the no-scale path and scaling formula unchanged

## Safety
The helper still returns the original `stakes` object when scaling is not needed, and still returns a new scaled list when scaling is needed. The multiplier formula is unchanged.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- 2304-case helper equivalence check: `mismatches=0`, `identity_mismatches=0`, `input_mutations=0`
- synthetic helper microbench: scaled path ~1.56x faster; no-scale path unchanged (~0.99x)

No full backtest run; this is a formula-preserving helper implementation change.
