### PR TITLE
Trim X7 hold profit checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12350,16 +12350,21 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # By default, no hold should be done
     hold_trade = False
+    profit_values = None
+
+    def get_profit_values():
+      nonlocal profit_values
+      if profit_values is None:
+        filled_entries = trade.select_filled_orders(trade.entry_side)
+        filled_exits = trade.select_filled_orders(trade.exit_side)
+        profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, rate)
+
+      return profit_values
 
     trade_ids: dict = self.hold_trades_cache.data.get("trade_ids")
     if trade_ids and trade.id in trade_ids:
       trade_profit_ratio = trade_ids[trade.id]
-      filled_entries = trade.select_filled_orders(trade.entry_side)
-      filled_exits = trade.select_filled_orders(trade.exit_side)
-      profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-        trade, filled_entries, filled_exits, rate
-      )
-      current_profit_ratio = profit_init_ratio
+      current_profit_ratio = get_profit_values()[3]
       if sell_reason == "force_sell":
         formatted_profit_ratio = f"{trade_profit_ratio * 100}%"
         formatted_current_profit_ratio = f"{current_profit_ratio * 100}%"
@@ -12388,12 +12393,7 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_pairs: dict = self.hold_trades_cache.data.get("trade_pairs")
     if trade_pairs and trade.pair in trade_pairs:
       trade_profit_ratio = trade_pairs[trade.pair]
-      filled_entries = trade.select_filled_orders(trade.entry_side)
-      filled_exits = trade.select_filled_orders(trade.exit_side)
-      profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = self.calc_total_profit(
-        trade, filled_entries, filled_exits, rate
-      )
-      current_profit_ratio = profit_init_ratio
+      current_profit_ratio = get_profit_values()[3]
       if sell_reason == "force_sell":
         formatted_profit_ratio = f"{trade_profit_ratio * 100}%"
         formatted_current_profit_ratio = f"{current_profit_ratio * 100}%"


### PR DESCRIPTION
## Summary
- reuse one lazy hold-support profit snapshot inside `_should_hold_trade()`
- avoids a second `select_filled_orders()` + `calc_total_profit()` pass when the same trade matches both `trade_ids` and `trade_pairs`
- keeps the existing hold-rule order, `force_sell` behavior, and profit threshold checks unchanged

## Safety
This only reuses the same profit tuple within one `_should_hold_trade()` call. There is no change to indicators, candle selection, order classification, profit arithmetic, or trading conditions.

## Backtest scope
I treated this as a behavior-preserving live/dry hold-support plumbing change, so validation focused on static checks and targeted equivalence instead of a full timing backtest. The equivalence check covered trade-id only, pair only, both hold rules, threshold exits, and `force_sell`; in the overlapping hold-rule cases the old path calculated profit twice while the new path calculates it once.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- targeted hold-profit branch equivalence script
