### PR TITLE
Trim X7 mode tag list churn

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -139,6 +139,34 @@ class NostalgiaForInfinityX7(IStrategy):
   # Long scalp mode tags
   long_scalp_mode_tags = ["161", "162", "163"]
 
+  long_rebuy_grind_mode_tags = long_rebuy_mode_tags + long_grind_mode_tags
+  long_scalp_rebuy_grind_mode_tags = long_scalp_mode_tags + long_rebuy_mode_tags + long_grind_mode_tags
+  long_rapid_rebuy_grind_mode_tags = long_rapid_mode_tags + long_rebuy_mode_tags + long_grind_mode_tags
+  long_rapid_rebuy_grind_scalp_mode_tags = (
+    long_rapid_mode_tags + long_rebuy_mode_tags + long_grind_mode_tags + long_scalp_mode_tags
+  )
+  long_adjust_mode_tags = (
+    long_normal_mode_tags
+    + long_pump_mode_tags
+    + long_quick_mode_tags
+    + long_high_profit_mode_tags
+    + long_rapid_mode_tags
+    + long_top_coins_mode_tags
+    + long_scalp_mode_tags
+  )
+  long_known_mode_tags = (
+    long_normal_mode_tags
+    + long_pump_mode_tags
+    + long_quick_mode_tags
+    + long_rebuy_mode_tags
+    + long_high_profit_mode_tags
+    + long_rapid_mode_tags
+    + long_grind_mode_tags
+    + long_btc_mode_tags
+    + long_top_coins_mode_tags
+    + long_scalp_mode_tags
+  )
+
   long_normal_mode_name = "long_normal"
   long_pump_mode_name = "long_pump"
   long_quick_mode_name = "long_quick"
@@ -170,6 +198,40 @@ class NostalgiaForInfinityX7(IStrategy):
   short_top_coins_mode_tags = ["641", "642"]
   # Short scalp mode tags
   short_scalp_mode_tags = ["661"]
+
+  short_rebuy_grind_mode_tags = short_rebuy_mode_tags + short_grind_mode_tags
+  short_scalp_rebuy_grind_mode_tags = short_scalp_mode_tags + short_rebuy_mode_tags + short_grind_mode_tags
+  short_rapid_rebuy_grind_mode_tags = short_rapid_mode_tags + short_rebuy_mode_tags + short_grind_mode_tags
+  short_adjust_mode_tags = (
+    short_normal_mode_tags
+    + short_pump_mode_tags
+    + short_quick_mode_tags
+    + short_high_profit_mode_tags
+    + short_rapid_mode_tags
+    + short_top_coins_mode_tags
+    + short_scalp_mode_tags
+  )
+  short_known_mode_tags = (
+    short_normal_mode_tags
+    + short_pump_mode_tags
+    + short_quick_mode_tags
+    + short_rebuy_mode_tags
+    + short_high_profit_mode_tags
+    + short_rapid_mode_tags
+    + short_grind_mode_tags
+    + short_top_coins_mode_tags
+    + short_scalp_mode_tags
+  )
+  short_exit_known_mode_tags = (
+    short_normal_mode_tags
+    + short_pump_mode_tags
+    + short_quick_mode_tags
+    + short_rebuy_mode_tags
+    + short_high_profit_mode_tags
+    + short_rapid_mode_tags
+    + short_grind_mode_tags
+    + short_scalp_mode_tags
+  )
 
   short_normal_mode_name = "short_normal"
   short_pump_mode_name = "short_pump"
