### PR TITLE
Trim X7 order tag support checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1074,9 +1074,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ]:
       filled_entries = trade.select_filled_orders(trade.entry_side)
       filled_exits = trade.select_filled_orders(trade.exit_side)
-      has_order_tags = False
-      if hasattr(filled_entries[0], "ft_order_tag"):
-        has_order_tags = True
+      has_order_tags = hasattr(filled_entries[0], "ft_order_tag")
       for order in filled_exits:
         order_tag = ""
         if has_order_tags:
@@ -44045,9 +44043,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and all(c in (self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags)
     )
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
@@ -46445,9 +46441,7 @@ class NostalgiaForInfinityX7(IStrategy):
     is_system_v3_1 = self.is_system_v3_1(trade)
     is_system_v3_2 = self.is_system_v3_2(trade)
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
@@ -48356,9 +48350,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
@@ -52017,9 +52009,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     # The first exit is de-risk (providing the trade is still open)
     if (count_of_exits > 0) and (filled_exits[0].ft_order_tag == "derisk_level_3"):
@@ -52204,9 +52194,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     # The first exit is de-risk (providing the trade is still open)
     if (count_of_exits > 0) and (filled_exits[0].ft_order_tag == "derisk_level_3"):
@@ -70499,9 +70487,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and all(c in (self.short_rebuy_mode_tags + self.short_grind_mode_tags) for c in enter_tags)
     )
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
@@ -72881,9 +72867,7 @@ class NostalgiaForInfinityX7(IStrategy):
     is_system_v3_1 = self.is_system_v3_1(trade)
     is_system_v3_2 = self.is_system_v3_2(trade)
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
@@ -74470,9 +74454,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)
@@ -78069,9 +78051,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     # The first exit is de-risk (providing the trade is still open)
     if (count_of_exits > 0) and (filled_exits[0].ft_order_tag == "derisk_level_3"):
@@ -78246,9 +78226,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
-    has_order_tags = False
-    if hasattr(filled_orders[0], "ft_order_tag"):
-      has_order_tags = True
+    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     if self.dp.runmode.value in ("live", "dry_run"):
       ticker = self.dp.ticker(trade.pair)


### PR DESCRIPTION
## Summary
- Replace repeated two-step `has_order_tags` initialization with direct `hasattr(...)` assignments.
- Covers the repeated long/short grind adjust paths and the stoploss derisk check.

## Why this is safe
- The boolean value is exactly the same: `False` by default, `True` when the first filled order/entry exposes `ft_order_tag`.
- This does not change tag parsing or any trade thresholds.
- Merge-tested with the existing order-tag parsing PR branch.

## Checks
- `has_order_tags` equivalence cases: 2, mismatches: 0
- microbench best-of-7: old `0.402576s`, new `0.385769s` (~1.04x for the tiny helper pattern)
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- merge check with `fork/perf/x7-order-tag-prefix`: OK

## Not tested
- Full backtest timing benchmark; this is a small behavior-preserving cleanup on repeated hot-path guard code.
