### PR TITLE
Trim X7 long regular grind-entry fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -49907,6 +49907,13 @@ class NostalgiaForInfinityX7(IStrategy):
   def long_grind_entry(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_aroonu_14 = last_candle["AROONU_14"]
+    last_aroonu_14_15m = last_candle["AROONU_14_15m"]
+    last_rsi_14_1h = last_candle["RSI_14_1h"]
+    last_rsi_14_4h = last_candle["RSI_14_4h"]
+    previous_ema_12 = previous_candle["EMA_12"]
+    previous_ema_26 = previous_candle["EMA_26"]
+
     last_rsi_14 = last_candle["RSI_14"]
     last_rsi_3_15m = last_candle["RSI_3_15m"]
     last_rsi_3_1h = last_candle["RSI_3_1h"]
@@ -49928,7 +49935,7 @@ class NostalgiaForInfinityX7(IStrategy):
           (last_rsi_14 < 36.0)
           and (last_rsi_3 > 10.0)
           and (last_rsi_3_15m > 10.0)
-          and (last_candle["AROONU_14"] < 25.0)
+          and (last_aroonu_14 < 25.0)
           and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
           and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
           and (last_close < (last_candle["EMA_16"] * 0.980))
@@ -49940,7 +49947,7 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_4h > 5.0)
           and (last_ema_26 > last_ema_12)
           and ((last_ema_26 - last_ema_12) > (last_open * 0.030))
-          and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_open / 100.0))
+          and ((previous_ema_26 - previous_ema_12) > (last_open / 100.0))
         )
         or (
           (last_rsi_14 < 36.0)
@@ -49950,12 +49957,12 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_4h > 10.0)
           and (last_ema_26 > last_ema_12)
           and ((last_ema_26 - last_ema_12) > (last_open * 0.020))
-          and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_open / 100.0))
+          and ((previous_ema_26 - previous_ema_12) > (last_open / 100.0))
         )
         or (
           (last_rsi_14 < 36.0)
           and (last_rsi_3 > 16.0)
-          and (last_candle["AROONU_14_15m"] < 25.0)
+          and (last_aroonu_14_15m < 25.0)
           and (last_close < (last_ema_12 * 0.984))
         )
         or (
@@ -49972,9 +49979,9 @@ class NostalgiaForInfinityX7(IStrategy):
           (last_rsi_14 < 36.0)
           and (last_rsi_3_1h > 20.0)
           and (last_rsi_3_4h > 20.0)
-          and (last_candle["RSI_14_1h"] < 80.0)
-          and (last_candle["RSI_14_4h"] < 60.0)
-          and (last_candle["AROONU_14"] > last_candle["AROOND_14"])
+          and (last_rsi_14_1h < 80.0)
+          and (last_rsi_14_4h < 60.0)
+          and (last_aroonu_14 > last_candle["AROOND_14"])
           and (previous_candle["AROONU_14"] < previous_candle["AROOND_14"])
         )
         or (
@@ -49982,8 +49989,8 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_15m > 15.0)
           and (last_rsi_3_1h > 20.0)
           and (last_rsi_3_4h > 20.0)
-          and (last_candle["RSI_14_1h"] < 80.0)
-          and (last_candle["RSI_14_4h"] < 60.0)
+          and (last_rsi_14_1h < 80.0)
+          and (last_rsi_14_4h < 60.0)
           and (last_candle["KST_10_15_20_30_10_10_10_15"] > last_candle["KSTs_9"])
           and (previous_candle["KST_10_15_20_30_10_10_10_15"] < previous_candle["KSTs_9"])
         )
@@ -49994,8 +50001,8 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_1h > 20.0)
           and (last_rsi_3_4h > 20.0)
           and (last_rsi_14 < 36.0)
-          and (last_candle["AROONU_14"] < 25.0)
-          and (last_candle["AROONU_14_15m"] < 25.0)
+          and (last_aroonu_14 < 25.0)
+          and (last_aroonu_14_15m < 25.0)
           and (last_candle["STOCHRSIk_14_14_3_3_15m"] < 50.0)
           and (last_close < (last_candle["EMA_20"] * 0.980))
         )


### PR DESCRIPTION
## Summary
- Reuse repeated long regular grind-entry candle fields around the existing condition ladder.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The patch keeps the regular grind-entry thresholds and ordering intact and avoids the active v3 grind-entry area.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required for this patch because it only reuses local references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`