@@ -1096,13 +1158,11 @@ class NostalgiaForInfinityX7(IStrategy):
       is_rapid_mode = all(c in self.long_rapid_mode_tags for c in enter_tags)
       is_rebuy_mode = all(c in self.long_rebuy_mode_tags for c in enter_tags) or (
         any(c in self.long_rebuy_mode_tags for c in enter_tags)
-        and all(c in (self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags)
+        and all(c in self.long_rebuy_grind_mode_tags for c in enter_tags)
       )
       is_scalp_mode = all(c in self.long_scalp_mode_tags for c in enter_tags) or (
         any(c in self.long_scalp_mode_tags for c in enter_tags)
-        and all(
-          c in (self.long_scalp_mode_tags + self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags
-        )
+        and all(c in self.long_scalp_rebuy_grind_mode_tags for c in enter_tags)
       )
       if profit_init_ratio > 0.0:
         # profit is over the threshold, don't exit
@@ -1971,7 +2031,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Long Rebuy mode
     if all(c in self.long_rebuy_mode_tags for c in enter_tags) or (
       any(c in self.long_rebuy_mode_tags for c in enter_tags)
-      and all(c in (self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags)
+      and all(c in self.long_rebuy_grind_mode_tags for c in enter_tags)
     ):
       sell, signal_name = self.long_exit_rebuy(
         pair,
@@ -2027,13 +2087,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Long rapid mode
     if all(c in self.long_rapid_mode_tags for c in enter_tags) or (
       any(c in self.long_rapid_mode_tags for c in enter_tags)
-      and all(
-        c
-        in (
-          self.long_rapid_mode_tags + self.long_rebuy_mode_tags + self.long_grind_mode_tags + self.long_scalp_mode_tags
-        )
-        for c in enter_tags
-      )
+      and all(c in self.long_rapid_rebuy_grind_scalp_mode_tags for c in enter_tags)
     ):
       sell, signal_name = self.long_exit_rapid(
         pair,
@@ -2141,9 +2195,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Long scalp mode
     if all(c in self.long_scalp_mode_tags for c in enter_tags) or (
       any(c in self.long_scalp_mode_tags for c in enter_tags)
-      and all(
-        c in (self.long_scalp_mode_tags + self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags
-      )
+      and all(c in self.long_scalp_rebuy_grind_mode_tags for c in enter_tags)
     ):
       sell, signal_name = self.long_exit_scalp(
         pair,
@@ -2332,9 +2384,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Short scalp mode
     if all(c in self.short_scalp_mode_tags for c in enter_tags) or (
       any(c in self.short_scalp_mode_tags for c in enter_tags)
-      and all(
-        c in (self.short_scalp_mode_tags + self.short_rebuy_mode_tags + self.short_grind_mode_tags) for c in enter_tags
-      )
+      and all(c in self.short_scalp_rebuy_grind_mode_tags for c in enter_tags)
     ):
       sell, signal_name = self.short_exit_scalp(
         pair,
@@ -2361,24 +2411,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return f"{signal_name} ( {enter_tag})"
 
     # Trades not opened by X7
-    if not trade.is_short and (
-      not any(
-        c
-        in (
-          self.long_normal_mode_tags
-          + self.long_pump_mode_tags
-          + self.long_quick_mode_tags
-          + self.long_rebuy_mode_tags
-          + self.long_high_profit_mode_tags
-          + self.long_rapid_mode_tags
-          + self.long_grind_mode_tags
-          + self.long_btc_mode_tags
-          + self.long_top_coins_mode_tags
-          + self.long_scalp_mode_tags
-        )
-        for c in enter_tags
-      )
-    ):
+    if not trade.is_short and (not any(c in self.long_known_mode_tags for c in enter_tags)):
       # use normal mode for such trades
       sell, signal_name = self.long_exit_normal(
         pair,
@@ -2406,22 +2439,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return f"{signal_name} ( {enter_tag})"
 
     # Trades not opened by X7
-    if trade.is_short and (
-      not any(
-        c
-        in (
-          self.short_normal_mode_tags
-          + self.short_pump_mode_tags
-          + self.short_quick_mode_tags
-          + self.short_rebuy_mode_tags
-          + self.short_high_profit_mode_tags
-          + self.short_rapid_mode_tags
-          + self.short_grind_mode_tags
-          + self.short_scalp_mode_tags
-        )
-        for c in enter_tags
-      )
-    ):
+    if trade.is_short and (not any(c in self.short_exit_known_mode_tags for c in enter_tags)):
       # use normal mode for such trades
       sell, signal_name = self.short_exit_normal(
         pair,
@@ -2470,7 +2488,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Rebuy mode
       if all(c in self.long_rebuy_mode_tags for c in enter_tags) or (
         any(c in self.long_rebuy_mode_tags for c in enter_tags)
-        and all(c in (self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags)
+        and all(c in self.long_rebuy_grind_mode_tags for c in enter_tags)
       ):
         stake_multiplier = self.system_v3_rebuy_mode_stake_multiplier
         stake = proposed_stake * stake_multiplier
@@ -2483,10 +2501,7 @@ class NostalgiaForInfinityX7(IStrategy):
         all(c in self.long_rapid_mode_tags for c in enter_tags)
         or (
           any(c in self.long_rapid_mode_tags for c in enter_tags)
-          and all(
-            c in (self.long_rapid_mode_tags + self.long_rebuy_mode_tags + self.long_grind_mode_tags)
-            for c in enter_tags
-          )
+          and all(c in self.long_rapid_rebuy_grind_mode_tags for c in enter_tags)
         )
       ):
         stake_multiplier = (
@@ -2541,7 +2556,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Rebuy mode
       if all(c in self.short_rebuy_mode_tags for c in enter_tags) or (
         any(c in self.short_rebuy_mode_tags for c in enter_tags)
-        and all(c in (self.short_rebuy_mode_tags + self.short_grind_mode_tags) for c in enter_tags)
+        and all(c in self.short_rebuy_grind_mode_tags for c in enter_tags)
       ):
         stake_multiplier = self.system_v3_rebuy_mode_stake_multiplier
         stake = proposed_stake * stake_multiplier
@@ -2562,10 +2577,7 @@ class NostalgiaForInfinityX7(IStrategy):
         all(c in self.short_rapid_mode_tags for c in enter_tags)
         or (
           any(c in self.short_rapid_mode_tags for c in enter_tags)
-          and all(
-            c in (self.short_rapid_mode_tags + self.short_rebuy_mode_tags + self.short_grind_mode_tags)
-            for c in enter_tags
-          )
+          and all(c in self.short_rapid_rebuy_grind_mode_tags for c in enter_tags)
         )
       ):
         stake_multiplier = (
@@ -2652,7 +2664,7 @@ class NostalgiaForInfinityX7(IStrategy):
       all(c in self.long_rebuy_mode_tags for c in enter_tags)
       or (
         any(c in self.long_rebuy_mode_tags for c in enter_tags)
-        and all(c in (self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags)
+        and all(c in self.long_rebuy_grind_mode_tags for c in enter_tags)
       )
     ):
       if is_system_v3 or is_system_v3_1 or is_system_v3_2:
@@ -2687,7 +2699,7 @@ class NostalgiaForInfinityX7(IStrategy):
       all(c in self.short_rebuy_mode_tags for c in enter_tags)
       or (
         any(c in self.short_rebuy_mode_tags for c in enter_tags)
-        and all(c in (self.short_rebuy_mode_tags + self.short_grind_mode_tags) for c in enter_tags)
+        and all(c in self.short_rebuy_grind_mode_tags for c in enter_tags)
       )
     ):
       if is_system_v3 or is_system_v3_1 or is_system_v3_2:
@@ -2722,33 +2734,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # Grinding
     elif not trade.is_short:
       if not is_long_grind_mode and not is_long_btc_mode and (is_system_v3 or is_system_v3_1 or is_system_v3_2):
-        if any(
-          c
-          in (
-            self.long_normal_mode_tags
-            + self.long_pump_mode_tags
-            + self.long_quick_mode_tags
-            + self.long_high_profit_mode_tags
-            + self.long_rapid_mode_tags
-            + self.long_top_coins_mode_tags
-            + self.long_scalp_mode_tags
-          )
-          for c in enter_tags
-        ) or not any(
-          c
-          in (
-            self.long_normal_mode_tags
-            + self.long_pump_mode_tags
-            + self.long_quick_mode_tags
-            + self.long_rebuy_mode_tags
-            + self.long_high_profit_mode_tags
-            + self.long_rapid_mode_tags
-            + self.long_grind_mode_tags
-            + self.long_btc_mode_tags
-            + self.long_top_coins_mode_tags
-            + self.long_scalp_mode_tags
-          )
-          for c in enter_tags
+        if any(c in self.long_adjust_mode_tags for c in enter_tags) or not any(
+          c in self.long_known_mode_tags for c in enter_tags
         ):
           return self.long_grind_adjust_trade_position_v3(
             trade,
@@ -2777,33 +2764,8 @@ class NostalgiaForInfinityX7(IStrategy):
           current_entry_profit,
           current_exit_profit,
         )
-      elif any(
-        c
-        in (
-          self.long_normal_mode_tags
-          + self.long_pump_mode_tags
-          + self.long_quick_mode_tags
-          + self.long_high_profit_mode_tags
-          + self.long_rapid_mode_tags
-          + self.long_top_coins_mode_tags
-          + self.long_scalp_mode_tags
-        )
-        for c in enter_tags
-      ) or not any(
-        c
-        in (
-          self.long_normal_mode_tags
-          + self.long_pump_mode_tags
-          + self.long_quick_mode_tags
-          + self.long_rebuy_mode_tags
-          + self.long_high_profit_mode_tags
-          + self.long_rapid_mode_tags
-          + self.long_grind_mode_tags
-          + self.long_btc_mode_tags
-          + self.long_top_coins_mode_tags
-          + self.long_scalp_mode_tags
-        )
-        for c in enter_tags
+      elif any(c in self.long_adjust_mode_tags for c in enter_tags) or not any(
+        c in self.long_known_mode_tags for c in enter_tags
       ):
         return self.long_grind_adjust_trade_position_v2(
           trade,
@@ -2821,32 +2783,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
     elif trade.is_short:
       if not is_short_grind_mode and (is_system_v3 or is_system_v3_1 or is_system_v3_2):
-        if any(
-          c
-          in (
-            self.short_normal_mode_tags
-            + self.short_pump_mode_tags
-            + self.short_quick_mode_tags
-            + self.short_high_profit_mode_tags
-            + self.short_rapid_mode_tags
-            + self.short_top_coins_mode_tags
-            + self.short_scalp_mode_tags
-          )
-          for c in enter_tags
-        ) or not any(
-          c
-          in (
-            self.short_normal_mode_tags
-            + self.short_pump_mode_tags
-            + self.short_quick_mode_tags
-            + self.short_rebuy_mode_tags
-            + self.short_high_profit_mode_tags
-            + self.short_rapid_mode_tags
-            + self.short_grind_mode_tags
-            + self.short_top_coins_mode_tags
-            + self.short_scalp_mode_tags
-          )
-          for c in enter_tags
+        if any(c in self.short_adjust_mode_tags for c in enter_tags) or not any(
+          c in self.short_known_mode_tags for c in enter_tags
         ):
           return self.short_grind_adjust_trade_position_v3(
             trade,
@@ -2876,32 +2814,8 @@ class NostalgiaForInfinityX7(IStrategy):
           current_exit_profit,
         )
       else:
-        if any(
-          c
-          in (
-            self.short_normal_mode_tags
-            + self.short_pump_mode_tags
-            + self.short_quick_mode_tags
-            + self.short_high_profit_mode_tags
-            + self.short_rapid_mode_tags
-            + self.short_top_coins_mode_tags
-            + self.short_scalp_mode_tags
-          )
-          for c in enter_tags
-        ) or not any(
-          c
-          in (
-            self.short_normal_mode_tags
-            + self.short_pump_mode_tags
-            + self.short_quick_mode_tags
-            + self.short_rebuy_mode_tags
-            + self.short_high_profit_mode_tags
-            + self.short_rapid_mode_tags
-            + self.short_grind_mode_tags
-            + self.short_top_coins_mode_tags
-            + self.short_scalp_mode_tags
-          )
-          for c in enter_tags
+        if any(c in self.short_adjust_mode_tags for c in enter_tags) or not any(
+          c in self.short_known_mode_tags for c in enter_tags
         ):
           return self.short_grind_adjust_trade_position_v2(
             trade,


### PR DESCRIPTION
## Summary
- add cached long/short mode-tag groups for repeated dispatch checks
- reuse those groups in custom-exit, stake, and adjust-position mode checks
- avoid rebuilding equivalent `list + list` tag combinations inside repeated membership tests

## Why it is safe
This preserves the exact tag group contents used by the existing predicates. The change only moves repeated tag-list concatenations into named cached groups, then reuses those groups in the same `any(...)` / `all(...)` checks.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- targeted tag-group sanity scan for 12 cached groups

## Backtest scope
I treated this as a behavior-preserving mode-dispatch cleanup, so validation focused on static checks and targeted tag-group equivalence checks rather than a full timing backtest. The patch keeps indicators, candle selection, order selection, profit arithmetic, tag contents, and trading conditions unchanged.
