### PR TITLE
Trim X7 entry signal lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12552,7 +12552,7 @@ class NostalgiaForInfinityX7(IStrategy):
     for enabled_long_entry_signal in self.long_entry_signal_params:
       long_entry_condition_index = int(enabled_long_entry_signal.split("_")[3])
       item_buy_protection_list = [True]
-      if self.long_entry_signal_params[f"{enabled_long_entry_signal}"]:
+      if self.long_entry_signal_params[enabled_long_entry_signal]:
         # Long Entry Conditions Starts Here
         # -----------------------------------------------------------------------------------------
         long_entry_logic = []
@@ -24045,7 +24045,7 @@ class NostalgiaForInfinityX7(IStrategy):
     for enabled_short_entry_signal in self.short_entry_signal_params:
       short_entry_condition_index = int(enabled_short_entry_signal.split("_")[3])
       item_short_buy_protection_list = [True]
-      if self.short_entry_signal_params[f"{enabled_short_entry_signal}"]:
+      if self.short_entry_signal_params[enabled_short_entry_signal]:
         # Short Entry Conditions Starts Here
         # -----------------------------------------------------------------------------------------
         # IMPORTANT: Short Condition Descriptions are not for shorts. These are for longs but completely mirrored opposite side


### PR DESCRIPTION
## Summary
- use the existing entry signal key directly for enabled-condition lookups
- removes redundant `f"{...}"` formatting in the long/short entry signal loops
- keeps the same dictionary keys and enabled-condition behavior

## Why it is safe
- `enabled_long_entry_signal` and `enabled_short_entry_signal` are already the exact string keys from their parameter dictionaries
- the lookup result is unchanged for all current long/short entry condition keys
- no entry conditions, signal keys, or config compatibility behavior were changed

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- entry signal lookup equivalence check: 41 current keys, `mismatches=0`
- synthetic lookup microbench: old `6.518118s`, new `5.462020s`, about `1.19x` faster
- local merge compatibility check with `perf/x7-entry-signal-index-parsing`: OK both merge orders

## Not tested
- full backtest; this is a narrow dictionary lookup cleanup only
