### PR TITLE
Trim X7 long exit target helpers

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -25872,6 +25872,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     mode_name = self.long_normal_mode_name
 
     sell = False
@@ -25986,7 +25990,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_sell_reason = target_data["sell_reason"]
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode_name,
         pair,
         trade,
@@ -26008,7 +26012,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"{signal_name_max}_m"
       if previous_sell_reason == f"exit_{mode_name}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode_name,
             pair,
             True,
@@ -26021,12 +26025,12 @@ class NostalgiaForInfinityX7(IStrategy):
             previous_candle_1,
           )
           if mark_pair:
-            self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
+            set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
       elif (profit_init_ratio > (previous_profit + 0.001)) and (
         previous_sell_reason != f"exit_{mode_name}_stoploss_doom"
       ):
         # Update the target, raise it.
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           True,
@@ -26039,7 +26043,7 @@ class NostalgiaForInfinityX7(IStrategy):
           previous_candle_1,
         )
         if mark_pair:
-          self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
@@ -26059,7 +26063,7 @@ class NostalgiaForInfinityX7(IStrategy):
           f"exit_profit_{mode_name}_stoploss_u_e",
         ]
       ):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26072,12 +26076,12 @@ class NostalgiaForInfinityX7(IStrategy):
           previous_candle_1,
         )
         if mark_pair:
-          self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
         else:
           # Just sell it, without maximize
           return True, f"{signal_name}"
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26090,7 +26094,7 @@ class NostalgiaForInfinityX7(IStrategy):
           previous_candle_1,
         )
         if mark_pair:
-          self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
         else:
           # Just sell it, without maximize
           return True, f"{signal_name}"
