### PR TITLE
Trim X7 grind leverage checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43931,13 +43931,14 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
       self.grinding_v2_grind_1_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_1_sub_thresholds = (
@@ -43958,7 +43959,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_2_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_2_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_sub_thresholds = (
@@ -43979,7 +43980,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_3_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_3_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_3_sub_thresholds = (
@@ -44000,7 +44001,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_4_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_4_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_4_sub_thresholds = (
@@ -44021,7 +44022,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_5_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_5_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_5_sub_thresholds = (
@@ -44229,10 +44230,7 @@ class NostalgiaForInfinityX7(IStrategy):
             grind_5_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             grind_5_found = True
       elif order.ft_order_side == "sell":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           # break
         order_tag = ""
@@ -46327,6 +46325,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
@@ -46354,7 +46353,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_2_stakes_futures if self.is_futures_mode else self.system_v3_grind_2_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_sub_thresholds = (
@@ -46375,7 +46374,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_3_stakes_futures if self.is_futures_mode else self.system_v3_grind_3_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_3_sub_thresholds = (
@@ -46396,7 +46395,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_4_stakes_futures if self.is_futures_mode else self.system_v3_grind_4_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_4_sub_thresholds = (
@@ -46417,7 +46416,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_5_stakes_futures if self.is_futures_mode else self.system_v3_grind_5_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_5_sub_thresholds = (
@@ -46614,10 +46613,7 @@ class NostalgiaForInfinityX7(IStrategy):
             rebuy_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             rebuy_found = True
       elif order.ft_order_side == "sell":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           # break
         order_tag = ""
@@ -70378,13 +70374,14 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
       self.grinding_v2_grind_1_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_1_sub_thresholds = (
@@ -70405,7 +70402,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_2_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_2_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_sub_thresholds = (
@@ -70426,7 +70423,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_3_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_3_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_3_sub_thresholds = (
@@ -70447,7 +70444,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_4_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_4_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_4_sub_thresholds = (
@@ -70468,7 +70465,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grinding_v2_grind_5_stakes_futures if self.is_futures_mode else self.grinding_v2_grind_5_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_5_sub_thresholds = (
@@ -70676,10 +70673,7 @@ class NostalgiaForInfinityX7(IStrategy):
             grind_5_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             grind_5_found = True
       elif order.ft_order_side == "buy":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           # break
         order_tag = ""
@@ -72756,6 +72750,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
@@ -72783,7 +72778,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_2_stakes_futures if self.is_futures_mode else self.system_v3_grind_2_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_sub_thresholds = (
@@ -72804,7 +72799,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_3_stakes_futures if self.is_futures_mode else self.system_v3_grind_3_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_3_sub_thresholds = (
@@ -72825,7 +72820,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_4_stakes_futures if self.is_futures_mode else self.system_v3_grind_4_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_4_sub_thresholds = (
@@ -72846,7 +72841,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.system_v3_grind_5_stakes_futures if self.is_futures_mode else self.system_v3_grind_5_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_5_sub_thresholds = (
@@ -73018,10 +73013,7 @@ class NostalgiaForInfinityX7(IStrategy):
             rebuy_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             rebuy_found = True
       elif order.ft_order_side == "buy":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           # break
         order_tag = ""


### PR DESCRIPTION
## Summary
- compute the futures/spot stake scale leverage once in the covered grind adjust paths
- reuse that value across repeated `scale_stakes_for_min_stake()` calls and partial-exit min-stake checks
- keeps the same futures/spot leverage value, stake inputs, thresholds, and order/profit logic

## Safety
This is local value reuse only. The value is still `trade.leverage` in futures mode and `1.0` otherwise, exactly matching the previous inline expression.

## Backtest scope
I treated this as a behavior-preserving grind plumbing change, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, stake arrays, thresholds, profit arithmetic, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for 22 replacements across 4 grind adjust functions
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
