### PR TITLE
Reuse X7 trade order state reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1797,9 +1797,11 @@ class NostalgiaForInfinityX7(IStrategy):
     return filled_orders, filled_entries, filled_exits
 
   def trade_order_state(self, trade: "Trade") -> tuple:
-    last_order = trade.orders[-1] if trade.orders else None
+    orders = trade.orders
+
+    last_order = orders[-1] if orders else None
     return (
-      len(trade.orders),
+      len(orders),
       getattr(last_order, "id", None),
       getattr(last_order, "status", None),
       getattr(last_order, "filled", None),


### PR DESCRIPTION
## Summary
- Reuse the trade order list while building the lightweight order-state tuple.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same trade.orders sequence is read once and used for the existing tuple fields.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`