### PR TITLE
Trim X7 profit loop branching

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1808,32 +1808,33 @@ class NostalgiaForInfinityX7(IStrategy):
     total_amount = 0.0
     total_stake = 0.0
     total_profit = 0.0
-    current_stake = 0.0
-    for entry_order in filled_entries:
-      if trade.is_short:
-        entry_stake = entry_order.safe_filled * entry_order.safe_price * (1 - fee_open_rate)
+    if trade.is_short:
+      fee_open_multiplier = 1 - fee_open_rate
+      fee_close_multiplier = 1 + fee_close_rate
+      for entry_order in filled_entries:
+        entry_stake = entry_order.safe_filled * entry_order.safe_price * fee_open_multiplier
         total_amount += entry_order.safe_filled
         total_stake += entry_stake
         total_profit += entry_stake
-      else:
-        entry_stake = entry_order.safe_filled * entry_order.safe_price * (1 + fee_open_rate)
+      for exit_order in filled_exits:
+        exit_stake = exit_order.safe_filled * exit_order.safe_price * fee_close_multiplier
+        total_amount -= exit_order.safe_filled
+        total_profit -= exit_stake
+      current_stake = total_amount * exit_rate * fee_close_multiplier
+      total_profit -= current_stake
+    else:
+      fee_open_multiplier = 1 + fee_open_rate
+      fee_close_multiplier = 1 - fee_close_rate
+      for entry_order in filled_entries:
+        entry_stake = entry_order.safe_filled * entry_order.safe_price * fee_open_multiplier
         total_amount += entry_order.safe_filled
         total_stake += entry_stake
         total_profit -= entry_stake
-    for exit_order in filled_exits:
-      if trade.is_short:
-        exit_stake = exit_order.safe_filled * exit_order.safe_price * (1 + fee_close_rate)
-        total_amount -= exit_order.safe_filled
-        total_profit -= exit_stake
-      else:
-        exit_stake = exit_order.safe_filled * exit_order.safe_price * (1 - fee_close_rate)
+      for exit_order in filled_exits:
+        exit_stake = exit_order.safe_filled * exit_order.safe_price * fee_close_multiplier
         total_amount -= exit_order.safe_filled
         total_profit += exit_stake
-    if trade.is_short:
-      current_stake = total_amount * exit_rate * (1 + fee_close_rate)
-      total_profit -= current_stake
-    else:
-      current_stake = total_amount * exit_rate * (1 - fee_close_rate)
+      current_stake = total_amount * exit_rate * fee_close_multiplier
       total_profit += current_stake
     if self.is_futures_mode:
       total_profit += trade.funding_fees


### PR DESCRIPTION
## Summary
- split `calc_total_profit()` into long/short loop bodies
- avoid checking `trade.is_short` inside every entry and exit order iteration
- reuse fee multipliers inside each side-specific path

## Safety
The formulas are unchanged. The refactor only moves the side branch outside the loops and keeps the same entry, exit, current-stake, and funding-fee calculations.

## Checks
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- 513-case `calc_total_profit()` equivalence check: `mismatches=0`, `max_delta=0`
- synthetic profit-loop microbench: long path ~1.35x faster; short path ~1.31x faster

No full backtest run; this is a formula-preserving calculation-loop refactor.