@@ -26102,7 +26106,7 @@ class NostalgiaForInfinityX7(IStrategy):
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{mode_name}_max"
-          self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in [
       f"exit_profit_{mode_name}_max",
@@ -26141,6 +26145,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     mode_name = self.long_pump_mode_name
 
     sell = False
@@ -26218,7 +26226,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode_name,
         pair,
         trade,
@@ -26242,7 +26250,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if previous_sell_reason == stoploss_ue:
         if profit_ratio > (previous_profit + 0.005):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode_name,
             pair,
             True,
@@ -26256,7 +26264,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
 
           if mark_pair:
-            self._set_profit_target(
+            set_profit_target(
               pair,
               mark_signal,
               current_rate,
@@ -26265,7 +26273,7 @@ class NostalgiaForInfinityX7(IStrategy):
             )
 
       elif profit_init_ratio > (previous_profit + 0.001) and previous_sell_reason != stoploss_doom:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           True,
@@ -26279,7 +26287,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26292,7 +26300,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_profit = target_data["profit"] if target_data else None
 
       if signal_name in (stoploss_doom, stoploss_ue):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26306,7 +26314,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26318,7 +26326,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, signal_name
 
       elif previous_profit is None or previous_profit < profit_init_ratio:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26332,7 +26340,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26348,7 +26356,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_profit = target_data["profit"] if target_data else None
 
       if previous_profit is None or previous_profit < profit_init_ratio:
-        self._set_profit_target(
+        set_profit_target(
           pair,
           max_signal,
           current_rate,
@@ -26387,6 +26395,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     mode_name = self.long_quick_mode_name
 
     sell = False
@@ -26504,7 +26516,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode_name,
         pair,
         trade,
@@ -26528,7 +26540,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if previous_sell_reason == stoploss_ue:
         if profit_ratio > (previous_profit + 0.001):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode_name,
             pair,
             True,
@@ -26542,7 +26554,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
 
           if mark_pair:
-            self._set_profit_target(
+            set_profit_target(
               pair,
               mark_signal,
               current_rate,
@@ -26551,7 +26563,7 @@ class NostalgiaForInfinityX7(IStrategy):
             )
 
       elif profit_init_ratio > (previous_profit + 0.001) and previous_sell_reason != stoploss_doom:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           True,
@@ -26565,7 +26577,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26584,7 +26596,7 @@ class NostalgiaForInfinityX7(IStrategy):
         stoploss_doom,
         f"exit_profit_{mode_name}_stoploss_u_e",
       ):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26598,7 +26610,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26610,7 +26622,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, signal_name
 
       elif previous_profit is None or previous_profit < profit_init_ratio:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26624,7 +26636,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26642,7 +26654,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_profit = target_data["profit"] if target_data else None
 
       if previous_profit is None or previous_profit < profit_init_ratio:
-        self._set_profit_target(
+        set_profit_target(
           pair,
           profit_max_signal,
           current_rate,
@@ -26691,6 +26703,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     mode_name = self.long_rebuy_mode_name
     stoploss_doom = f"exit_{mode_name}_stoploss_doom"
     stoploss_u_e = f"exit_{mode_name}_stoploss_u_e"
@@ -26783,7 +26799,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_sell_reason = target_data["sell_reason"]
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode_name,
         pair,
         trade,
@@ -26807,7 +26823,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if previous_sell_reason == stoploss_u_e:
         if profit_ratio > (previous_profit + 0.001):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode_name,
             pair,
             True,
@@ -26821,7 +26837,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
 
           if mark_pair:
-            self._set_profit_target(
+            set_profit_target(
               pair,
               mark_signal,
               current_rate,
@@ -26830,7 +26846,7 @@ class NostalgiaForInfinityX7(IStrategy):
             )
 
       elif profit_init_ratio > (previous_profit + 0.001) and previous_sell_reason != stoploss_doom:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           True,
@@ -26844,7 +26860,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26857,7 +26873,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_profit = target_data["profit"] if target_data else None
 
       if signal_name in (stoploss_doom, stoploss_u_e):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26871,7 +26887,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26882,7 +26898,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, signal_name
 
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -26896,7 +26912,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -26911,7 +26927,7 @@ class NostalgiaForInfinityX7(IStrategy):
         previous_profit = target_data["profit"] if target_data else None
 
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          self._set_profit_target(
+          set_profit_target(
             pair,
             profit_max,
             current_rate,
@@ -26955,6 +26971,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     mode_name = self.long_high_profit_mode_name
 
     stoploss_doom = f"exit_{mode_name}_stoploss_doom"
@@ -27027,7 +27047,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_sell_reason = target_data["sell_reason"]
       previous_time_profit_reached = datetime.fromisoformat(target_data["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode_name,
         pair,
         trade,
@@ -27051,7 +27071,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if previous_sell_reason == stoploss_u_e:
         if profit_ratio > (previous_profit + 0.001):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode_name,
             pair,
             True,
@@ -27065,7 +27085,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
 
           if mark_pair:
-            self._set_profit_target(
+            set_profit_target(
               pair,
               mark_signal,
               current_rate,
@@ -27074,7 +27094,7 @@ class NostalgiaForInfinityX7(IStrategy):
             )
 
       elif profit_init_ratio > (previous_profit + 0.001) and previous_sell_reason != stoploss_doom:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           True,
@@ -27088,7 +27108,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27101,7 +27121,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_profit = target_data["profit"] if target_data else None
 
       if signal_name in (stoploss_doom, stoploss_u_e):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -27115,7 +27135,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27126,7 +27146,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, signal_name
 
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode_name,
           pair,
           sell,
@@ -27140,7 +27160,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27155,7 +27175,7 @@ class NostalgiaForInfinityX7(IStrategy):
         previous_profit = target_data["profit"] if target_data else None
 
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
-          self._set_profit_target(
+          set_profit_target(
             pair,
             profit_max,
             current_rate,
@@ -27198,6 +27218,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     is_backtest = self.is_backtest_mode()
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
 
@@ -27320,7 +27344,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_sell_reason = pair_cache["sell_reason"]
       previous_time_profit_reached = datetime.fromisoformat(pair_cache["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode,
         pair,
         trade,
@@ -27344,7 +27368,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if previous_sell_reason == f"exit_{mode}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.001):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode,
             pair,
             True,
@@ -27358,7 +27382,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
 
           if mark_pair:
-            self._set_profit_target(
+            set_profit_target(
               pair,
               mark_signal,
               current_rate,
@@ -27367,7 +27391,7 @@ class NostalgiaForInfinityX7(IStrategy):
             )
 
       elif profit_init_ratio > (previous_profit + 0.001) and previous_sell_reason != f"exit_{mode}_stoploss_doom":
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           True,
@@ -27381,7 +27405,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27405,7 +27429,7 @@ class NostalgiaForInfinityX7(IStrategy):
       }
 
       if signal_name in protected_signals and previous_sell_reason not in blocked_previous_signals:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           sell,
@@ -27419,7 +27443,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27430,7 +27454,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return True, signal_name
 
       elif previous_profit is None or previous_profit < profit_init_ratio:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           sell,
@@ -27444,7 +27468,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27458,7 +27482,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_profit = pair_cache["profit"] if pair_cache else None
 
       if previous_profit is None or previous_profit < profit_init_ratio:
-        self._set_profit_target(
+        set_profit_target(
           pair,
           f"exit_profit_{mode}_max",
           current_rate,
@@ -27563,6 +27587,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     mode = self.long_top_coins_mode_name
 
     cache = self.target_profit_cache
@@ -27632,7 +27660,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_sell_reason = pair_cache["sell_reason"]
       previous_time_profit_reached = datetime.fromisoformat(pair_cache["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode,
         pair,
         trade,
@@ -27656,7 +27684,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if previous_sell_reason == f"exit_{mode}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode,
             pair,
             True,
@@ -27670,7 +27698,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
 
           if mark_pair:
-            self._set_profit_target(
+            set_profit_target(
               pair,
               mark_signal,
               current_rate,
@@ -27679,7 +27707,7 @@ class NostalgiaForInfinityX7(IStrategy):
             )
 
       elif profit_init_ratio > (previous_profit + 0.001) and previous_sell_reason != f"exit_{mode}_stoploss_doom":
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           True,
@@ -27693,7 +27721,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27723,7 +27751,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
 
       if should_mark:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           sell,
@@ -27737,7 +27765,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(
+          set_profit_target(
             pair,
             mark_signal,
             current_rate,
@@ -27751,7 +27779,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_profit = pair_cache["profit"] if pair_cache else None
 
       if previous_profit is None or previous_profit < profit_init_ratio:
-        self._set_profit_target(
+        set_profit_target(
           pair,
           f"exit_profit_{mode}_max",
           current_rate,
@@ -27795,6 +27823,10 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    mark_profit_target = self.mark_profit_target
+    set_profit_target = self._set_profit_target
+    exit_profit_target = self.exit_profit_target
+
     mode = self.long_scalp_mode_name
 
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
@@ -27883,7 +27915,7 @@ class NostalgiaForInfinityX7(IStrategy):
       previous_sell_reason = pair_data["sell_reason"]
       previous_time_profit_reached = datetime.fromisoformat(pair_data["time_profit_reached"])
 
-      sell_max, signal_name_max = self.exit_profit_target(
+      sell_max, signal_name_max = exit_profit_target(
         mode,
         pair,
         trade,
@@ -27907,7 +27939,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if previous_sell_reason == f"exit_{mode}_stoploss_u_e":
         if profit_ratio > (previous_profit + 0.005):
-          mark_pair, mark_signal = self.mark_profit_target(
+          mark_pair, mark_signal = mark_profit_target(
             mode,
             pair,
             True,
@@ -27921,11 +27953,11 @@ class NostalgiaForInfinityX7(IStrategy):
           )
 
           if mark_pair:
-            self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
+            set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
 
       elif profit_init_ratio > (previous_profit + 0.001) and previous_sell_reason != f"exit_{mode}_stoploss_doom":
         # Update the target, raise it.
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           True,
@@ -27939,7 +27971,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
@@ -27949,7 +27981,7 @@ class NostalgiaForInfinityX7(IStrategy):
         f"exit_{mode}_stoploss_doom",
         f"exit_{mode}_stoploss_u_e",
       }:
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           sell,
@@ -27963,13 +27995,13 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_ratio, current_time)
         else:
           # Just sell it, without maximize
           return True, f"{signal_name}"
 
       elif (previous_profit is None) or (previous_profit < profit_init_ratio):
-        mark_pair, mark_signal = self.mark_profit_target(
+        mark_pair, mark_signal = mark_profit_target(
           mode,
           pair,
           sell,
@@ -27983,7 +28015,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
         if mark_pair:
-          self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
         else:
           # Just sell it, without maximize
           return True, f"{signal_name}"
@@ -27994,7 +28026,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
           mark_signal = f"exit_profit_{mode}_max"
-          self._set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
+          set_profit_target(pair, mark_signal, current_rate, profit_init_ratio, current_time)
 
     if signal_name not in {
       f"exit_profit_{mode}_max",


### PR DESCRIPTION
## Summary
- Reuse repeated profit-target helper method lookups across the long exit wrappers.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- Bound helper methods are cached locally per call; exit target inputs, signal names, and profit arithmetic are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required for this patch because it only reuses local references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`