### PR TITLE
Trim X7 long target-profit lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -25959,13 +25959,17 @@ class NostalgiaForInfinityX7(IStrategy):
         enter_tags,
       )
 
+    cache = self.target_profit_cache
+    cache_data = cache.data if cache is not None else None
+
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-      previous_rate = self.target_profit_cache.data[pair]["rate"]
-      previous_profit = self.target_profit_cache.data[pair]["profit"]
-      previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
-      previous_time_profit_reached = datetime.fromisoformat(self.target_profit_cache.data[pair]["time_profit_reached"])
+    target_data = cache_data.get(pair) if cache_data is not None else None
+    if target_data is not None:
+      previous_rate = target_data["rate"]
+      previous_profit = target_data["profit"]
+      previous_sell_reason = target_data["sell_reason"]
+      previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
         self.long_normal_mode_name,
@@ -26026,9 +26030,10 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-        previous_profit = self.target_profit_cache.data[pair]["profit"]
-        previous_sell_reason = self.target_profit_cache.data[pair]["sell_reason"]
+      target_data = cache_data.get(pair) if cache_data is not None else None
+      if target_data is not None:
+        previous_profit = target_data["profit"]
+        previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
         f"exit_{self.long_normal_mode_name}_stoploss_doom",
         f"exit_{self.long_normal_mode_name}_stoploss_u_e",
@@ -26077,8 +26082,9 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        if self.target_profit_cache is not None and pair in self.target_profit_cache.data:
-          previous_profit = self.target_profit_cache.data[pair]["profit"]
+        target_data = cache_data.get(pair) if cache_data is not None else None
+        if target_data is not None:
+          previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{self.long_normal_mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)


### PR DESCRIPTION
## Summary
- read `target_profit_cache.data` once in the long normal exit helper
- reuse `target_data` at the same three target-profit lookup points
- refresh `target_data` before later lookup points so earlier cache writes remain visible

## Safety
This keeps the same cache key, stored fields, target-profit decisions, signal names, and `_set_profit_target()` calls. The repeated `self.target_profit_cache.data[pair]` lookups are replaced with local cache/data references only.

## Backtest scope
I treated this as behavior-preserving long-exit cache lookup reuse, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, profit arithmetic, target-profit thresholds, stoploss thresholds, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for long normal target-profit cache replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
