### PR TITLE
Reuse X7 long rebuy exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -26770,6 +26770,8 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    is_futures_mode = self.is_futures_mode
+
     mark_profit_target = self.mark_profit_target
     set_profit_target = self._set_profit_target
     exit_profit_target = self.exit_profit_target
@@ -26820,7 +26822,7 @@ class NostalgiaForInfinityX7(IStrategy):
       if is_system_v3_2:
         threshold = (
           self.system_v3_2_stop_threshold_futures_rebuy
-          if self.is_futures_mode
+          if is_futures_mode
           else self.system_v3_2_stop_threshold_spot_rebuy
         )
 
@@ -26830,7 +26832,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif is_system_v3_1:
         threshold = (
           self.system_v3_1_stop_threshold_futures_rebuy
-          if self.is_futures_mode
+          if is_futures_mode
           else self.system_v3_1_stop_threshold_spot_rebuy
         )
 
@@ -26839,16 +26841,14 @@ class NostalgiaForInfinityX7(IStrategy):
 
       elif is_system_v3:
         threshold = (
-          self.system_v3_stop_threshold_futures_rebuy
-          if self.is_futures_mode
-          else self.system_v3_stop_threshold_spot_rebuy
+          self.system_v3_stop_threshold_futures_rebuy if is_futures_mode else self.system_v3_stop_threshold_spot_rebuy
         )
 
         if profit_stake < -(entry_cost * threshold / leverage):
           sell, signal_name = True, stoploss_doom
 
       else:
-        threshold = self.stop_threshold_futures_rebuy if self.is_futures_mode else self.stop_threshold_spot_rebuy
+        threshold = self.stop_threshold_futures_rebuy if is_futures_mode else self.stop_threshold_spot_rebuy
 
         if profit_stake < -(entry_cost * threshold / leverage) and (
           trade.open_date_utc.replace(tzinfo=None) >= datetime(2024, 9, 13) or self.is_backtest_mode()


### PR DESCRIPTION
## Summary
- Reuse futures-mode state in the long rebuy exit helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- Exit target inputs, signal names, and profit thresholds are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`