### PR TITLE
Trim X7 v3 grind fee checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -46294,7 +46294,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    fee_rate = fee_open_rate + fee_close_rate
     stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
+    grind_entry_retry_time = current_time - timedelta(minutes=5)
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
@@ -46727,7 +46729,7 @@ class NostalgiaForInfinityX7(IStrategy):
     is_not_trade_max_stake_v3_1 = current_stake_amount < (slice_amount * self.system_v3_1_max_stake)
 
     is_long_extra_checks_entry = (
-      current_time - timedelta(minutes=5) > filled_entries[-1].order_filled_utc
+      grind_entry_retry_time > filled_entries[-1].order_filled_utc
       # and ((current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.02))
       # and (
       #   (current_stake_amount < (filled_entries[0].cost * 0.50))
@@ -47060,7 +47062,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_1_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_1_current_open_rate) / grind_1_current_open_rate
-      if (grind_profit > (grind_1_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_1_profit_threshold + fee_rate)) and self.long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_1_total_amount * exit_rate / trade.leverage
@@ -47182,7 +47184,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_2_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_2_current_open_rate) / grind_2_current_open_rate
-      if (grind_profit > (grind_2_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_2_profit_threshold + fee_rate)) and self.long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_2_total_amount * exit_rate / trade.leverage
@@ -47304,7 +47306,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_3_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_3_current_open_rate) / grind_3_current_open_rate
-      if (grind_profit > (grind_3_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_3_profit_threshold + fee_rate)) and self.long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_3_total_amount * exit_rate / trade.leverage
@@ -47436,7 +47438,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_4_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_4_current_open_rate) / grind_4_current_open_rate
-      if (grind_profit > (grind_4_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_4_profit_threshold + fee_rate)) and self.long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_4_total_amount * exit_rate / trade.leverage
@@ -47558,7 +47560,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_5_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_5_current_open_rate) / grind_5_current_open_rate
-      if (grind_profit > (grind_5_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_5_profit_threshold + fee_rate)) and self.long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_5_total_amount * exit_rate / trade.leverage
@@ -72668,7 +72670,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
     fee_open_rate = trade.fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade.fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
+    fee_rate = fee_open_rate + fee_close_rate
     stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
+    grind_entry_retry_time = current_time - timedelta(minutes=5)
 
     grind_1_max_sub_grinds = 0
     grind_1_stakes = self.scale_stakes_for_min_stake(
@@ -73055,7 +73059,7 @@ class NostalgiaForInfinityX7(IStrategy):
     is_not_trade_max_stake_v3_1 = current_stake_amount < (slice_amount * self.system_v3_1_max_stake)
 
     is_short_extra_checks_entry = (
-      current_time - timedelta(minutes=5) > filled_entries[-1].order_filled_utc
+      grind_entry_retry_time > filled_entries[-1].order_filled_utc
       # and ((current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc) or (slice_profit > 0.02))
       # and (
       #   (current_stake_amount < (filled_entries[0].cost * 0.50))
@@ -73325,7 +73329,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_1_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_1_current_open_rate) / grind_1_current_open_rate
-      if (grind_profit > (grind_1_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_1_profit_threshold + fee_rate)) and self.short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_1_total_amount * exit_rate / trade.leverage
@@ -73447,7 +73451,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_2_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_2_current_open_rate) / grind_2_current_open_rate
-      if (grind_profit > (grind_2_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_2_profit_threshold + fee_rate)) and self.short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_2_total_amount * exit_rate / trade.leverage
@@ -73569,7 +73573,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_3_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_3_current_open_rate) / grind_3_current_open_rate
-      if (grind_profit > (grind_3_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_3_profit_threshold + fee_rate)) and self.short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_3_total_amount * exit_rate / trade.leverage
@@ -73701,7 +73705,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_4_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_4_current_open_rate) / grind_4_current_open_rate
-      if (grind_profit > (grind_4_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_4_profit_threshold + fee_rate)) and self.short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_4_total_amount * exit_rate / trade.leverage
@@ -73823,7 +73827,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_5_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_5_current_open_rate) / grind_5_current_open_rate
-      if (grind_profit > (grind_5_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_5_profit_threshold + fee_rate)) and self.short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_5_total_amount * exit_rate / trade.leverage


### PR DESCRIPTION
## Summary
- compute the v3 grind fee sum once per long/short adjust call
- reuse the existing 5-minute entry retry timestamp instead of rebuilding it at the comparison
- keeps v3 grind thresholds, retry timing, comparisons, and branch ordering unchanged

## Safety
The fee value is still `fee_open_rate + fee_close_rate`, and the retry value is still `current_time - timedelta(minutes=5)`. This only reuses the same values within each call.

## Backtest scope
I treated this as behavior-preserving v3 grind arithmetic/time reuse, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle selection, order selection/classification, profit arithmetic formulas, timing constants, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for long/short v3 grind fee/time replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
