### PR TITLE
Trim X7 entry protection seed

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12399,12 +12399,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     for enabled_long_entry_signal in self.long_entry_signal_params:
       long_entry_condition_index = int(enabled_long_entry_signal.rsplit("_", 2)[1])
-      item_buy_protection_list = [True]
       if self.long_entry_signal_params[enabled_long_entry_signal]:
         # Long Entry Conditions Starts Here
         # -----------------------------------------------------------------------------------------
         long_entry_logic = []
-        long_entry_logic.append(reduce(lambda x, y: x & y, item_buy_protection_list))
+        long_entry_logic.append(True)
 
         # Condition #1 - Normal mode (Long).
         if long_entry_condition_index == 1:
@@ -23892,7 +23891,6 @@ class NostalgiaForInfinityX7(IStrategy):
 
     for enabled_short_entry_signal in self.short_entry_signal_params:
       short_entry_condition_index = int(enabled_short_entry_signal.rsplit("_", 2)[1])
-      item_short_buy_protection_list = [True]
       if self.short_entry_signal_params[enabled_short_entry_signal]:
         # Short Entry Conditions Starts Here
         # -----------------------------------------------------------------------------------------
@@ -23900,7 +23898,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # Please dont change these comment descriptions. With these descriptions we are comparing long/short positions.
 
         short_entry_logic = []
-        short_entry_logic.append(reduce(lambda x, y: x & y, item_short_buy_protection_list))
+        short_entry_logic.append(True)
 
         # Condition #501 - Normal mode (Short).
         if short_entry_condition_index == 501:


### PR DESCRIPTION
## Summary
- Replace singleton `[True]` protection reducers with the same direct `True` seed for long/short entry condition lists.

## Safety
- The boolean seed is identical to reducing a one-item `[True]` list, so entry filters and signal conditions stay unchanged.
- No indicators, candle selection, order selection/classification, profit arithmetic, or trading thresholds are changed.
- This avoids the active v3 grind-entry area.

## Backtest scope
This is a behavior-preserving plumbing/local-reuse change, so I did not run a full backtest for this PR. The preserved invariants are: indicators unchanged, candle selection unchanged, order selection/classification unchanged, date constants unchanged, profit arithmetic unchanged, and trading conditions unchanged.

## Checks
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
