### PR TITLE
Cache X7 order-filled version lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -2599,13 +2599,19 @@ class NostalgiaForInfinityX7(IStrategy):
   # ---------------------------------------------------------------------------------------------
   def order_filled(self, pair: str, trade: Trade, order: Order, current_time: datetime, **kwargs) -> None:
     # Check if it's the first entry
+    system_name_use = self.system_name_use
+    system_v3_2_name = self.system_v3_2_name
+    system_v3_1_name = self.system_v3_1_name
+    system_v3_name = self.system_v3_name
+    set_custom_data = trade.set_custom_data
+
     if trade.nr_of_successful_entries == 1:
-      if self.system_name_use == self.system_v3_2_name:
-        trade.set_custom_data(key="system_version", value=self.system_v3_2_name)
-      elif self.system_name_use == self.system_v3_1_name:
-        trade.set_custom_data(key="system_version", value=self.system_v3_1_name)
-      elif self.system_name_use == self.system_v3_name:
-        trade.set_custom_data(key="system_version", value=self.system_v3_name)
+      if system_name_use == system_v3_2_name:
+        set_custom_data(key="system_version", value=system_v3_2_name)
+      elif system_name_use == system_v3_1_name:
+        set_custom_data(key="system_version", value=system_v3_1_name)
+      elif system_name_use == system_v3_name:
+        set_custom_data(key="system_version", value=system_v3_name)
     return None
 
   # Adjust Trade Position


### PR DESCRIPTION
## Summary
- Reuse repeated system-version attributes in order_filled.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same system_version values are written under the same first-entry condition.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required because this patch only caches local attributes, methods, or Series references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`