### PR TITLE
Trim X7 short exit-signal band lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -54204,13 +54204,18 @@ class NostalgiaForInfinityX7(IStrategy):
     last_rsi_14 = last_candle["RSI_14"]
     last_close = last_candle["close"]
     last_ema_200 = last_candle["EMA_200"]
+    last_bbl_20 = last_candle["BBL_20_2.0"]
+    previous_1_close = previous_candle_1["close"]
+    previous_1_bbl_20 = previous_candle_1["BBL_20_2.0"]
+    previous_2_close = previous_candle_2["close"]
+    previous_2_bbl_20 = previous_candle_2["BBL_20_2.0"]
 
     # Sell signal 1
     if (
       (last_rsi_14 < 16.0)
-      and (last_close < last_candle["BBL_20_2.0"])
-      and (previous_candle_1["close"] < previous_candle_1["BBL_20_2.0"])
-      and (previous_candle_2["close"] < previous_candle_2["BBL_20_2.0"])
+      and (last_close < last_bbl_20)
+      and (previous_1_close < previous_1_bbl_20)
+      and (previous_2_close < previous_2_bbl_20)
       and (previous_candle_3["close"] < previous_candle_3["BBL_20_2.0"])
       and (previous_candle_4["close"] < previous_candle_4["BBL_20_2.0"])
     ):
@@ -54224,9 +54229,9 @@ class NostalgiaForInfinityX7(IStrategy):
     # Sell signal 2
     elif (
       (last_rsi_14 < 14.0)
-      and (last_close < last_candle["BBL_20_2.0"])
-      and (previous_candle_1["close"] < previous_candle_1["BBL_20_2.0"])
-      and (previous_candle_2["close"] < previous_candle_2["BBL_20_2.0"])
+      and (last_close < last_bbl_20)
+      and (previous_1_close < previous_1_bbl_20)
+      and (previous_2_close < previous_2_bbl_20)
     ):
       if last_close < last_ema_200:
         if current_profit > 0.01:


### PR DESCRIPTION
## Summary
- Cache the repeated short exit-signal Bollinger band fields used by the first two signal checks.

## Safety
- Only repeated Series lookups are reused; exit thresholds, candle references, and return tags are unchanged.
- No indicators, candle selection, order selection/classification, profit arithmetic, or trading thresholds are changed.
- This avoids the active v3 grind-entry area.

## Backtest scope
This is a behavior-preserving plumbing/local-reuse change, so I did not run a full backtest for this PR. The preserved invariants are: indicators unchanged, candle selection unchanged, order selection/classification unchanged, date constants unchanged, profit arithmetic unchanged, and trading conditions unchanged.

## Checks
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
