### PR TITLE
Trim X7 short exit entry-cost lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -53077,9 +53077,10 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Stoplosses
     if not sell:
+      entry_cost = filled_entries[0].cost
       if is_system_v3_2:
         if profit_stake < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_2_stop_threshold_futures_rebuy
             if self.is_futures_mode
@@ -53090,7 +53091,7 @@ class NostalgiaForInfinityX7(IStrategy):
           sell, signal_name = True, f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
       elif is_system_v3_1:
         if profit_stake < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_1_stop_threshold_futures_rebuy
             if self.is_futures_mode
@@ -53101,7 +53102,7 @@ class NostalgiaForInfinityX7(IStrategy):
           sell, signal_name = True, f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
       elif is_system_v3:
         if profit_stake < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_stop_threshold_futures_rebuy
             if self.is_futures_mode
@@ -53114,7 +53115,7 @@ class NostalgiaForInfinityX7(IStrategy):
         if (
           profit_stake
           < -(
-            filled_entries[0].cost
+            entry_cost
             * (self.stop_threshold_futures_rebuy if self.is_futures_mode else self.stop_threshold_spot_rebuy)
             / trade.leverage
           )
@@ -53613,12 +53614,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_3"] < 1.0):
         sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_10"
 
+      entry_cost = filled_entries[0].cost
       if is_system_v3_2:
         # Stoplosses
         if self.system_v3_2_stops_enable and (
           profit_stake
           < -(
-            filled_entries[0].cost
+            entry_cost
             * (
               self.system_v3_2_stop_threshold_rapid_futures
               if self.is_futures_mode
@@ -53633,7 +53635,7 @@ class NostalgiaForInfinityX7(IStrategy):
         if self.stops_enable and (
           profit_stake
           < -(
-            filled_entries[0].cost
+            entry_cost
             * (
               self.system_v3_1_stop_threshold_rapid_futures
               if self.is_futures_mode
@@ -53648,7 +53650,7 @@ class NostalgiaForInfinityX7(IStrategy):
         if self.stops_enable and (
           profit_stake
           < -(
-            filled_entries[0].cost
+            entry_cost
             * (
               self.system_v3_stop_threshold_rapid_futures
               if self.is_futures_mode
@@ -53666,7 +53668,7 @@ class NostalgiaForInfinityX7(IStrategy):
             and (
               profit_stake
               < -(
-                filled_entries[0].cost
+                entry_cost
                 * (self.stop_threshold_rapid_futures if self.is_futures_mode else self.stop_threshold_rapid_spot)
               )
             )
@@ -54202,12 +54204,13 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Extra exit logic
     if not sell:
+      entry_cost = filled_entries[0].cost
       if is_system_v3_2:
         # Stoplosses
         if self.system_v3_2_stops_enable and (
           profit_stake
           < -(
-            filled_entries[0].cost
+            entry_cost
             * (
               self.system_v3_2_stop_threshold_scalp_futures
               if self.is_futures_mode
@@ -54220,7 +54223,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif is_system_v3_1:
         # Stoplosses
         if profit_stake < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_1_stop_threshold_scalp_futures
             if self.is_futures_mode
@@ -54232,7 +54235,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif is_system_v3:
         # Stoplosses
         if profit_stake < -(
-          filled_entries[0].cost
+          entry_cost
           * (
             self.system_v3_stop_threshold_scalp_futures
             if self.is_futures_mode
@@ -54244,8 +54247,7 @@ class NostalgiaForInfinityX7(IStrategy):
       else:
         # Stoplosses
         if profit_stake < -(
-          filled_entries[0].cost
-          * (self.stop_threshold_scalp_futures if self.is_futures_mode else self.stop_threshold_scalp_spot)
+          entry_cost * (self.stop_threshold_scalp_futures if self.is_futures_mode else self.stop_threshold_scalp_spot)
           # / (trade.leverage if self.is_futures_mode else 1.0)
         ):
           sell, signal_name = True, f"exit_{self.short_scalp_mode_name}_stoploss_doom"


### PR DESCRIPTION
## Summary
- read the first entry cost once in short rebuy/rapid/scalp stoploss sections
- reuse that local value across their stoploss threshold calculations
- keeps threshold selection, comparisons, signal names, and branch ordering unchanged

## Safety
This only replaces repeated `filled_entries[0].cost` lookups with a local `entry_cost` in the existing stoploss paths. No stoploss thresholds, candle checks, target-profit logic, or signal names are changed.

## Backtest scope
I treated this as behavior-preserving short-exit stoploss lookup reuse, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, profit arithmetic, stoploss thresholds, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for short rebuy/rapid/scalp entry-cost replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
