### PR TITLE
Trim X7 empty order guard

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12292,7 +12292,7 @@ class NostalgiaForInfinityX7(IStrategy):
     """Check if there are valid entry conditions"""
     if filled_orders is None:
       filled_orders = trade.select_filled_orders()
-    if len(filled_orders) < 1:
+    if not filled_orders:
       return False
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
     if not trade.is_short:


### PR DESCRIPTION
## Summary
- use direct truthiness for the empty filled-order guard in `has_valid_entry_conditions()`
- replaces `len(filled_orders) < 1` with `not filled_orders`
- keeps the same early return behavior before reading the last filled order

## Why it is safe
- the guard still returns `False` only when the filled-order list is empty
- non-empty filled-order lists continue to use the same last-order price and entry-condition logic
- no order selection, entry conditions, or grind logic changed

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- empty order guard equivalence check: 3 cases, `mismatches=0`
- synthetic guard microbench: old `0.162761s`, new `0.123763s`, about `1.32x` faster
- local merge compatibility check with current open optimization PR branches: OK

## Not tested
- full backtest; this is a narrow empty-list guard cleanup only
