### PR TITLE
Trim X7 long stoploss candle lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43510,6 +43510,10 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_stoploss_doom"
 
+    last_close = last_candle["close"]
+    last_ema_200 = last_candle["EMA_200"]
+    last_rsi_14 = last_candle["RSI_14"]
+
     # Stoploss u_e
     if (
       self.u_e_stops_enable
@@ -43520,11 +43524,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # / trade.leverage
         )
       )
-      and (last_candle["close"] < last_candle["EMA_200"])
+      and (last_close < last_ema_200)
       and (last_candle["CMF_20"] < -0.0)
-      and (((last_candle["EMA_200"] - last_candle["close"]) / last_candle["close"]) < 0.010)
-      and (last_candle["RSI_14"] > previous_candle_1["RSI_14"])
-      and (last_candle["RSI_14"] > (last_candle["RSI_14_1h"] + 24.0))
+      and (((last_ema_200 - last_close) / last_close) < 0.010)
+      and (last_rsi_14 > previous_candle_1["RSI_14"])
+      and (last_rsi_14 > (last_candle["RSI_14_1h"] + 24.0))
       # and (current_time - timedelta(minutes=720) > trade.open_date_utc)
       # temporary
       and (is_backtest or trade_open_date >= datetime(2025, 4, 3))


### PR DESCRIPTION
## Summary
- Reuse repeated close/EMA/RSI fields in the long stoploss `u_e` condition.

## Safety
- Stop thresholds, system-version branches, date guards, and entry-condition checks are unchanged.
- No indicators, candle selection, order selection/classification, profit arithmetic, or trading thresholds are changed.
- This avoids the active v3 grind-entry area.

## Backtest scope
This is a behavior-preserving plumbing/local-reuse change, so I did not run a full backtest for this PR. The preserved invariants are: indicators unchanged, candle selection unchanged, order selection/classification unchanged, date constants unchanged, profit arithmetic unchanged, and trading conditions unchanged.

## Checks
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
