### PR TITLE
Trim X7 derisk flag timeout checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43900,6 +43900,14 @@ class NostalgiaForInfinityX7(IStrategy):
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
     stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
+    derisk_flag_timeout = None
+
+    def get_derisk_flag_timeout():
+      nonlocal derisk_flag_timeout
+      if derisk_flag_timeout is None:
+        derisk_flag_timeout = current_time - timedelta(hours=96)
+
+      return derisk_flag_timeout
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
@@ -44431,7 +44439,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_1_profit")
       flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_1_time"))
-      if current_time - timedelta(hours=96) > flag_time:
+      if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
           trade.set_custom_data(key="grinding_v2_derisk_level_1_flag", value=None)
         else:
@@ -44528,7 +44536,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_2_profit")
       flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_2_time"))
-      if current_time - timedelta(hours=96) > flag_time:
+      if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
           trade.set_custom_data(key="grinding_v2_derisk_level_2_flag", value=None)
         else:
@@ -44625,7 +44633,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_3_profit")
       flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_3_time"))
-      if current_time - timedelta(hours=96) > flag_time:
+      if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
           trade.set_custom_data(key="grinding_v2_derisk_level_3_flag", value=None)
         else:
@@ -70292,6 +70300,14 @@ class NostalgiaForInfinityX7(IStrategy):
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
     stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
+    derisk_flag_timeout = None
+
+    def get_derisk_flag_timeout():
+      nonlocal derisk_flag_timeout
+      if derisk_flag_timeout is None:
+        derisk_flag_timeout = current_time - timedelta(hours=96)
+
+      return derisk_flag_timeout
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
@@ -70823,7 +70839,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_1_profit")
       flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_1_time"))
-      if current_time - timedelta(hours=96) > flag_time:
+      if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
           trade.set_custom_data(key="grinding_v2_derisk_level_1_flag", value=None)
         else:
@@ -70920,7 +70936,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_2_profit")
       flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_2_time"))
-      if current_time - timedelta(hours=96) > flag_time:
+      if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
           trade.set_custom_data(key="grinding_v2_derisk_level_2_flag", value=None)
         else:
@@ -71017,7 +71033,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_3_profit")
       flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_3_time"))
-      if current_time - timedelta(hours=96) > flag_time:
+      if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
           trade.set_custom_data(key="grinding_v2_derisk_level_3_flag", value=None)
         else:


### PR DESCRIPTION
## Summary
- compute the 96-hour derisk flag timeout lazily once per v2 grind adjustment call
- reuse it across derisk level 1/2/3 flag checks
- keeps flag lookup order, timeout comparison, and flag reset behavior unchanged

## Safety
The timeout value is still `current_time - timedelta(hours=96)`. It is computed lazily, so calls without active derisk flags do not pay extra datetime work.

## Backtest scope
I treated this as a behavior-preserving derisk flag plumbing change, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, profit arithmetic, custom-data keys, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for 6 timeout replacements across long/short v2 grind adjust helpers
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
