### PR TITLE
Tighten X7 cache save path

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -77590,9 +77590,13 @@ class Cache:
 
   def _save(self):
     # This method only exists to simplify unit testing
-    rapidjson.dump(self.data, self.path.open("w"), **self.rapidjson_dump_kwargs())
-    self._mtime = self.path.stat().st_mtime
-    self._previous_data = copy.deepcopy(self.data)
+    cache_path = self.path
+    cache_data = self.data
+    rapidjson_dump_kwargs = self.rapidjson_dump_kwargs
+
+    rapidjson.dump(cache_data, cache_path.open("w"), **rapidjson_dump_kwargs())
+    self._mtime = cache_path.stat().st_mtime
+    self._previous_data = copy.deepcopy(cache_data)
 
 
 class HoldsCache(Cache):


### PR DESCRIPTION
## Summary
- Reuse cache path, data, and dump helper in Cache._save.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- JSON dump arguments, mtime update, and previous-data copy are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required because this patch only caches local attributes, methods, or Series references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`