### PR TITLE
Trim X7 pair base parsing

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12160,7 +12160,7 @@ class NostalgiaForInfinityX7(IStrategy):
     return True
 
   def _handle_grind_mode(self, pair: str, config: dict, current_time: datetime) -> bool:
-    is_pair_grind_mode = pair.split("/")[0] in config["coins"]
+    is_pair_grind_mode = pair.partition("/")[0] in config["coins"]
     if not is_pair_grind_mode:
       log.info(f"[{current_time}] Cancelling entry for {pair} due to not being in grind mode coins list.")
       return False
@@ -12174,7 +12174,7 @@ class NostalgiaForInfinityX7(IStrategy):
     return True
 
   def _handle_top_coins_mode(self, pair: str, config: dict, current_time: datetime) -> bool:
-    is_pair_top_coins_mode = pair.split("/")[0] in config["coins"]
+    is_pair_top_coins_mode = pair.partition("/")[0] in config["coins"]
     if not is_pair_top_coins_mode:
       log.info(f"[{current_time}] Cancelling entry for {pair} due to not being in top coins list.")
       return False
@@ -12514,7 +12514,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if not is_backtest:
       current_free_slots = self.config["max_open_trades"] - Trade.get_open_trade_count()
     # Grind mode
-    pair_coin = metadata["pair"].split("/")[0]
+    pair_coin = metadata["pair"].partition("/")[0]
     num_open_long_grind_mode = 0
     is_pair_long_grind_mode = pair_coin in self.grind_mode_coins
     if not is_backtest:


### PR DESCRIPTION
## Summary
- replace `split("/")[0]` with `partition("/")[0]` where X7 only needs the pair base asset
- covers grind/top-coins entry gating and the pair coin used in indicator population
- avoids creating a temporary list for simple prefix extraction

## Why it is safe
- `partition("/")[0]` preserves the same result as `split("/")[0]` for normal spot pairs, futures-style pairs, missing-separator strings, and leading-separator strings
- no coin lists, entry conditions, or indicator values were changed

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- pair base equivalence check: 7 representative cases, `mismatches=0`
- synthetic parsing microbench: old `6.694475s`, new `5.683678s`, about `1.18x` faster

## Not tested
- full backtest; this is a narrow string-prefix parsing cleanup only
