### PR TITLE
Trim X7 exit wrapper mode-name churn

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -25867,13 +25867,15 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.long_normal_mode_name
+
     sell = False
 
     # if the profit is negative skip checking these
     if profit_init_ratio > 0.0:
       # Original sell signals
       sell, signal_name = self.long_exit_signals(
-        self.long_normal_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -25891,7 +25893,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Main sell signals
       if not sell:
         sell, signal_name = self.long_exit_main(
-          self.long_normal_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -25909,7 +25911,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Williams %R based sells
       if not sell:
         sell, signal_name = self.long_exit_williams_r(
-          self.long_normal_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -25927,7 +25929,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Downtrend/descending based sells
       if not sell:
         sell, signal_name = self.long_exit_dec(
-          self.long_normal_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -25945,7 +25947,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Stoplosses
     if not sell:
       sell, signal_name = self.long_exit_stoploss(
-        self.long_normal_mode_name,
+        mode_name,
         current_rate,
         profit_stake,
         profit_ratio,
@@ -25980,7 +25982,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.long_normal_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -25999,10 +26001,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.long_normal_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.long_normal_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -26016,11 +26018,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.long_normal_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.long_normal_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -26043,17 +26045,17 @@ class NostalgiaForInfinityX7(IStrategy):
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
-        f"exit_{self.long_normal_mode_name}_stoploss_doom",
-        f"exit_{self.long_normal_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ] and (
         previous_sell_reason
         not in [
-          f"exit_{self.long_normal_mode_name}_stoploss_doom",
-          f"exit_profit_{self.long_normal_mode_name}_stoploss_u_e",
+          f"exit_{mode_name}_stoploss_doom",
+          f"exit_profit_{mode_name}_stoploss_u_e",
         ]
       ):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.long_normal_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -26071,7 +26073,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.long_normal_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -26094,13 +26096,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.long_normal_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.long_normal_mode_name}_max",
-      f"exit_{self.long_normal_mode_name}_stoploss_doom",
-      f"exit_{self.long_normal_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"
@@ -51950,13 +51952,15 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_normal_mode_name
+
     sell = False
 
     # if the profit is negative skip checking these
     if profit_init_ratio > 0.0:
       # Original sell signals
       sell, signal_name = self.short_exit_signals(
-        self.short_normal_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -51974,7 +51978,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Main sell signals
       if not sell:
         sell, signal_name = self.short_exit_main(
-          self.short_normal_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -51992,7 +51996,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Williams %R based sells
       if not sell:
         sell, signal_name = self.short_exit_williams_r(
-          self.short_normal_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52010,7 +52014,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Downtrend/descending based sells
       if not sell:
         sell, signal_name = self.short_exit_dec(
-          self.short_normal_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52028,7 +52032,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Stoplosses
     if not sell:
       sell, signal_name = self.short_exit_stoploss(
-        self.short_normal_mode_name,
+        mode_name,
         current_rate,
         profit_stake,
         profit_ratio,
@@ -52063,7 +52067,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_normal_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -52082,10 +52086,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_normal_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_normal_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -52099,11 +52103,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_normal_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_normal_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -52126,17 +52130,17 @@ class NostalgiaForInfinityX7(IStrategy):
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
-        f"exit_{self.short_normal_mode_name}_stoploss_doom",
-        f"exit_{self.short_normal_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ] and (
         previous_sell_reason
         not in [
-          f"exit_{self.short_normal_mode_name}_stoploss_doom",
-          f"exit_profit_{self.short_normal_mode_name}_stoploss_u_e",
+          f"exit_{mode_name}_stoploss_doom",
+          f"exit_profit_{mode_name}_stoploss_u_e",
         ]
       ):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_normal_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -52154,7 +52158,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_normal_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -52177,13 +52181,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_normal_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_normal_mode_name}_max",
-      f"exit_{self.short_normal_mode_name}_stoploss_doom",
-      f"exit_{self.short_normal_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"
@@ -52217,13 +52221,15 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_pump_mode_name
+
     sell = False
 
     # if the profit is negative skip checking these
     if profit_init_ratio > 0.0:
       # Original sell signals
       sell, signal_name = self.short_exit_signals(
-        self.short_pump_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -52241,7 +52247,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Main sell signals
       if not sell:
         sell, signal_name = self.short_exit_main(
-          self.short_pump_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52259,7 +52265,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Williams %R based sells
       if not sell:
         sell, signal_name = self.short_exit_williams_r(
-          self.short_pump_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52277,7 +52283,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Downtrend/descending based sells
       if not sell:
         sell, signal_name = self.short_exit_dec(
-          self.short_pump_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52295,7 +52301,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Stoplosses
     if not sell:
       sell, signal_name = self.short_exit_stoploss(
-        self.short_pump_mode_name,
+        mode_name,
         current_rate,
         profit_stake,
         profit_ratio,
@@ -52330,7 +52336,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_pump_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -52349,10 +52355,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_pump_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_pump_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -52366,11 +52372,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_pump_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_pump_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -52391,11 +52397,11 @@ class NostalgiaForInfinityX7(IStrategy):
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
-        f"exit_{self.short_pump_mode_name}_stoploss_doom",
-        f"exit_{self.short_pump_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ]:
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_pump_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -52413,7 +52419,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_pump_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -52436,13 +52442,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_pump_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_pump_mode_name}_max",
-      f"exit_{self.short_pump_mode_name}_stoploss_doom",
-      f"exit_{self.short_pump_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"
@@ -52476,13 +52482,15 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_quick_mode_name
+
     sell = False
 
     # if the profit is negative skip checking these
     if profit_init_ratio > 0.0:
       # Original sell signals
       sell, signal_name = self.short_exit_signals(
-        self.short_quick_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -52500,7 +52508,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Main sell signals
       if not sell:
         sell, signal_name = self.short_exit_main(
-          self.short_quick_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52518,7 +52526,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Williams %R based sells
       if not sell:
         sell, signal_name = self.short_exit_williams_r(
-          self.short_quick_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52536,7 +52544,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Downtrend/descending based sells
       if not sell:
         sell, signal_name = self.short_exit_dec(
-          self.short_quick_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -52554,7 +52562,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Stoplosses
     if not sell:
       sell, signal_name = self.short_exit_stoploss(
-        self.short_quick_mode_name,
+        mode_name,
         current_rate,
         profit_stake,
         profit_ratio,
@@ -52579,13 +52587,13 @@ class NostalgiaForInfinityX7(IStrategy):
     # Extra sell logic
     if not sell:
       if (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_14"] < 22.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_1"
+        sell, signal_name = True, f"exit_{mode_name}_q_1"
 
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["MFI_14"] < 16.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_2"
+        sell, signal_name = True, f"exit_{mode_name}_q_2"
 
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["WILLR_14"] <= -99.9):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_3"
+        sell, signal_name = True, f"exit_{mode_name}_q_3"
 
       elif (
         (0.09 >= profit_init_ratio > 0.02)
@@ -52593,19 +52601,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3"] < 10.0)
         and (last_candle["RSI_3_15m"] < 10.0)
       ):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_4"
+        sell, signal_name = True, f"exit_{mode_name}_q_4"
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_3_15m"] < 4.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_5"
+        sell, signal_name = True, f"exit_{mode_name}_q_5"
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_3"] < 15.0) and (last_candle["RSI_3_15m"] < 15.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_6"
+        sell, signal_name = True, f"exit_{mode_name}_q_6"
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_3"] < 10.0) and (last_candle["RSI_3_15m"] < 20.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_7"
+        sell, signal_name = True, f"exit_{mode_name}_q_7"
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_3"] < 8.0) and (last_candle["RSI_3_15m"] < 25.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_8"
+        sell, signal_name = True, f"exit_{mode_name}_q_8"
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_3"] < 6.0) and (last_candle["RSI_3_15m"] < 30.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_9"
+        sell, signal_name = True, f"exit_{mode_name}_q_9"
       elif (0.09 >= profit_init_ratio > 0.02) and (last_candle["RSI_3"] < 1.0):
-        sell, signal_name = True, f"exit_{self.short_quick_mode_name}_q_10"
+        sell, signal_name = True, f"exit_{mode_name}_q_10"
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
@@ -52620,7 +52628,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_quick_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -52639,10 +52647,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_quick_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.001):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_quick_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -52656,11 +52664,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_quick_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_quick_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -52683,17 +52691,17 @@ class NostalgiaForInfinityX7(IStrategy):
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
-        f"exit_{self.short_quick_mode_name}_stoploss_doom",
-        f"exit_{self.short_quick_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ] and (
         previous_sell_reason
         not in [
-          f"exit_{self.short_quick_mode_name}_stoploss_doom",
-          f"exit_profit_{self.short_quick_mode_name}_stoploss_u_e",
+          f"exit_{mode_name}_stoploss_doom",
+          f"exit_profit_{mode_name}_stoploss_u_e",
         ]
       ):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_quick_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -52711,7 +52719,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_quick_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -52734,13 +52742,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_quick_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_quick_mode_name}_max",
-      f"exit_{self.short_quick_mode_name}_stoploss_doom",
-      f"exit_{self.short_quick_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"
@@ -52773,13 +52781,15 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_rebuy_mode_name
+
     is_backtest = self.is_backtest_mode()
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
     sell = False
 
     # Original sell signals
     sell, signal_name = self.short_exit_signals(
-      self.short_rebuy_mode_name,
+      mode_name,
       profit_current_stake_ratio,
       max_profit,
       max_loss,
@@ -52797,7 +52807,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Main sell signals
     if not sell:
       sell, signal_name = self.short_exit_main(
-        self.short_rebuy_mode_name,
+        mode_name,
         profit_current_stake_ratio,
         max_profit,
         max_loss,
@@ -52815,7 +52825,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Williams %R based sells
     if not sell:
       sell, signal_name = self.short_exit_williams_r(
-        self.short_rebuy_mode_name,
+        mode_name,
         profit_current_stake_ratio,
         max_profit,
         max_loss,
@@ -52833,7 +52843,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Downtrend/descending based sells
     if not sell:
       sell, signal_name = self.short_exit_dec(
-        self.short_rebuy_mode_name,
+        mode_name,
         profit_current_stake_ratio,
         max_profit,
         max_loss,
@@ -52861,7 +52871,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           / trade.leverage
         ):
-          sell, signal_name = True, f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3_1:
         if profit_stake < -(
           entry_cost
@@ -52872,7 +52882,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           / trade.leverage
         ):
-          sell, signal_name = True, f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3:
         if profit_stake < -(
           entry_cost
@@ -52883,7 +52893,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           / trade.leverage
         ):
-          sell, signal_name = True, f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       else:
         if (
           profit_stake
@@ -52895,7 +52905,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # temporary
           and (is_backtest or trade.open_date_utc.replace(tzinfo=None) >= datetime(2024, 9, 13))
         ):
-          sell, signal_name = True, f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
@@ -52910,7 +52920,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_rebuy_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -52929,10 +52939,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_rebuy_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.001):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_rebuy_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -52946,11 +52956,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_rebuy_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_rebuy_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -52971,11 +52981,11 @@ class NostalgiaForInfinityX7(IStrategy):
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
-        f"exit_{self.short_rebuy_mode_name}_stoploss_doom",
-        f"exit_{self.short_rebuy_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ]:
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_rebuy_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -52993,7 +53003,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_rebuy_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -53016,13 +53026,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_rebuy_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_rebuy_mode_name}_max",
-      f"exit_{self.short_rebuy_mode_name}_stoploss_doom",
-      f"exit_{self.short_rebuy_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"
@@ -53056,11 +53066,13 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_high_profit_mode_name
+
     sell = False
 
     # Original sell signals
     sell, signal_name = self.short_exit_signals(
-      self.short_high_profit_mode_name,
+      mode_name,
       profit_init_ratio,
       max_profit,
       max_loss,
@@ -53078,7 +53090,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Main sell signals
     if not sell:
       sell, signal_name = self.short_exit_main(
-        self.short_high_profit_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53096,7 +53108,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Williams %R based sells
     if not sell:
       sell, signal_name = self.short_exit_williams_r(
-        self.short_high_profit_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53114,7 +53126,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Stoplosses
     if not sell:
       sell, signal_name = self.short_exit_stoploss(
-        self.short_high_profit_mode_name,
+        mode_name,
         current_rate,
         profit_stake,
         profit_ratio,
@@ -53148,7 +53160,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_high_profit_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -53167,10 +53179,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_high_profit_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.001):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_high_profit_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -53184,11 +53196,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_high_profit_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_high_profit_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -53209,11 +53221,11 @@ class NostalgiaForInfinityX7(IStrategy):
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
-        f"exit_{self.short_high_profit_mode_name}_stoploss_doom",
-        f"exit_{self.short_high_profit_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ]:
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_high_profit_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -53231,7 +53243,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_high_profit_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -53254,11 +53266,11 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_high_profit_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_high_profit_mode_name}_max",
+      f"exit_profit_{mode_name}_max",
       # f"exit_{self.short_high_profit_mode_name}_stoploss_doom",
       # f"exit_{self.short_high_profit_mode_name}_stoploss_u_e",
     ]:
@@ -53293,6 +53305,8 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_rapid_mode_name
+
     is_backtest = self.is_backtest_mode()
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
     sell = False
@@ -53302,7 +53316,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if profit_init_ratio > 0.0:
       # Original sell signals
       sell, signal_name = self.short_exit_signals(
-        self.short_rapid_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53320,7 +53334,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Main sell signals
       if not sell:
         sell, signal_name = self.short_exit_main(
-          self.short_rapid_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -53338,7 +53352,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Williams %R based sells
       if not sell:
         sell, signal_name = self.short_exit_williams_r(
-          self.short_rapid_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -53356,7 +53370,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # Downtrend/descending based sells
       if not sell:
         sell, signal_name = self.short_exit_dec(
-          self.short_rapid_mode_name,
+          mode_name,
           profit_init_ratio,
           max_profit,
           max_loss,
@@ -53374,30 +53388,30 @@ class NostalgiaForInfinityX7(IStrategy):
     # Extra exit logic
     if not sell:
       if (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_14"] < 22.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_1"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_1"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["MFI_14"] < 16.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_2"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_2"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["WILLR_14"] <= -99.9):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_3"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_3"
       elif (
         (0.09 >= profit_init_ratio > 0.005)
         and (last_candle["RSI_14"] <= 28.0)
         and (last_candle["RSI_3"] < 10.0)
         and (last_candle["RSI_3_15m"] < 10.0)
       ):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_4"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_4"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_3_15m"] < 4.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_5"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_5"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_3"] < 15.0) and (last_candle["RSI_3_15m"] < 15.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_6"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_6"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_3"] < 10.0) and (last_candle["RSI_3_15m"] < 20.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_7"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_7"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_3"] < 8.0) and (last_candle["RSI_3_15m"] < 25.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_8"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_8"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_3"] < 6.0) and (last_candle["RSI_3_15m"] < 30.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_9"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_9"
       elif (0.09 >= profit_init_ratio > 0.005) and (last_candle["RSI_3"] < 1.0):
-        sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_rpd_10"
+        sell, signal_name = True, f"exit_{mode_name}_rpd_10"
 
       entry_cost = filled_entries[0].cost
       if is_system_v3_2:
@@ -53414,7 +53428,7 @@ class NostalgiaForInfinityX7(IStrategy):
             / trade.leverage
           )
         ):
-          sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3_1:
         # Stoplosses
         if self.stops_enable and (
@@ -53429,7 +53443,7 @@ class NostalgiaForInfinityX7(IStrategy):
             / trade.leverage
           )
         ):
-          sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3:
         # Stoplosses
         if self.stops_enable and (
@@ -53444,7 +53458,7 @@ class NostalgiaForInfinityX7(IStrategy):
             / trade.leverage
           )
         ):
-          sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       else:
         # Stoplosses
         if (
@@ -53461,7 +53475,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # temporary
           and (is_backtest or trade.open_date_utc.replace(tzinfo=None) >= datetime(2024, 9, 13))
         ):
-          sell, signal_name = True, f"exit_{self.short_rapid_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
@@ -53476,7 +53490,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_rapid_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -53495,10 +53509,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_rapid_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.001):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_rapid_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -53512,11 +53526,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_rapid_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_rapid_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -53539,17 +53553,17 @@ class NostalgiaForInfinityX7(IStrategy):
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
-        f"exit_{self.short_rapid_mode_name}_stoploss_doom",
-        f"exit_{self.short_rapid_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ] and (
         previous_sell_reason
         not in [
-          f"exit_{self.short_rapid_mode_name}_stoploss_doom",
-          f"exit_profit_{self.short_rapid_mode_name}_stoploss_u_e",
+          f"exit_{mode_name}_stoploss_doom",
+          f"exit_profit_{mode_name}_stoploss_u_e",
         ]
       ):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_rapid_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -53567,7 +53581,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_rapid_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -53590,13 +53604,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_rapid_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_rapid_mode_name}_max",
-      f"exit_{self.short_rapid_mode_name}_stoploss_doom",
-      f"exit_{self.short_rapid_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"
@@ -53661,11 +53675,13 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_top_coins_mode_name
+
     sell = False
 
     # Original sell signals
     sell, signal_name = self.short_exit_signals(
-      self.short_top_coins_mode_name,
+      mode_name,
       profit_init_ratio,
       max_profit,
       max_loss,
@@ -53683,7 +53699,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Main sell signals
     if not sell:
       sell, signal_name = self.short_exit_main(
-        self.short_top_coins_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53701,7 +53717,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Williams %R based sells
     if not sell:
       sell, signal_name = self.short_exit_williams_r(
-        self.short_top_coins_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53719,7 +53735,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Downtrend/descending based sells
     if not sell:
       sell, signal_name = self.short_exit_dec(
-        self.short_top_coins_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53737,7 +53753,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Stoplosses
     if not sell:
       sell, signal_name = self.short_exit_stoploss(
-        self.short_top_coins_mode_name,
+        mode_name,
         current_rate,
         profit_stake,
         profit_ratio,
@@ -53772,7 +53788,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_top_coins_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -53791,10 +53807,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_top_coins_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_top_coins_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -53808,11 +53824,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_top_coins_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_top_coins_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -53835,17 +53851,17 @@ class NostalgiaForInfinityX7(IStrategy):
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
       if signal_name in [
-        f"exit_{self.short_top_coins_mode_name}_stoploss_doom",
-        f"exit_{self.short_top_coins_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ] and (
         previous_sell_reason
         not in [
-          f"exit_{self.short_top_coins_mode_name}_stoploss_doom",
-          f"exit_profit_{self.short_top_coins_mode_name}_stoploss_u_e",
+          f"exit_{mode_name}_stoploss_doom",
+          f"exit_profit_{mode_name}_stoploss_u_e",
         ]
       ):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_top_coins_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -53863,7 +53879,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_top_coins_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -53886,13 +53902,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_top_coins_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_top_coins_mode_name}_max",
-      f"exit_{self.short_top_coins_mode_name}_stoploss_doom",
-      f"exit_{self.short_top_coins_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"
@@ -53925,12 +53941,14 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mode_name = self.short_scalp_mode_name
+
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
     sell = False
 
     # Original sell signals
     sell, signal_name = self.short_exit_signals(
-      self.short_scalp_mode_name,
+      mode_name,
       profit_init_ratio,
       max_profit,
       max_loss,
@@ -53948,7 +53966,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Main sell signals
     if not sell:
       sell, signal_name = self.short_exit_main(
-        self.short_scalp_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53966,7 +53984,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Williams %R based sells
     if not sell:
       sell, signal_name = self.short_exit_williams_r(
-        self.short_scalp_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -53984,7 +54002,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Downtrend/descending based sells
     if not sell:
       sell, signal_name = self.short_exit_dec(
-        self.short_scalp_mode_name,
+        mode_name,
         profit_init_ratio,
         max_profit,
         max_loss,
@@ -54016,7 +54034,7 @@ class NostalgiaForInfinityX7(IStrategy):
             / trade.leverage
           )
         ):
-          sell, signal_name = True, f"exit_{self.short_scalp_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3_1:
         # Stoplosses
         if profit_stake < -(
@@ -54028,7 +54046,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           / trade.leverage
         ):
-          sell, signal_name = True, f"exit_{self.short_scalp_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3:
         # Stoplosses
         if profit_stake < -(
@@ -54040,14 +54058,14 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           / trade.leverage
         ):
-          sell, signal_name = True, f"exit_{self.short_scalp_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       else:
         # Stoplosses
         if profit_stake < -(
           entry_cost * (self.stop_threshold_scalp_futures if self.is_futures_mode else self.stop_threshold_scalp_spot)
           # / (trade.leverage if self.is_futures_mode else 1.0)
         ):
-          sell, signal_name = True, f"exit_{self.short_scalp_mode_name}_stoploss_doom"
+          sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
@@ -54062,7 +54080,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
       sell_max, signal_name_max = self.exit_profit_target(
-        self.short_scalp_mode_name,
+        mode_name,
         pair,
         trade,
         current_time,
@@ -54081,10 +54099,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       if sell_max and signal_name_max is not None:
         return True, f"{signal_name_max}_m"
-      if previous_sell_reason == f"exit_{self.short_scalp_mode_name}_stoploss_u_e":
+      if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
           mark_pair, mark_signal = self.mark_profit_target(
-            self.short_scalp_mode_name,
+            mode_name,
             pair,
             True,
             previous_sell_reason,
@@ -54098,11 +54116,11 @@ class NostalgiaForInfinityX7(IStrategy):
           if mark_pair:
             self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
-        previous_sell_reason != f"exit_{self.short_scalp_mode_name}_stoploss_doom"
+        previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_scalp_mode_name,
+          mode_name,
           pair,
           True,
           previous_sell_reason,
@@ -54123,11 +54141,11 @@ class NostalgiaForInfinityX7(IStrategy):
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
-        f"exit_{self.short_scalp_mode_name}_stoploss_doom",
-        f"exit_{self.short_scalp_mode_name}_stoploss_u_e",
+        f"exit_{mode_name}_stoploss_doom",
+        f"exit_{mode_name}_stoploss_u_e",
       ]:
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_scalp_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -54145,7 +54163,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
         mark_pair, mark_signal = self.mark_profit_target(
-          self.short_scalp_mode_name,
+          mode_name,
           pair,
           sell,
           signal_name,
@@ -54168,13 +54186,13 @@ class NostalgiaForInfinityX7(IStrategy):
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          mark_signal = f"exit_profit_{self.short_scalp_mode_name}_max"
+          mark_signal = f"exit_profit_{mode_name}_max"
           self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
-      f"exit_profit_{self.short_scalp_mode_name}_max",
-      f"exit_{self.short_scalp_mode_name}_stoploss_doom",
-      f"exit_{self.short_scalp_mode_name}_stoploss_u_e",
+      f"exit_profit_{mode_name}_max",
+      f"exit_{mode_name}_stoploss_doom",
+      f"exit_{mode_name}_stoploss_u_e",
     ]:
       if sell and (signal_name is not None):
         return True, f"{signal_name}"


### PR DESCRIPTION
## Summary
    - Cache repeated exit wrapper mode-name attributes in local variables.
- Reuse the local mode name for exit dispatch, target-profit markers, and signal-name checks.

    ## Safety
    - Signal strings stay built from the same mode-name values.
- No candle, order, profit, stake, or threshold logic changes.

    ## Backtest scope
    This is a behavior-preserving lookup-reuse patch. It does not change indicators, candle selection, entry/exit thresholds, order classification, profit arithmetic, or stake formulas. Validation focused on formatting, linting, and compile checks because the same values are read once into local variables and then reused in the existing logic.

    ## Checks
    - `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
