### PR TITLE
Trim X7 adjust leverage checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -50435,6 +50435,7 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> tuple[Optional[float], str, bool]:
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt"]
     trade_open_date = None if is_backtest else trade.open_date_utc.replace(tzinfo=None)
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     max_rebuy_sub_grinds = 0
     regular_mode_rebuy_stakes = self.scale_stakes_for_min_stake(
@@ -50758,10 +50759,7 @@ class NostalgiaForInfinityX7(IStrategy):
             rebuy_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             rebuy_found = True
       elif order.ft_order_side == "sell":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           break
         order_tag = ""
@@ -50921,11 +50919,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((current_time - timedelta(hours=12) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_rebuy_stakes[rebuy_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_rebuy_stakes[rebuy_sub_grind_count] / stake_scale_leverage
         if buy_amount > max_stake:
           buy_amount = max_stake
         if buy_amount < (min_stake * 1.5):
@@ -50968,11 +50962,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_1_stakes[grind_1_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -51009,11 +50999,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and slice_profit < (-0.65 / trade.leverage)
       and (grind_1_sub_grind_count < max_grind_1_sub_grinds)
     ):
-      buy_amount = (
-        slice_amount
-        * regular_mode_grind_1_stakes[grind_1_sub_grind_count]
-        / (trade.leverage if self.is_futures_mode else 1.0)
-      )
+      buy_amount = slice_amount * regular_mode_grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
       if buy_amount < (min_stake * 1.5):
         buy_amount = min_stake * 1.5
       if buy_amount > max_stake:
@@ -51138,11 +51124,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_2_stakes[grind_2_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_2_stakes[grind_2_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -51267,11 +51249,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_3_stakes[grind_3_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_3_stakes[grind_3_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -51396,11 +51374,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_4_stakes[grind_4_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_4_stakes[grind_4_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -51525,11 +51499,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_5_stakes[grind_5_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_5_stakes[grind_5_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -51654,11 +51624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and (is_long_grind_entry)
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_6_stakes[grind_6_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_6_stakes[grind_6_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -51935,6 +51901,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     current_stake_amount = trade.amount * current_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     rebuy_mode_stakes = self.rebuy_mode_stakes_futures if self.is_futures_mode else self.rebuy_mode_stakes_spot
     max_sub_grinds = len(rebuy_mode_stakes)
@@ -51954,7 +51921,7 @@ class NostalgiaForInfinityX7(IStrategy):
         total_amount += order.safe_filled
         total_cost += order.safe_filled * order.safe_price
       elif order.ft_order_side == "sell":
-        if (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake:
+        if (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
         break
     if sub_grind_count > 0:
@@ -52120,6 +52087,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     current_stake_amount = trade.amount * current_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     rebuy_mode_stakes = (
       self.system_v3_rebuy_mode_stakes_futures if self.is_futures_mode else self.system_v3_rebuy_mode_stakes_spot
@@ -52143,7 +52111,7 @@ class NostalgiaForInfinityX7(IStrategy):
         total_amount += order.safe_filled
         total_cost += order.safe_filled * order.safe_price
       elif order.ft_order_side == "sell":
-        if (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake:
+        if (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
         break
     if sub_grind_count > 0:
@@ -76480,6 +76448,7 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> tuple[Optional[float], str, bool]:
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt"]
     trade_open_date = None if is_backtest else trade.open_date_utc.replace(tzinfo=None)
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     max_rebuy_sub_grinds = 0
     regular_mode_rebuy_stakes = self.scale_stakes_for_min_stake(
@@ -76803,10 +76772,7 @@ class NostalgiaForInfinityX7(IStrategy):
             rebuy_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             rebuy_found = True
       elif order.ft_order_side == "buy":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           break
         order_tag = ""
@@ -76966,11 +76932,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((current_time - timedelta(hours=12) > filled_orders[-1].order_filled_utc) or (slice_profit > 0.06))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_rebuy_stakes[rebuy_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_rebuy_stakes[rebuy_sub_grind_count] / stake_scale_leverage
         if buy_amount > max_stake:
           buy_amount = max_stake
         if buy_amount < (min_stake * 1.5):
@@ -77013,11 +76975,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_1_stakes[grind_1_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -77054,11 +77012,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and slice_profit > (0.65 / trade.leverage)
       and (grind_1_sub_grind_count < max_grind_1_sub_grinds)
     ):
-      buy_amount = (
-        slice_amount
-        * regular_mode_grind_1_stakes[grind_1_sub_grind_count]
-        / (trade.leverage if self.is_futures_mode else 1.0)
-      )
+      buy_amount = slice_amount * regular_mode_grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
       if buy_amount < (min_stake * 1.5):
         buy_amount = min_stake * 1.5
       if buy_amount > max_stake:
@@ -77183,11 +77137,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_2_stakes[grind_2_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_2_stakes[grind_2_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -77312,11 +77262,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_3_stakes[grind_3_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_3_stakes[grind_3_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -77441,11 +77387,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_4_stakes[grind_4_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_4_stakes[grind_4_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -77570,11 +77512,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_5_stakes[grind_5_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_5_stakes[grind_5_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -77699,11 +77637,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and (is_short_grind_entry)
       ):
-        buy_amount = (
-          slice_amount
-          * regular_mode_grind_6_stakes[grind_6_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * regular_mode_grind_6_stakes[grind_6_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -77980,6 +77914,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     current_stake_amount = trade.amount * current_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     rebuy_mode_stakes = self.rebuy_mode_stakes_futures if self.is_futures_mode else self.rebuy_mode_stakes_spot
     max_sub_grinds = len(rebuy_mode_stakes)
@@ -77999,7 +77934,7 @@ class NostalgiaForInfinityX7(IStrategy):
         total_amount += order.safe_filled
         total_cost += order.safe_filled * order.safe_price
       elif order.ft_order_side == "buy":
-        if (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake:
+        if (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
         break
     if sub_grind_count > 0:
@@ -78139,6 +78074,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     current_stake_amount = trade.amount * current_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     rebuy_mode_stakes = (
       self.system_v3_rebuy_mode_stakes_futures if self.is_futures_mode else self.system_v3_rebuy_mode_stakes_spot
@@ -78162,7 +78098,7 @@ class NostalgiaForInfinityX7(IStrategy):
         total_amount += order.safe_filled
         total_cost += order.safe_filled * order.safe_price
       elif order.ft_order_side == "buy":
-        if (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake:
+        if (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
         break
     if sub_grind_count > 0:


### PR DESCRIPTION
## Summary
- compute the futures/spot stake scale leverage once in no-derisk and rebuy adjust helpers
- reuse that value across repeated stake-sizing and partial-exit min-stake checks
- keeps the same futures/spot leverage value, stake inputs, thresholds, and order/profit logic

## Safety
This is local value reuse only. The reused value is still `trade.leverage` in futures mode and `1.0` otherwise, exactly matching the previous inline expression.

## Backtest scope
I treated this as a behavior-preserving adjust-helper plumbing change, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, stake arrays, thresholds, profit arithmetic, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for 22 code replacements across 6 adjust helpers
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
