### PR TITLE
Cache X7 hold loader state

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12215,14 +12215,16 @@ class NostalgiaForInfinityX7(IStrategy):
   # Load Hold Trades Config
   # ---------------------------------------------------------------------------------------------
   def load_hold_trades_config(self):
-    if self.hold_trades_cache is None:
+    hold_trades_cache = self.hold_trades_cache
+    if hold_trades_cache is None:
       hold_trades_config_file = self.get_hold_trades_config_file()
       if hold_trades_config_file:
         log.warning("Loading hold support data from %s", hold_trades_config_file)
-        self.hold_trades_cache = HoldsCache(hold_trades_config_file)
+        hold_trades_cache = HoldsCache(hold_trades_config_file)
+        self.hold_trades_cache = hold_trades_cache
 
-    if self.hold_trades_cache:
-      self.hold_trades_cache.load()
+    if hold_trades_cache:
+      hold_trades_cache.load()
 
   # Should Hold Trade
   # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reuse the hold-trades cache reference during load setup.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The cache is created, stored, and loaded under the same conditions.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required because this patch only caches local attributes, methods, or Series references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`