### PR TITLE
Reuse X7 target-profit store removal

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12240,9 +12240,11 @@ class NostalgiaForInfinityX7(IStrategy):
   # Remove Profit Target
   # ---------------------------------------------------------------------------------------------
   def _remove_profit_target(self, pair: str):
-    if self.target_profit_cache is not None:
-      self.target_profit_cache.data.pop(pair, None)
-      self.target_profit_cache.save()
+    target_profit_cache = self.target_profit_cache
+
+    if target_profit_cache is not None:
+      target_profit_cache.data.pop(pair, None)
+      target_profit_cache.save()
 
   # Get Hold Trades Config File
   # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reuse target_profit_cache while removing a pair profit target.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same cache object is checked, mutated, and saved with no key or value changes.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`