### PR TITLE
Trim X7 filled order snapshot loop

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1710,10 +1710,13 @@ class NostalgiaForInfinityX7(IStrategy):
     filled_orders = trade.select_filled_orders()
     filled_entries = []
     filled_exits = []
+    entry_side = trade.entry_side
+    exit_side = trade.exit_side
     for order in filled_orders:
-      if order.ft_order_side == trade.entry_side:
+      order_side = order.ft_order_side
+      if order_side == entry_side:
         filled_entries.append(order)
-      elif order.ft_order_side == trade.exit_side:
+      elif order_side == exit_side:
         filled_exits.append(order)
     return filled_orders, filled_entries, filled_exits
 


### PR DESCRIPTION
## Summary
- cache `trade.entry_side` and `trade.exit_side` once in `filled_order_snapshot()`
- reuse the current order side inside the loop when splitting filled orders
- keep the returned filled order, entry, and exit lists unchanged

## Safety
This does not change which orders are selected. It only avoids repeated trade-side attribute lookups while walking the same `filled_orders` list.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- 6-case snapshot equivalence check: `mismatches=0`
- synthetic snapshot microbench: ~1.89x faster for the loop helper

No full backtest run; this is a behavior-preserving helper-loop cleanup.
