### PR TITLE
Trim X7 short target-profit lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -52295,13 +52295,17 @@ class NostalgiaForInfinityX7(IStrategy):
         enter_tags,
       )
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_normal_mode_name,
@@ -52362,9 +52366,10 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
-        previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
+        previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
         f"exit_{self.short_normal_mode_name}_stoploss_doom",
         f"exit_{self.short_normal_mode_name}_stoploss_u_e",
@@ -52413,8 +52418,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_normal_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
@@ -52556,13 +52562,17 @@ class NostalgiaForInfinityX7(IStrategy):
         enter_tags,
       )
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_pump_mode_name,
@@ -52622,8 +52632,9 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
       if signal_name in [
         f"exit_{self.short_pump_mode_name}_stoploss_doom",
         f"exit_{self.short_pump_mode_name}_stoploss_u_e",
@@ -52666,8 +52677,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_pump_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
@@ -52840,13 +52852,17 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_3"] < 1.0):
         sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_10"
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_quick_mode_name,
@@ -52907,9 +52923,10 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
-        previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
+        previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
         f"exit_{self.short_quick_mode_name}_stoploss_doom",
         f"exit_{self.short_quick_mode_name}_stoploss_u_e",
@@ -52958,8 +52975,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_quick_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
@@ -53123,13 +53141,17 @@ class NostalgiaForInfinityX7(IStrategy):
         ):
           sell, signal_name = True, f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_rebuy_mode_name,
@@ -53189,8 +53211,9 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
       if signal_name in [
         f"exit_{self.short_rebuy_mode_name}_stoploss_doom",
         f"exit_{self.short_rebuy_mode_name}_stoploss_u_e",
@@ -53233,8 +53256,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_rebuy_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
@@ -53355,13 +53379,17 @@ class NostalgiaForInfinityX7(IStrategy):
         current_time,
         enter_tags,
       )
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_high_profit_mode_name,
@@ -53421,8 +53449,9 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
       if signal_name in [
         f"exit_{self.short_high_profit_mode_name}_stoploss_doom",
         f"exit_{self.short_high_profit_mode_name}_stoploss_u_e",
@@ -53465,8 +53494,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.03:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_high_profit_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
@@ -53676,13 +53706,17 @@ class NostalgiaForInfinityX7(IStrategy):
         ):
           sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_stoploss_doom"
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_rapid_mode_name,
@@ -53743,9 +53777,10 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
-        previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
+        previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
         f"exit_{self.short_rapid_mode_name}_stoploss_doom",
         f"exit_{self.short_rapid_mode_name}_stoploss_u_e",
@@ -53794,8 +53829,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_rapid_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
@@ -53966,13 +54002,17 @@ class NostalgiaForInfinityX7(IStrategy):
         enter_tags,
       )
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_top_coins_mode_name,
@@ -54033,9 +54073,10 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
-        previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
+        previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
         f"exit_{self.short_top_coins_mode_name}_stoploss_doom",
         f"exit_{self.short_top_coins_mode_name}_stoploss_u_e",
@@ -54084,8 +54125,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_top_coins_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
@@ -54250,13 +54292,17 @@ class NostalgiaForInfinityX7(IStrategy):
         ):
           sell, signal_name = True, f"exit_{self.short_scalp_mode_name}_stoploss_doom"
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.short_scalp_mode_name,
@@ -54316,8 +54362,9 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
       if signal_name in [
         f"exit_{self.short_scalp_mode_name}_stoploss_doom",
         f"exit_{self.short_scalp_mode_name}_stoploss_u_e",
@@ -54360,8 +54407,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.short_scalp_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)


### PR DESCRIPTION
## Summary
- read `target_profit_cache.data` once per short exit helper
- reuse `target_data` for the three existing target-profit lookup points in each helper
- refresh `target_data` before later lookup points so cache writes earlier in the function are still visible

## Safety
This keeps the same cache key, stored fields, target-profit decisions, signal names, and `_set_profit_target()` calls. The repeated `self.target_profit_cache.data[pair]` lookups are replaced with local cache/data references only.

## Backtest scope
I treated this as behavior-preserving short-exit cache lookup reuse, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, profit arithmetic, target-profit thresholds, stoploss thresholds, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for short target-profit cache replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
