### PR TITLE
Trim X7 exit-profit candle lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1230,6 +1230,13 @@ class NostalgiaForInfinityX7(IStrategy):
         # profit is under the threshold, cancel it
         self._remove_profit_target(pair)
         return False, None
+
+      last_rsi_14 = last_candle["RSI_14"]
+      previous_rsi_14 = previous_candle_1["RSI_14"]
+      last_cmf_20 = last_candle["CMF_20"]
+      last_cmf_20_1h = last_candle["CMF_20_1h"]
+      last_cmf_20_4h = last_candle["CMF_20_4h"]
+      last_roc_9_4h = last_candle["ROC_9_4h"]
       if trade.is_short:
         is_scalp_mode = all(c in self.short_scalp_mode_tags for c in enter_tags)
         if is_scalp_mode:
@@ -1275,223 +1282,223 @@ class NostalgiaForInfinityX7(IStrategy):
         elif 0.001 <= profit_init_ratio < 0.01:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_0_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_0_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_0_3"
         elif 0.01 <= profit_init_ratio < 0.02:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_1_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_1_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_1_3"
         elif 0.02 <= profit_init_ratio < 0.03:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_2_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_2_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_2_3"
         elif 0.03 <= profit_init_ratio < 0.04:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_3_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_3_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_3_3"
         elif 0.04 <= profit_init_ratio < 0.05:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_4_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_4_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_4_3"
         elif 0.05 <= profit_init_ratio < 0.06:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_5_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_5_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_5_3"
         elif 0.06 <= profit_init_ratio < 0.07:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_6_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_6_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_6_3"
         elif 0.07 <= profit_init_ratio < 0.08:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_7_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_7_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_7_3"
         elif 0.08 <= profit_init_ratio < 0.09:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_8_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_8_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_8_3"
         elif 0.09 <= profit_init_ratio < 0.10:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_9_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_9_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_9_3"
         elif 0.10 <= profit_init_ratio < 0.11:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_10_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_10_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_10_3"
         elif 0.11 <= profit_init_ratio < 0.12:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_11_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_11_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_11_3"
         elif 0.12 <= profit_init_ratio:
           if (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["RSI_14"] > 50.0)
-            and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-            and (last_candle["CMF_20"] > 0.0)
+            and (last_rsi_14 > 50.0)
+            and (last_rsi_14 > previous_rsi_14)
+            and (last_cmf_20 > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_12_1"
           elif (
             profit_init_ratio < (previous_profit - 0.03)
-            and (last_candle["CMF_20"] > 0.0)
-            and (last_candle["CMF_20_1h"] > 0.0)
-            and (last_candle["CMF_20_4h"] > 0.0)
+            and (last_cmf_20 > 0.0)
+            and (last_cmf_20_1h > 0.0)
+            and (last_cmf_20_4h > 0.0)
           ):
             return True, f"exit_profit_{mode_name}_t_12_2"
-          elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] < -40.0):
+          elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h < -40.0):
             return True, f"exit_profit_{mode_name}_t_12_3"
       else:
         is_scalp_mode = all(c in self.long_scalp_mode_tags for c in enter_tags)
@@ -1539,223 +1546,223 @@ class NostalgiaForInfinityX7(IStrategy):
           if 0.001 <= profit_init_ratio < 0.01:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_0_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_0_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_0_3"
           elif 0.01 <= profit_init_ratio < 0.02:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_1_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_1_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_1_3"
           elif 0.02 <= profit_init_ratio < 0.03:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_2_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_2_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_2_3"
           elif 0.03 <= profit_init_ratio < 0.04:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_3_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_3_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_3_3"
           elif 0.04 <= profit_init_ratio < 0.05:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_4_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_4_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_4_3"
           elif 0.05 <= profit_init_ratio < 0.06:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_5_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_5_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_5_3"
           elif 0.06 <= profit_init_ratio < 0.07:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_6_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_6_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_6_3"
           elif 0.07 <= profit_init_ratio < 0.08:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_7_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_7_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_7_3"
           elif 0.08 <= profit_init_ratio < 0.09:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_8_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_8_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_8_3"
           elif 0.09 <= profit_init_ratio < 0.10:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_9_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_9_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_9_3"
           elif 0.10 <= profit_init_ratio < 0.11:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_10_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_10_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_10_3"
           elif 0.11 <= profit_init_ratio < 0.12:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_11_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_11_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_11_3"
           elif 0.12 <= profit_init_ratio:
             if (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["RSI_14"] < 50.0)
-              and (last_candle["RSI_14"] < previous_candle_1["RSI_14"])
-              and (last_candle["CMF_20"] < -0.0)
+              and (last_rsi_14 < 50.0)
+              and (last_rsi_14 < previous_rsi_14)
+              and (last_cmf_20 < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_12_1"
             elif (
               profit_init_ratio < (previous_profit - 0.03)
-              and (last_candle["CMF_20"] < -0.0)
-              and (last_candle["CMF_20_1h"] < -0.0)
-              and (last_candle["CMF_20_4h"] < -0.0)
+              and (last_cmf_20 < -0.0)
+              and (last_cmf_20_1h < -0.0)
+              and (last_cmf_20_4h < -0.0)
             ):
               return True, f"exit_profit_{mode_name}_t_12_2"
-            elif profit_init_ratio < (previous_profit - 0.05) and (last_candle["ROC_9_4h"] > 40.0):
+            elif profit_init_ratio < (previous_profit - 0.05) and (last_roc_9_4h > 40.0):
               return True, f"exit_profit_{mode_name}_t_12_3"
     else:
       return False, None


### PR DESCRIPTION
## Summary
- cache the repeated candle fields used by `exit_profit_target()` once inside the max-target branch
- reuse RSI, CMF, and ROC locals across the repeated target ladder checks
- keeps target thresholds, comparisons, return reasons, and branch ordering unchanged

## Safety
The candle fields are read after the existing early cancellation branch, then reused only in the same branch that already read those fields many times. No target-profit thresholds or conditions are changed.

## Backtest scope
I treated this as behavior-preserving candle lookup reuse inside exit-profit target handling, so validation focused on static checks and targeted equivalence rather than a full backtest. Indicators, candle values, order selection/classification, profit arithmetic, target thresholds, and trading conditions are unchanged.

## Checks
- targeted static/equivalence check for exit-profit candle-field replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
