### PR TITLE
Trim X7 entry signal index parsing

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12550,7 +12550,7 @@ class NostalgiaForInfinityX7(IStrategy):
     #
 
     for enabled_long_entry_signal in self.long_entry_signal_params:
-      long_entry_condition_index = int(enabled_long_entry_signal.split("_")[3])
+      long_entry_condition_index = int(enabled_long_entry_signal.rsplit("_", 2)[1])
       item_buy_protection_list = [True]
       if self.long_entry_signal_params[f"{enabled_long_entry_signal}"]:
         # Long Entry Conditions Starts Here
@@ -24043,7 +24043,7 @@ class NostalgiaForInfinityX7(IStrategy):
     #
 
     for enabled_short_entry_signal in self.short_entry_signal_params:
-      short_entry_condition_index = int(enabled_short_entry_signal.split("_")[3])
+      short_entry_condition_index = int(enabled_short_entry_signal.rsplit("_", 2)[1])
       item_short_buy_protection_list = [True]
       if self.short_entry_signal_params[f"{enabled_short_entry_signal}"]:
         # Short Entry Conditions Starts Here


### PR DESCRIPTION
## Summary
- replace full `split("_")` entry-condition parsing with `rsplit("_", 2)`
- applies to long and short entry signal index extraction in the indicator loops
- avoids splitting the whole condition key when only the numeric segment is needed

## Why it is safe
- the existing key format is `<side>_entry_condition_<index>_enable`
- the new extraction returns the same numeric index for all current long/short entry condition keys
- condition names, enable flags, and entry logic are unchanged

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- entry signal index equivalence check: 41 current keys, `mismatches=0`
- synthetic parsing microbench: old `2.970623s`, new `2.672229s`, about `1.11x` faster

## Not tested
- full backtest; this is a narrow condition-key parsing cleanup only
