### PR TITLE
Trim X7 regular grind leverage checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -48269,6 +48269,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     # Rebuy mode
     if is_rebuy_mode:
@@ -48346,7 +48347,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_1_stakes_futures if self.is_futures_mode else self.grind_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_1_sub_thresholds = (
@@ -48363,7 +48364,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_2_stakes_futures if self.is_futures_mode else self.grind_2_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_sub_thresholds = (
@@ -48380,7 +48381,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_3_stakes_futures if self.is_futures_mode else self.grind_3_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_3_sub_thresholds = (
@@ -48397,7 +48398,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_4_stakes_futures if self.is_futures_mode else self.grind_4_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_4_sub_thresholds = (
@@ -48414,7 +48415,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_5_stakes_futures if self.is_futures_mode else self.grind_5_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_5_sub_thresholds = (
@@ -48431,7 +48432,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_6_stakes_futures if self.is_futures_mode else self.grind_6_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_6_sub_thresholds = (
@@ -48448,7 +48449,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_1_derisk_1_stakes_futures if self.is_futures_mode else self.grind_1_derisk_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_1_derisk_1_sub_thresholds = (
@@ -48471,7 +48472,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_2_derisk_1_stakes_futures if self.is_futures_mode else self.grind_2_derisk_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_derisk_1_sub_thresholds = (
@@ -48690,10 +48691,7 @@ class NostalgiaForInfinityX7(IStrategy):
             grind_1_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             grind_1_found = True
       elif order.ft_order_side == "sell":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           break
         order_tag = ""
@@ -48983,11 +48981,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * grind_1_derisk_1_stakes[grind_1_derisk_1_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_1_derisk_1_stakes[grind_1_derisk_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -49134,11 +49128,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
         and is_long_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * grind_2_derisk_1_stakes[grind_2_derisk_1_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_2_derisk_1_stakes[grind_2_derisk_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -49277,9 +49267,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_long_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_1_stakes[grind_1_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -49320,9 +49308,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (is_derisk or is_derisk_calc or is_grind_mode)
       and (grind_1_sub_grind_count < grind_1_max_sub_grinds)
     ):
-      buy_amount = (
-        slice_amount * grind_1_stakes[grind_1_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-      )
+      buy_amount = slice_amount * grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
       if buy_amount < (min_stake * 1.5):
         buy_amount = min_stake * 1.5
       if buy_amount > max_stake:
@@ -49460,9 +49446,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_long_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_2_stakes[grind_2_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_2_stakes[grind_2_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -49600,9 +49584,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_long_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_3_stakes[grind_3_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_3_stakes[grind_3_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -49740,9 +49722,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_long_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_4_stakes[grind_4_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_4_stakes[grind_4_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -49880,9 +49860,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_long_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_5_stakes[grind_5_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_5_stakes[grind_5_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -50020,9 +49998,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_long_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_6_stakes[grind_6_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_6_stakes[grind_6_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -50218,7 +50194,7 @@ class NostalgiaForInfinityX7(IStrategy):
           if self.is_futures_mode
           else self.regular_mode_derisk_1_reentry_spot
         )
-        / (trade.leverage if self.is_futures_mode else 1.0)
+        / stake_scale_leverage
       )
     ):
       sell_amount = derisk_1_reentry_order.safe_filled * exit_rate / trade.leverage
@@ -74376,6 +74352,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
 
     # Rebuy mode
     if is_rebuy_mode:
@@ -74453,7 +74430,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_1_stakes_futures if self.is_futures_mode else self.grind_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_1_sub_thresholds = (
@@ -74470,7 +74447,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_2_stakes_futures if self.is_futures_mode else self.grind_2_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_sub_thresholds = (
@@ -74487,7 +74464,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_3_stakes_futures if self.is_futures_mode else self.grind_3_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_3_sub_thresholds = (
@@ -74504,7 +74481,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_4_stakes_futures if self.is_futures_mode else self.grind_4_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_4_sub_thresholds = (
@@ -74521,7 +74498,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_5_stakes_futures if self.is_futures_mode else self.grind_5_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_5_sub_thresholds = (
@@ -74538,7 +74515,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_6_stakes_futures if self.is_futures_mode else self.grind_6_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_6_sub_thresholds = (
@@ -74555,7 +74532,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_1_derisk_1_stakes_futures if self.is_futures_mode else self.grind_1_derisk_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_1_derisk_1_sub_thresholds = (
@@ -74578,7 +74555,7 @@ class NostalgiaForInfinityX7(IStrategy):
       self.grind_2_derisk_1_stakes_futures if self.is_futures_mode else self.grind_2_derisk_1_stakes_spot,
       slice_amount,
       min_stake,
-      trade.leverage if self.is_futures_mode else 1.0,
+      stake_scale_leverage,
       trade.leverage,
     )
     grind_2_derisk_1_sub_thresholds = (
@@ -74797,10 +74774,7 @@ class NostalgiaForInfinityX7(IStrategy):
             grind_1_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
             grind_1_found = True
       elif order.ft_order_side == "buy":
-        if (
-          order is filled_exits[-1]
-          and (order.safe_remaining * exit_rate / (trade.leverage if self.is_futures_mode else 1.0)) > min_stake
-        ):
+        if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           break
         order_tag = ""
@@ -75090,11 +75064,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * grind_1_derisk_1_stakes[grind_1_derisk_1_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_1_derisk_1_stakes[grind_1_derisk_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -75241,11 +75211,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and ((num_open_grinds == 0) or (slice_profit > 0.03))
         and is_short_grind_entry
       ):
-        buy_amount = (
-          slice_amount
-          * grind_2_derisk_1_stakes[grind_2_derisk_1_sub_grind_count]
-          / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_2_derisk_1_stakes[grind_2_derisk_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -75384,9 +75350,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_short_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_1_stakes[grind_1_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -75427,9 +75391,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (is_derisk or is_derisk_calc or is_grind_mode)
       and (grind_1_sub_grind_count < grind_1_max_sub_grinds)
     ):
-      buy_amount = (
-        slice_amount * grind_1_stakes[grind_1_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-      )
+      buy_amount = slice_amount * grind_1_stakes[grind_1_sub_grind_count] / stake_scale_leverage
       if buy_amount < (min_stake * 1.5):
         buy_amount = min_stake * 1.5
       if buy_amount > max_stake:
@@ -75567,9 +75529,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_short_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_2_stakes[grind_2_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_2_stakes[grind_2_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -75707,9 +75667,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_short_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_3_stakes[grind_3_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_3_stakes[grind_3_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -75847,9 +75805,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_short_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_4_stakes[grind_4_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_4_stakes[grind_4_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -75987,9 +75943,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_short_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_5_stakes[grind_5_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_5_stakes[grind_5_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -76127,9 +76081,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and is_short_grind_entry
         and is_not_trade_max_stake
       ):
-        buy_amount = (
-          slice_amount * grind_6_stakes[grind_6_sub_grind_count] / (trade.leverage if self.is_futures_mode else 1.0)
-        )
+        buy_amount = slice_amount * grind_6_stakes[grind_6_sub_grind_count] / stake_scale_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
@@ -76325,7 +76277,7 @@ class NostalgiaForInfinityX7(IStrategy):
           if self.is_futures_mode
           else self.regular_mode_derisk_1_reentry_spot
         )
-        / (trade.leverage if self.is_futures_mode else 1.0)
+        / stake_scale_leverage
       )
     ):
       sell_amount = derisk_1_reentry_order.safe_filled * exit_rate / trade.leverage


### PR DESCRIPTION
## Summary
- compute the futures/spot stake scale leverage once in the regular long/short grind adjust helpers
- reuse that value across repeated stake-sizing and partial-exit min-stake checks
- keeps the same futures/spot leverage value, stake inputs, thresholds, and order/profit logic

## Safety
This is local value reuse only. The reused value is still `trade.leverage` in futures mode and `1.0` otherwise, exactly matching the previous inline expression.

## Backtest scope
I treated this as a behavior-preserving regular-grind plumbing change, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, stake arrays, thresholds, profit arithmetic, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for 38 code replacements across 2 regular grind adjust helpers
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
