### PR TITLE
Trim X7 short regular grind-entry fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -75580,6 +75580,13 @@ class NostalgiaForInfinityX7(IStrategy):
   def short_grind_entry(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_aroond_14 = last_candle["AROOND_14"]
+    last_aroond_14_15m = last_candle["AROOND_14_15m"]
+    last_rsi_14_1h = last_candle["RSI_14_1h"]
+    last_rsi_14_4h = last_candle["RSI_14_4h"]
+    previous_ema_12 = previous_candle["EMA_12"]
+    previous_ema_26 = previous_candle["EMA_26"]
+
     last_rsi_14 = last_candle["RSI_14"]
     last_rsi_3_15m = last_candle["RSI_3_15m"]
     last_rsi_3_1h = last_candle["RSI_3_1h"]
@@ -75601,7 +75608,7 @@ class NostalgiaForInfinityX7(IStrategy):
           (last_rsi_14 > 64.0)
           and (last_rsi_3 < 90.0)
           and (last_rsi_3_15m < 90.0)
-          and (last_candle["AROOND_14"] < 25.0)
+          and (last_aroond_14 < 25.0)
           and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
           and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
           and (last_close > (last_candle["EMA_16"] * 1.020))
@@ -75613,7 +75620,7 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_4h < 95.0)
           and (last_ema_12 > last_ema_26)
           and ((last_ema_12 - last_ema_26) > (last_open * 0.030))
-          and ((previous_candle["EMA_12"] - previous_candle["EMA_26"]) > (last_open / 100.0))
+          and ((previous_ema_12 - previous_ema_26) > (last_open / 100.0))
         )
         or (
           (last_rsi_14 > 64.0)
@@ -75623,12 +75630,12 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_4h < 90.0)
           and (last_ema_12 > last_ema_26)
           and ((last_ema_12 - last_ema_26) > (last_open * 0.020))
-          and ((previous_candle["EMA_12"] - previous_candle["EMA_26"]) > (last_open / 100.0))
+          and ((previous_ema_12 - previous_ema_26) > (last_open / 100.0))
         )
         or (
           (last_rsi_14 > 64.0)
           and (last_rsi_3 < 84.0)
-          and (last_candle["AROOND_14_15m"] < 25.0)
+          and (last_aroond_14_15m < 25.0)
           and (last_close > (last_ema_12 * 1.016))
         )
         or (
@@ -75645,9 +75652,9 @@ class NostalgiaForInfinityX7(IStrategy):
           (last_rsi_14 > 64.0)
           and (last_rsi_3_1h < 80.0)
           and (last_rsi_3_4h < 80.0)
-          and (last_candle["RSI_14_1h"] > 20.0)
-          and (last_candle["RSI_14_4h"] > 40.0)
-          and (last_candle["AROONU_14"] < last_candle["AROOND_14"])
+          and (last_rsi_14_1h > 20.0)
+          and (last_rsi_14_4h > 40.0)
+          and (last_candle["AROONU_14"] < last_aroond_14)
           and (previous_candle["AROONU_14"] > previous_candle["AROOND_14"])
         )
         or (
@@ -75655,8 +75662,8 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_15m < 85.0)
           and (last_rsi_3_1h < 80.0)
           and (last_rsi_3_4h < 80.0)
-          and (last_candle["RSI_14_1h"] > 20.0)
-          and (last_candle["RSI_14_4h"] > 40.0)
+          and (last_rsi_14_1h > 20.0)
+          and (last_rsi_14_4h > 40.0)
           and (last_candle["KST_10_15_20_30_10_10_10_15"] < last_candle["KSTs_9"])
           and (previous_candle["KST_10_15_20_30_10_10_10_15"] > previous_candle["KSTs_9"])
         )
@@ -75667,8 +75674,8 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_rsi_3_1h < 80.0)
           and (last_rsi_3_4h < 80.0)
           and (last_rsi_14 > 64.0)
-          and (last_candle["AROOND_14"] < 25.0)
-          and (last_candle["AROOND_14_15m"] < 25.0)
+          and (last_aroond_14 < 25.0)
+          and (last_aroond_14_15m < 25.0)
           and (last_candle["STOCHRSIk_14_14_3_3_15m"] > 50.0)
           and (last_close > (last_candle["EMA_20"] * 1.020))
         )


### PR DESCRIPTION
## Summary
- Reuse repeated short regular grind-entry candle fields around the existing condition ladder.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The patch keeps the regular grind-entry thresholds and ordering intact and avoids the active v3 grind-entry area.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required for this patch because it only reuses local references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`