### PR TITLE
Trim X7 short buyback v2 entry fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -71556,6 +71556,11 @@ class NostalgiaForInfinityX7(IStrategy):
   def short_buyback_entry_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_ema_12 = last_candle["EMA_12"]
+    last_ema_26 = last_candle["EMA_26"]
+    last_roc_9_1d = last_candle["ROC_9_1d"]
+    last_rsi_3 = last_candle["RSI_3"]
+
     last_close = last_candle["close"]
     last_rsi_14 = last_candle["RSI_14"]
     last_rsi_3_15m = last_candle["RSI_3_15m"]
@@ -71568,7 +71573,7 @@ class NostalgiaForInfinityX7(IStrategy):
       (last_candle["enter_short"] == True)
       or (
         (last_rsi_14 > 64.0)
-        and (last_candle["RSI_3"] < 80.0)
+        and (last_rsi_3 < 80.0)
         and (last_rsi_3_15m < 70.0)
         and (last_rsi_3_1h < 70.0)
         and (last_rsi_3_4h < 70.0)
@@ -71591,7 +71596,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       or (
         (last_rsi_14 > 64.0)
-        and (last_candle["RSI_3"] < 95.0)
+        and (last_rsi_3 < 95.0)
         and (last_rsi_3_15m < 85.0)
         and (last_rsi_3_1h < 85.0)
         and (last_rsi_3_4h < 85.0)
@@ -71600,14 +71605,14 @@ class NostalgiaForInfinityX7(IStrategy):
         # and (last_candle["ROC_2_1d"] > -10.0)
         # and (last_candle["ROC_9_1h"] > -10.0)
         # and (last_candle["ROC_9_4h"] > -10.0)
-        and (last_candle["ROC_9_1d"] < 5.0)
-        and (last_candle["EMA_12"] > last_candle["EMA_26"])
-        and ((last_candle["EMA_12"] - last_candle["EMA_26"]) > (last_candle["open"] * 0.020))
+        and (last_roc_9_1d < 5.0)
+        and (last_ema_12 > last_ema_26)
+        and ((last_ema_12 - last_ema_26) > (last_candle["open"] * 0.020))
         and ((previous_candle["EMA_12"] - previous_candle["EMA_26"]) > (last_candle["open"] / 100.0))
       )
       or (
         (last_rsi_14 > 64.0)
-        and (last_candle["RSI_3"] < 90.0)
+        and (last_rsi_3 < 90.0)
         and (last_rsi_3_15m < 90.0)
         and (last_rsi_3_1h < 90.0)
         and (last_rsi_3_4h < 90.0)
@@ -71617,7 +71622,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["ROC_2_1d"] < 5.0)
         and (last_candle["ROC_9_1h"] < 5.0)
         and (last_candle["ROC_9_4h"] < 5.0)
-        and (last_candle["ROC_9_1d"] < 10.0)
+        and (last_roc_9_1d < 10.0)
         # and (last_candle["ROC_9_4h"] < 40.0)
         # and (last_candle["ROC_9_1d"] < 50.0)
         and (last_candle["AROOND_14_15m"] < 25.0)
@@ -71625,7 +71630,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_candle["low_min_6_1h"] * 1.18))
         and (last_close < (last_candle["low_min_12_1h"] * 1.25))
         # and (last_candle["close"] < (last_candle["low_min_24_4h"] * 1.20))
-        and (last_close > (last_candle["EMA_12"] * 1.020))
+        and (last_close > (last_ema_12 * 1.020))
       )
       or (
         (last_rsi_14 < 64.0)
@@ -71638,13 +71643,13 @@ class NostalgiaForInfinityX7(IStrategy):
         # and (last_candle["ROC_2_1d"] > -5.0)
         and (last_candle["ROC_9_1h"] < 5.0)
         and (last_candle["ROC_9_4h"] < 5.0)
-        and (last_candle["ROC_9_1d"] < 5.0)
+        and (last_roc_9_1d < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         # and (last_candle["close"] > (last_candle["close_max_48"] * 0.90))
         # and (last_candle["close"] < (last_candle["low_min_6_1h"] * 1.18))
         # and (last_candle["close"] < (last_candle["low_min_12_1h"] * 1.25))
-        and (last_close > (last_candle["EMA_26"] * 1.040))
+        and (last_close > (last_ema_26 * 1.040))
         and (last_close > (last_candle["BBU_20_2.0"] * 1.001))
       )
     ):


### PR DESCRIPTION
## Summary
- Reuse repeated short buyback v2 candle fields as local variables before evaluating the existing entry conditions.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same Series values are read once per call and reused; condition order and thresholds stay unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required for this patch because it only reuses local references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`