### PR TITLE
Hoist X7 confirm-exit trade fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12096,6 +12096,12 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: datetime,
     **kwargs,
   ) -> bool:
+    trade_realized_profit = trade.realized_profit
+    trade_stake_amount = trade.stake_amount
+    trade_is_short = trade.is_short
+    trade_liquidation_price = trade.liquidation_price
+    trade_open_rate = trade.open_rate
+
     is_backtest = self.is_backtest_mode()
     # Allow force exits
     if exit_reason != "force_exit":
@@ -12105,18 +12111,18 @@ class NostalgiaForInfinityX7(IStrategy):
         # log.info(f"[{current_time}] Cancelling {exit_reason} exit for {pair}")
         is_liquidation = False
         if self.is_futures_mode and is_backtest:
-          if (trade.is_short and rate > trade.liquidation_price) or (
-            not trade.is_short and rate < trade.liquidation_price
+          if (trade_is_short and rate > trade_liquidation_price) or (
+            not trade_is_short and rate < trade_liquidation_price
           ):
             is_liquidation = True
         if not is_liquidation:
           return False
       if self.exit_profit_only:
         profit = 0.0
-        if trade.realized_profit != 0.0:
-          profit = ((rate - trade.open_rate) / trade.open_rate) * trade.stake_amount * (1 - trade.fee_close)
-          profit = profit + trade.realized_profit
-          profit = profit / trade.stake_amount
+        if trade_realized_profit != 0.0:
+          profit = ((rate - trade_open_rate) / trade_open_rate) * trade_stake_amount * (1 - trade.fee_close)
+          profit = profit + trade_realized_profit
+          profit = profit / trade_stake_amount
         else:
           profit = trade.calc_profit_ratio(rate)
         if profit < self.exit_profit_offset:


### PR DESCRIPTION
## Summary
- Reuse trade fields in confirm_trade_exit liquidation/profit checks.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same trade values feed the existing force-exit, stoploss, and profit-only checks.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`