### PR TITLE
fix namerror

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43907,7 +43907,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
         )
         and (
-          self.has_valid_entry_conditions(trade, current_rate, last_candle, previous_candle_1, filled_orders) == False
+          self.has_valid_entry_conditions(trade, current_rate, last_candle, previous_candle_1, filled_entries) == False
         )
         # temporary
         and (is_backtest or trade.open_date_utc.replace(tzinfo=None) >= datetime(2024, 9, 13))
@@ -70340,7 +70340,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
         )
         and (
-          self.has_valid_entry_conditions(trade, current_rate, last_candle, previous_candle_1, filled_orders) == False
+          self.has_valid_entry_conditions(trade, current_rate, last_candle, previous_candle_1, filled_entries) == False
         )
         # temporary
         and (is_backtest or trade.open_date_utc.replace(tzinfo=None) >= datetime(2024, 9, 13))


### PR DESCRIPTION
fixes:
2026-05-29 22:52:08 ERROR   freqtrade.strategy.strategy_wrapper - Unexpected error NameError("name 'filled_orders' is not defined") calling <bound method NostalgiaForInfinityX7.custom_exit of <NostalgiaForInfinityX7.NostalgiaForInfinityX7 object at 0x71a8391b78c0>>
Traceback (most recent call last):
  File "/freqtrade/freqtrade/strategy/strategy_wrapper.py", line 46, in wrapper
    return f(*args, **kwargs)
  File "/freqtrade/user_data/strategies/NostalgiaForInfinityX7.py", line 2114, in custom_exit
    sell, signal_name = self.long_exit_top_coins(
                        ~~~~~~^
      pair,
      ^^^^^
    ...<17 lines>...
      enter_tags,
      ^^^^^^^^^^^
    )
    ^
  File "/freqtrade/user_data/strategies/NostalgiaForInfinityX7.py", line 27736, in long_exit_top_coins
    sell, signal_name = self.long_exit_stoploss(
                        ~~~~~^
      mode,
      ^^^^^
    ...<17 lines>...
      enter_tags,
      ^^^^^^^^^^^
    )
    ^
  File "/freqtrade/user_data/strategies/NostalgiaForInfinityX7.py", line 43933, in long_exit_stoploss
    self.has_valid_entry_conditions(trade, current_rate, last_candle, previous_candle_1, filled_orders) == False
                                                                                         ^^^^^^^^^^^^^
NameError: name 'filled_orders' is not defined. Did you mean: 'filled_entries'?