### PR TITLE
Cache X7 hold-trade data access

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12227,6 +12227,10 @@ class NostalgiaForInfinityX7(IStrategy):
   # Should Hold Trade
   # ---------------------------------------------------------------------------------------------
   def _should_hold_trade(self, trade: "Trade", rate: float, sell_reason: str) -> bool:
+    calc_total_profit = self.calc_total_profit
+    trade_id = trade.id
+    trade_pair = trade.pair
+
     if self.config["runmode"].value not in ("live", "dry_run"):
       return False
 
@@ -12236,11 +12240,13 @@ class NostalgiaForInfinityX7(IStrategy):
     # Just to be sure our hold data is loaded, should be a no-op call after the first bot loop
     self.load_hold_trades_config()
 
-    if not self.hold_trades_cache:
+    hold_trades_cache = self.hold_trades_cache
+    if not hold_trades_cache:
       # Cache hasn't been setup, likely because the corresponding file does not exist, sell
       return False
 
-    if not self.hold_trades_cache.data:
+    hold_trades_data = hold_trades_cache.data
+    if not hold_trades_data:
       # We have no pairs we want to hold until profit, sell
       return False
 
@@ -12253,13 +12259,13 @@ class NostalgiaForInfinityX7(IStrategy):
       if profit_values is None:
         filled_entries = trade.select_filled_orders(trade.entry_side)
         filled_exits = trade.select_filled_orders(trade.exit_side)
-        profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, rate)
+        profit_values = calc_total_profit(trade, filled_entries, filled_exits, rate)
 
       return profit_values
 
-    trade_ids: dict = self.hold_trades_cache.data.get("trade_ids")
-    if trade_ids and trade.id in trade_ids:
-      trade_profit_ratio = trade_ids[trade.id]
+    trade_ids: dict = hold_trades_data.get("trade_ids")
+    if trade_ids and trade_id in trade_ids:
+      trade_profit_ratio = trade_ids[trade_id]
       current_profit_ratio = get_profit_values()[3]
       if sell_reason == "force_sell":
         formatted_profit_ratio = f"{trade_profit_ratio * 100}%"
@@ -12286,9 +12292,9 @@ class NostalgiaForInfinityX7(IStrategy):
       # This pair is on the list to hold, and we haven't reached minimum profit, hold
       hold_trade = True
 
-    trade_pairs: dict = self.hold_trades_cache.data.get("trade_pairs")
-    if trade_pairs and trade.pair in trade_pairs:
-      trade_profit_ratio = trade_pairs[trade.pair]
+    trade_pairs: dict = hold_trades_data.get("trade_pairs")
+    if trade_pairs and trade_pair in trade_pairs:
+      trade_profit_ratio = trade_pairs[trade_pair]
       current_profit_ratio = get_profit_values()[3]
       if sell_reason == "force_sell":
         formatted_profit_ratio = f"{trade_profit_ratio * 100}%"


### PR DESCRIPTION
## Summary
- Reuse hold-trade cache data and trade identifiers in _should_hold_trade.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- Hold configuration lookups and profit checks are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required because this patch only caches local attributes, methods, or Series references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`