### PR TITLE
Trim X7 confirm-entry close lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -11986,8 +11986,9 @@ class NostalgiaForInfinityX7(IStrategy):
     df, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
     if len(df) >= 1:
       last_candle = df.iloc[-1]
-      if (side == "long" and rate > last_candle["close"]) or (side == "short" and rate < last_candle["close"]):
-        slippage = (rate / last_candle["close"]) - 1.0
+      last_close = last_candle["close"]
+      if (side == "long" and rate > last_close) or (side == "short" and rate < last_close):
+        slippage = (rate / last_close) - 1.0
         if (side == "long" and slippage < self.max_slippage) or (side == "short" and slippage > -self.max_slippage):
           return True
         else:


### PR DESCRIPTION
## Summary
- Reuse the latest close value inside `confirm_trade_entry()` slippage checks instead of reading the same candle field repeatedly.

## Safety
- The rate/slippage comparisons use the same candle close value and keep the existing slippage thresholds unchanged.
- No indicators, candle selection, order selection/classification, profit arithmetic, or trading thresholds are changed.
- This avoids the active v3 grind-entry area.

## Backtest scope
This is a behavior-preserving plumbing/local-reuse change, so I did not run a full backtest for this PR. The preserved invariants are: indicators unchanged, candle selection unchanged, order selection/classification unchanged, date constants unchanged, profit arithmetic unchanged, and trading conditions unchanged.

## Checks
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
