### PR TITLE
Trim X7 long regular grind-entry lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -50010,6 +50010,16 @@ class NostalgiaForInfinityX7(IStrategy):
   def long_grind_entry(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_rsi_14 = last_candle["RSI_14"]
+    last_rsi_3_15m = last_candle["RSI_3_15m"]
+    last_rsi_3_1h = last_candle["RSI_3_1h"]
+    last_rsi_3_4h = last_candle["RSI_3_4h"]
+    last_close = last_candle["close"]
+    last_ema_26 = last_candle["EMA_26"]
+    last_ema_12 = last_candle["EMA_12"]
+    last_rsi_3 = last_candle["RSI_3"]
+    last_open = last_candle["open"]
+
     if (
       (last_candle["protections_long_global"] == True)
       and (last_candle["protections_long_rebuy"] == True)
@@ -50018,63 +50028,63 @@ class NostalgiaForInfinityX7(IStrategy):
       and (
         (last_candle["enter_long"] == True)
         or (
-          (last_candle["RSI_14"] < 36.0)
-          and (last_candle["RSI_3"] > 10.0)
-          and (last_candle["RSI_3_15m"] > 10.0)
+          (last_rsi_14 < 36.0)
+          and (last_rsi_3 > 10.0)
+          and (last_rsi_3_15m > 10.0)
           and (last_candle["AROONU_14"] < 25.0)
           and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
           and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-          and (last_candle["close"] < (last_candle["EMA_16"] * 0.980))
+          and (last_close < (last_candle["EMA_16"] * 0.980))
         )
         or (
-          (last_candle["RSI_14"] < 36.0)
-          and (last_candle["RSI_3_15m"] > 5.0)
-          and (last_candle["RSI_3_1h"] > 5.0)
-          and (last_candle["RSI_3_4h"] > 5.0)
-          and (last_candle["EMA_26"] > last_candle["EMA_12"])
-          and ((last_candle["EMA_26"] - last_candle["EMA_12"]) > (last_candle["open"] * 0.030))
-          and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_candle["open"] / 100.0))
+          (last_rsi_14 < 36.0)
+          and (last_rsi_3_15m > 5.0)
+          and (last_rsi_3_1h > 5.0)
+          and (last_rsi_3_4h > 5.0)
+          and (last_ema_26 > last_ema_12)
+          and ((last_ema_26 - last_ema_12) > (last_open * 0.030))
+          and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_open / 100.0))
         )
         or (
-          (last_candle["RSI_14"] < 36.0)
-          and (last_candle["RSI_3"] > 5.0)
-          and (last_candle["RSI_3_15m"] > 10.0)
-          and (last_candle["RSI_3_1h"] > 10.0)
-          and (last_candle["RSI_3_4h"] > 10.0)
-          and (last_candle["EMA_26"] > last_candle["EMA_12"])
-          and ((last_candle["EMA_26"] - last_candle["EMA_12"]) > (last_candle["open"] * 0.020))
-          and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_candle["open"] / 100.0))
+          (last_rsi_14 < 36.0)
+          and (last_rsi_3 > 5.0)
+          and (last_rsi_3_15m > 10.0)
+          and (last_rsi_3_1h > 10.0)
+          and (last_rsi_3_4h > 10.0)
+          and (last_ema_26 > last_ema_12)
+          and ((last_ema_26 - last_ema_12) > (last_open * 0.020))
+          and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_open / 100.0))
         )
         or (
-          (last_candle["RSI_14"] < 36.0)
-          and (last_candle["RSI_3"] > 16.0)
+          (last_rsi_14 < 36.0)
+          and (last_rsi_3 > 16.0)
           and (last_candle["AROONU_14_15m"] < 25.0)
-          and (last_candle["close"] < (last_candle["EMA_12"] * 0.984))
+          and (last_close < (last_ema_12 * 0.984))
         )
         or (
-          (last_candle["RSI_14"] < 36.0)
-          and (last_candle["RSI_3_15m"] > 10.0)
-          and (last_candle["RSI_3_1h"] > 10.0)
-          and (last_candle["RSI_3_4h"] > 10.0)
+          (last_rsi_14 < 36.0)
+          and (last_rsi_3_15m > 10.0)
+          and (last_rsi_3_1h > 10.0)
+          and (last_rsi_3_4h > 10.0)
           and (last_candle["AROONU_14_1h"] > last_candle["AROOND_14_1h"])
           and (last_candle["AROONU_14_4h"] > last_candle["AROOND_14_4h"])
-          and (last_candle["close"] < (last_candle["EMA_26"] * 0.978))
-          and (last_candle["close"] < (last_candle["BBL_20_2.0"] * 0.999))
+          and (last_close < (last_ema_26 * 0.978))
+          and (last_close < (last_candle["BBL_20_2.0"] * 0.999))
         )
         or (
-          (last_candle["RSI_14"] < 36.0)
-          and (last_candle["RSI_3_1h"] > 20.0)
-          and (last_candle["RSI_3_4h"] > 20.0)
+          (last_rsi_14 < 36.0)
+          and (last_rsi_3_1h > 20.0)
+          and (last_rsi_3_4h > 20.0)
           and (last_candle["RSI_14_1h"] < 80.0)
           and (last_candle["RSI_14_4h"] < 60.0)
           and (last_candle["AROONU_14"] > last_candle["AROOND_14"])
           and (previous_candle["AROONU_14"] < previous_candle["AROOND_14"])
         )
         or (
-          (last_candle["RSI_14"] < 36.0)
-          and (last_candle["RSI_3_15m"] > 15.0)
-          and (last_candle["RSI_3_1h"] > 20.0)
-          and (last_candle["RSI_3_4h"] > 20.0)
+          (last_rsi_14 < 36.0)
+          and (last_rsi_3_15m > 15.0)
+          and (last_rsi_3_1h > 20.0)
+          and (last_rsi_3_4h > 20.0)
           and (last_candle["RSI_14_1h"] < 80.0)
           and (last_candle["RSI_14_4h"] < 60.0)
           and (last_candle["KST_10_15_20_30_10_10_10_15"] > last_candle["KSTs_9"])
@@ -50082,15 +50092,15 @@ class NostalgiaForInfinityX7(IStrategy):
         )
         or (
           is_derisk
-          and (last_candle["RSI_3"] > 20.0)
-          and (last_candle["RSI_3_15m"] > 20.0)
-          and (last_candle["RSI_3_1h"] > 20.0)
-          and (last_candle["RSI_3_4h"] > 20.0)
-          and (last_candle["RSI_14"] < 36.0)
+          and (last_rsi_3 > 20.0)
+          and (last_rsi_3_15m > 20.0)
+          and (last_rsi_3_1h > 20.0)
+          and (last_rsi_3_4h > 20.0)
+          and (last_rsi_14 < 36.0)
           and (last_candle["AROONU_14"] < 25.0)
           and (last_candle["AROONU_14_15m"] < 25.0)
           and (last_candle["STOCHRSIk_14_14_3_3_15m"] < 50.0)
-          and (last_candle["close"] < (last_candle["EMA_20"] * 0.980))
+          and (last_close < (last_candle["EMA_20"] * 0.980))
         )
       )
     ):


### PR DESCRIPTION
## Summary
    - Cache the repeated `last_candle` fields used by `long_grind_entry()`.
- Reuse local values through the regular long grind-entry condition ladder.

    ## Safety
    - Every local is copied from the same `last_candle` row before the condition checks.
- Entry thresholds and condition order stay unchanged.

    ## Backtest scope
    This is a behavior-preserving lookup-reuse patch. It does not change indicators, candle selection, entry/exit thresholds, order classification, profit arithmetic, or stake formulas. Validation focused on formatting, linting, and compile checks because the same values are read once into local variables and then reused in the existing logic.

    ## Checks
    - `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
