### PR TITLE
Trim X7 long buyback v2 entry fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -45502,6 +45502,13 @@ class NostalgiaForInfinityX7(IStrategy):
   def long_buyback_entry_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_ema_12 = last_candle["EMA_12"]
+    last_ema_26 = last_candle["EMA_26"]
+    last_roc_9_1d = last_candle["ROC_9_1d"]
+    last_rsi_3 = last_candle["RSI_3"]
+    last_rsi_3_1h = last_candle["RSI_3_1h"]
+    last_rsi_3_4h = last_candle["RSI_3_4h"]
+
     last_close = last_candle["close"]
     last_rsi_14 = last_candle["RSI_14"]
     last_rsi_3_15m = last_candle["RSI_3_15m"]
@@ -45512,7 +45519,7 @@ class NostalgiaForInfinityX7(IStrategy):
       (last_candle["enter_long"] == True)
       or (
         (last_rsi_14 < 36.0)
-        and (last_candle["RSI_3"] > 20.0)
+        and (last_rsi_3 > 20.0)
         and (last_rsi_3_15m > 20.0)
         # and (last_candle["RSI_3_1h"] > 20.0)
         # and (last_candle["RSI_3_4h"] > 20.0)
@@ -45535,33 +45542,33 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       or (
         (last_rsi_14 < 36.0)
-        and (last_candle["RSI_3"] > 5.0)
+        and (last_rsi_3 > 5.0)
         and (last_rsi_3_15m > 15.0)
-        and (last_candle["RSI_3_1h"] > 15.0)
-        and (last_candle["RSI_3_4h"] > 15.0)
+        and (last_rsi_3_1h > 15.0)
+        and (last_rsi_3_4h > 15.0)
         and (last_roc_2_1h > -5.0)
         and (last_roc_2_4h > -5.0)
         # and (last_candle["ROC_2_1d"] > -10.0)
         # and (last_candle["ROC_9_1h"] > -10.0)
         # and (last_candle["ROC_9_4h"] > -10.0)
-        and (last_candle["ROC_9_1d"] > -5.0)
-        and (last_candle["EMA_26"] > last_candle["EMA_12"])
-        and ((last_candle["EMA_26"] - last_candle["EMA_12"]) > (last_candle["open"] * 0.020))
+        and (last_roc_9_1d > -5.0)
+        and (last_ema_26 > last_ema_12)
+        and ((last_ema_26 - last_ema_12) > (last_candle["open"] * 0.020))
         and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_candle["open"] / 100.0))
       )
       or (
         (last_rsi_14 < 36.0)
-        and (last_candle["RSI_3"] > 10.0)
+        and (last_rsi_3 > 10.0)
         and (last_rsi_3_15m > 10.0)
-        and (last_candle["RSI_3_1h"] > 10.0)
-        and (last_candle["RSI_3_4h"] > 10.0)
+        and (last_rsi_3_1h > 10.0)
+        and (last_rsi_3_4h > 10.0)
         and (last_candle["RSI_3_1d"] > 10.0)
         and (last_roc_2_1h > -5.0)
         and (last_roc_2_4h > -5.0)
         and (last_candle["ROC_2_1d"] > -5.0)
         and (last_candle["ROC_9_1h"] > -5.0)
         and (last_candle["ROC_9_4h"] > -5.0)
-        and (last_candle["ROC_9_1d"] > -10.0)
+        and (last_roc_9_1d > -10.0)
         # and (last_candle["ROC_9_4h"] < 40.0)
         # and (last_candle["ROC_9_1d"] < 50.0)
         and (last_candle["AROONU_14_15m"] < 25.0)
@@ -45569,26 +45576,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_candle["high_max_6_1h"] * 0.85))
         and (last_close > (last_candle["high_max_12_1h"] * 0.80))
         # and (last_candle["close"] < (last_candle["low_min_24_4h"] * 1.20))
-        and (last_close < (last_candle["EMA_12"] * 0.980))
+        and (last_close < (last_ema_12 * 0.980))
       )
       or (
         (last_rsi_14 < 36.0)
         and (last_rsi_3_15m > 10.0)
-        and (last_candle["RSI_3_1h"] > 10.0)
-        and (last_candle["RSI_3_4h"] > 10.0)
+        and (last_rsi_3_1h > 10.0)
+        and (last_rsi_3_4h > 10.0)
         and (last_candle["RSI_3_1d"] > 10.0)
         and (last_roc_2_1h > -5.0)
         and (last_roc_2_4h > -5.0)
         # and (last_candle["ROC_2_1d"] > -5.0)
         and (last_candle["ROC_9_1h"] > -5.0)
         and (last_candle["ROC_9_4h"] > -5.0)
-        and (last_candle["ROC_9_1d"] > -5.0)
+        and (last_roc_9_1d > -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         # and (last_candle["close"] > (last_candle["close_max_48"] * 0.90))
         # and (last_candle["close"] > (last_candle["high_max_6_1h"] * 0.85))
         # and (last_candle["close"] > (last_candle["high_max_12_1h"] * 0.80))
-        and (last_close < (last_candle["EMA_26"] * 0.960))
+        and (last_close < (last_ema_26 * 0.960))
         and (last_close < (last_candle["BBL_20_2.0"] * 0.999))
       )
     ):


### PR DESCRIPTION
## Summary
- Reuse repeated long buyback v2 candle fields as local variables before evaluating the existing entry conditions.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same Series values are read once per call and reused; condition order and thresholds stay unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required for this patch because it only reuses local references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`