### PR TITLE
Trim X7 v2 exit RSI lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -45908,13 +45908,16 @@ class NostalgiaForInfinityX7(IStrategy):
   def long_buyback_exit_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_rsi_3 = last_candle["RSI_3"]
+    last_rsi_14 = last_candle["RSI_14"]
+
     if (
-      (last_candle["RSI_3"] > 99.0)
-      or (last_candle["RSI_14"] > 70.0)
+      (last_rsi_3 > 99.0)
+      or (last_rsi_14 > 70.0)
       or (last_candle["WILLR_14"] > -0.1)
       or (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
       or (last_candle["close"] > (last_candle["BBU_20_2.0"] * 1.01))
-      or ((last_candle["RSI_3"] > 90.0) and (last_candle["RSI_14"] < 50.0))
+      or ((last_rsi_3 > 90.0) and (last_rsi_14 < 50.0))
     ):
       return True
 
@@ -45923,13 +45926,16 @@ class NostalgiaForInfinityX7(IStrategy):
   def long_grind_exit_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_rsi_3 = last_candle["RSI_3"]
+    last_rsi_14 = last_candle["RSI_14"]
+
     if (
-      (last_candle["RSI_3"] > 99.0)
-      or (last_candle["RSI_14"] > 70.0)
+      (last_rsi_3 > 99.0)
+      or (last_rsi_14 > 70.0)
       or (last_candle["WILLR_14"] > -0.1)
       or (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
       or (last_candle["close"] > (last_candle["BBU_20_2.0"] * 1.01))
-      or ((last_candle["RSI_3"] > 90.0) and (last_candle["RSI_14"] < 50.0))
+      or ((last_rsi_3 > 90.0) and (last_rsi_14 < 50.0))
     ):
       return True
 
@@ -72077,13 +72083,16 @@ class NostalgiaForInfinityX7(IStrategy):
   def short_buyback_exit_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_rsi_3 = last_candle["RSI_3"]
+    last_rsi_14 = last_candle["RSI_14"]
+
     if (
-      (last_candle["RSI_3"] < 1.0)
-      or (last_candle["RSI_14"] < 30.0)
+      (last_rsi_3 < 1.0)
+      or (last_rsi_14 < 30.0)
       or (last_candle["WILLR_14"] < -99.9)
       or (last_candle["STOCHRSIk_14_14_3_3"] > 5.0)
       or (last_candle["close"] < (last_candle["BBL_20_2.0"] * 0.99))
-      or ((last_candle["RSI_3"] < 10.0) and (last_candle["RSI_14"] > 50.0))
+      or ((last_rsi_3 < 10.0) and (last_rsi_14 > 50.0))
     ):
       return True
 
@@ -72092,13 +72101,16 @@ class NostalgiaForInfinityX7(IStrategy):
   def short_grind_exit_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_rsi_3 = last_candle["RSI_3"]
+    last_rsi_14 = last_candle["RSI_14"]
+
     if (
-      (last_candle["RSI_3"] < 1.0)
-      or (last_candle["RSI_14"] < 30.0)
+      (last_rsi_3 < 1.0)
+      or (last_rsi_14 < 30.0)
       or (last_candle["WILLR_14"] < -99.9)
       or (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
       or (last_candle["close"] < (last_candle["BBL_20_2.0"] * 0.99))
-      or ((last_candle["RSI_3"] < 10.0) and (last_candle["RSI_14"] > 50.0))
+      or ((last_rsi_3 < 10.0) and (last_rsi_14 > 50.0))
     ):
       return True
 


### PR DESCRIPTION
## Summary
- Reuse repeated RSI fields in the long/short v2 buyback and grind exit helpers.

## Safety
- The v2 helper predicates keep the same comparisons, thresholds, and return behavior.
- No indicators, candle selection, order selection/classification, profit arithmetic, or trading thresholds are changed.
- This avoids the active v3 grind-entry area.

## Backtest scope
This is a behavior-preserving plumbing/local-reuse change, so I did not run a full backtest for this PR. The preserved invariants are: indicators unchanged, candle selection unchanged, order selection/classification unchanged, date constants unchanged, profit arithmetic unchanged, and trading conditions unchanged.

## Checks
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
