### PR TITLE
Tighten X7 cache load path

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -77578,15 +77578,19 @@ class Cache:
 
   def _load(self):
     # This method only exists to simplify unit testing
-    with self.path.open("r") as rfh:
+    cache_path = self.path
+    rapidjson_load_kwargs = self.rapidjson_load_kwargs
+    process_loaded_data = self.process_loaded_data
+
+    with cache_path.open("r") as rfh:
       try:
-        data = rapidjson.load(rfh, **self.rapidjson_load_kwargs())
+        data = rapidjson.load(rfh, **rapidjson_load_kwargs())
       except rapidjson.JSONDecodeError as exc:
-        log.error("Failed to load JSON from %s: %s", self.path, exc)
+        log.error("Failed to load JSON from %s: %s", cache_path, exc)
       else:
-        self.data = self.process_loaded_data(data)
+        self.data = process_loaded_data(data)
         self._previous_data = copy.deepcopy(self.data)
-        self._mtime = self.path.stat().st_mtime_ns
+        self._mtime = cache_path.stat().st_mtime_ns
 
   def _save(self):
     # This method only exists to simplify unit testing


### PR DESCRIPTION
## Summary
- Reuse cache path and helper methods in Cache._load.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- JSON loading, error handling, mtime update, and loaded data processing are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required because this patch only caches local attributes, methods, or Series references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`