### PR TITLE
Trim X7 stoploss entry-cost lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43720,12 +43720,14 @@ class NostalgiaForInfinityX7(IStrategy):
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
     if not self.stops_enable:
       return False, None
+
+    entry_cost = filled_entries[0].cost
     if is_system_v3_2:
       # Stoploss doom
       if self.system_v3_2_stops_enable and (
         profit_stake
         < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_2_stop_threshold_doom_futures
             if self.is_futures_mode
@@ -43740,7 +43742,7 @@ class NostalgiaForInfinityX7(IStrategy):
       if self.doom_stops_enable and (
         profit_stake
         < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_1_stop_threshold_doom_futures
             if self.is_futures_mode
@@ -43755,7 +43757,7 @@ class NostalgiaForInfinityX7(IStrategy):
       if self.doom_stops_enable and (
         profit_stake
         < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_stop_threshold_doom_futures
             if self.is_futures_mode
@@ -43772,8 +43774,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (
           profit_stake
           < -(
-            filled_entries[0].cost
-            * (self.stop_threshold_doom_futures if self.is_futures_mode else self.stop_threshold_doom_spot)
+            entry_cost * (self.stop_threshold_doom_futures if self.is_futures_mode else self.stop_threshold_doom_spot)
           )
         )
         and (
@@ -43790,7 +43791,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (
         profit_stake
         < -(
-          filled_entries[0].cost * (self.stop_threshold_futures if self.is_futures_mode else self.stop_threshold_spot)
+          entry_cost * (self.stop_threshold_futures if self.is_futures_mode else self.stop_threshold_spot)
           # / trade.leverage
         )
       )
@@ -70111,12 +70112,14 @@ class NostalgiaForInfinityX7(IStrategy):
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
     if not self.stops_enable:
       return False, None
+
+    entry_cost = filled_entries[0].cost
     if is_system_v3_2:
       # Stoploss doom
       if self.system_v3_2_stops_enable and (
         profit_stake
         < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_2_stop_threshold_doom_futures
             if self.is_futures_mode
@@ -70131,7 +70134,7 @@ class NostalgiaForInfinityX7(IStrategy):
       if self.doom_stops_enable and (
         profit_stake
         < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_1_stop_threshold_doom_futures
             if self.is_futures_mode
@@ -70146,7 +70149,7 @@ class NostalgiaForInfinityX7(IStrategy):
       if self.doom_stops_enable and (
         profit_stake
         < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_stop_threshold_doom_futures
             if self.is_futures_mode
@@ -70163,8 +70166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (
           profit_stake
           < -(
-            filled_entries[0].cost
-            * (self.stop_threshold_doom_futures if self.is_futures_mode else self.stop_threshold_doom_spot)
+            entry_cost * (self.stop_threshold_doom_futures if self.is_futures_mode else self.stop_threshold_doom_spot)
           )
         )
         and (
@@ -70181,7 +70183,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (
         profit_stake
         < -(
-          filled_entries[0].cost * (self.stop_threshold_futures if self.is_futures_mode else self.stop_threshold_spot)
+          entry_cost * (self.stop_threshold_futures if self.is_futures_mode else self.stop_threshold_spot)
           # / trade.leverage
         )
       )


### PR DESCRIPTION
## Summary
- read the first entry cost once inside long/short stoploss helpers
- reuse that local value across doom and u_e stoploss threshold calculations
- keeps stoploss threshold selection, comparisons, signal names, and branch ordering unchanged

## Safety
This only replaces repeated `filled_entries[0].cost` lookups with a local `entry_cost` after the existing `stops_enable` guard. The threshold math and return paths are unchanged.

## Backtest scope
I treated this as a behavior-preserving stoploss lookup reuse, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, profit arithmetic, stoploss thresholds, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for long/short stoploss entry-cost replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
