### PR TITLE
Reduce X7 short v3 rebuy lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -77263,13 +77263,19 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ) -> Optional[float]:
     # min/max stakes include leverage. The return amounts is before leverage.
-    min_stake /= trade.leverage
+    dp = self.dp
+    is_futures_mode = self.is_futures_mode
+    trade_pair = trade.pair
+    trade_amount = trade.amount
+    trade_leverage = trade.leverage
+
+    min_stake /= trade_leverage
     # we already waiting for an order to get filled
     if trade.has_open_orders:
       return None
 
-    max_stake /= trade.leverage
-    df, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
+    max_stake /= trade_leverage
+    df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
     if len(df) < 2:
       return None
     last_candle = df.iloc[-1]
@@ -77287,8 +77293,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
     has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
-    if self.dp.runmode.value in ("live", "dry_run"):
-      ticker = self.dp.ticker(trade.pair)
+    if dp.runmode.value in ("live", "dry_run"):
+      ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
         exit_price_side = self.config["exit_pricing"]["price_side"]
         if trade.is_short:
@@ -77311,17 +77317,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
     )
 
-    current_stake_amount = trade.amount * current_rate
-    stake_scale_leverage = trade.leverage if self.is_futures_mode else 1.0
+    current_stake_amount = trade_amount * current_rate
+    stake_scale_leverage = trade_leverage if is_futures_mode else 1.0
 
     rebuy_mode_stakes = (
-      self.system_v3_rebuy_mode_stakes_futures if self.is_futures_mode else self.system_v3_rebuy_mode_stakes_spot
+      self.system_v3_rebuy_mode_stakes_futures if is_futures_mode else self.system_v3_rebuy_mode_stakes_spot
     )
     max_sub_grinds = len(rebuy_mode_stakes)
     rebuy_mode_sub_thresholds = (
-      self.system_v3_rebuy_mode_thresholds_futures
-      if self.is_futures_mode
-      else self.system_v3_rebuy_mode_thresholds_spot
+      self.system_v3_rebuy_mode_thresholds_futures if is_futures_mode else self.system_v3_rebuy_mode_thresholds_spot
     )
     partial_sell = False
     sub_grind_count = 0
@@ -77359,16 +77363,16 @@ class NostalgiaForInfinityX7(IStrategy):
           and (last_candle["close"] < (last_candle["EMA_26"] * 1.012))
         )
       ):
-        buy_amount = slice_amount * rebuy_mode_stakes[sub_grind_count] / trade.leverage
+        buy_amount = slice_amount * rebuy_mode_stakes[sub_grind_count] / trade_leverage
         if buy_amount < (min_stake * 1.5):
           buy_amount = min_stake * 1.5
         if buy_amount > max_stake:
           return None
-        self.dp.send_msg(
+        dp.send_msg(
           self.notification_msg(
             "rebuy",
             tag="r",
-            pair=trade.pair,
+            pair=trade_pair,
             rate=current_rate,
             stake_amount=buy_amount,
             profit_stake=profit_stake,


### PR DESCRIPTION
## Summary
- Reuse repeated trade and datapoint context in the short v3 rebuy adjust helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- No v3 grind-entry code is touched; rebuy amounts, derisk checks, and order returns are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest timing was not required because this patch only caches local attributes, methods, or Series references inside the same call. Indicators, candle selection, order selection/classification, profit arithmetic, date constants, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`