### PR TITLE
Hoist X7 informative merge helpers

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4269,6 +4269,8 @@ class NostalgiaForInfinityX7(IStrategy):
   # ---------------------------------------------------------------------------------------------
   def populate_indicators(self, df: DataFrame, metadata: dict) -> DataFrame:
     tik = time.perf_counter()
+    prepare_informative_merge = self.prepare_informative_merge
+    base_timeframe = self.timeframe
 
     # =========================================================================
     # CONFIG
@@ -4317,13 +4319,13 @@ class NostalgiaForInfinityX7(IStrategy):
       # REMOVE UNUSED OHLCV BEFORE MERGE
       # ---------------------------------------------------------------------
 
-      btc_informative = self.prepare_informative_merge(btc_informative)
+      btc_informative = prepare_informative_merge(btc_informative)
 
       # ---------------------------------------------------------------------
       # MERGE
       # ---------------------------------------------------------------------
 
-      df = merge_informative_pair(df, btc_informative, self.timeframe, btc_tf, ffill=False)
+      df = merge_informative_pair(df, btc_informative, base_timeframe, btc_tf, ffill=False)
 
       # ---------------------------------------------------------------------
       # CLEANUP
@@ -4374,13 +4376,13 @@ class NostalgiaForInfinityX7(IStrategy):
       else:
         keep_ohlcv = set()
 
-      info_indicators = self.prepare_informative_merge(info_indicators, keep_ohlcv)
+      info_indicators = prepare_informative_merge(info_indicators, keep_ohlcv)
 
       # ---------------------------------------------------------------------
       # MERGE
       # ---------------------------------------------------------------------
 
-      df = merge_informative_pair(df, info_indicators, self.timeframe, info_tf, ffill=False)
+      df = merge_informative_pair(df, info_indicators, base_timeframe, info_tf, ffill=False)
 
       # ---------------------------------------------------------------------
       # CLEANUP


### PR DESCRIPTION
## Summary
- Reuse the informative merge helper and base timeframe during populate_indicators.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- Informative dataframe selection, merge semantics, and indicator formulas are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`