### PR TITLE
Trim X7 rebuy derisk tag checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -52041,7 +52041,7 @@ class NostalgiaForInfinityX7(IStrategy):
       has_order_tags = True
 
     # The first exit is de-risk (providing the trade is still open)
-    if (count_of_exits > 0) and (filled_exits[0].ft_order_tag in ["derisk_level_3"]):
+    if (count_of_exits > 0) and (filled_exits[0].ft_order_tag == "derisk_level_3"):
       return self.long_grind_adjust_trade_position_v2(
         trade,
         enter_tags,
@@ -52228,7 +52228,7 @@ class NostalgiaForInfinityX7(IStrategy):
       has_order_tags = True
 
     # The first exit is de-risk (providing the trade is still open)
-    if (count_of_exits > 0) and (filled_exits[0].ft_order_tag in ["derisk_level_3"]):
+    if (count_of_exits > 0) and (filled_exits[0].ft_order_tag == "derisk_level_3"):
       return self.long_grind_adjust_trade_position_v3(
         trade,
         enter_tags,
@@ -78110,7 +78110,7 @@ class NostalgiaForInfinityX7(IStrategy):
       has_order_tags = True
 
     # The first exit is de-risk (providing the trade is still open)
-    if (count_of_exits > 0) and (filled_exits[0].ft_order_tag in ["derisk_level_3"]):
+    if (count_of_exits > 0) and (filled_exits[0].ft_order_tag == "derisk_level_3"):
       return self.short_grind_adjust_trade_position_v2(
         trade,
         enter_tags,


### PR DESCRIPTION
## Summary
- use direct equality for the single `derisk_level_3` rebuy tag checks
- replaces one-item membership tests in the long/short rebuy adjust handoff guards
- keeps the same first-exit derisk routing behavior

## Why it is safe
- `tag == "derisk_level_3"` is equivalent to `tag in ["derisk_level_3"]` for the existing string tag checks
- no tag names, derisk routing, stake logic, or order selection changed

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- derisk tag check equivalence check: 6 cases, `mismatches=0`
- synthetic tag check microbench: old `14.952959s`, new `12.651529s`, about `1.18x` faster
- local merge compatibility check with current open optimization PR branches: OK

## Not tested
- full backtest; this is a narrow string tag comparison cleanup only
