### PR TITLE
Reuse X7 long rapid exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -27285,6 +27285,8 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    is_futures_mode = self.is_futures_mode
+
     mark_profit_target = self.mark_profit_target
     set_profit_target = self._set_profit_target
     exit_profit_target = self.exit_profit_target
@@ -27370,28 +27372,26 @@ class NostalgiaForInfinityX7(IStrategy):
           stop_enabled = self.system_v3_2_stops_enable
           stop_threshold = (
             self.system_v3_2_stop_threshold_rapid_futures
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_2_stop_threshold_rapid_spot
           )
         elif is_system_v3_1:
           stop_enabled = self.stops_enable
           stop_threshold = (
             self.system_v3_1_stop_threshold_rapid_futures
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_1_stop_threshold_rapid_spot
           )
         elif is_system_v3:
           stop_enabled = self.stops_enable
           stop_threshold = (
             self.system_v3_stop_threshold_rapid_futures
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_stop_threshold_rapid_spot
           )
         else:
           stop_enabled = self.stops_enable
-          stop_threshold = (
-            self.stop_threshold_rapid_futures if self.is_futures_mode else self.stop_threshold_rapid_spot
-          )
+          stop_threshold = self.stop_threshold_rapid_futures if is_futures_mode else self.stop_threshold_rapid_spot
 
         if stop_enabled:
           stoploss_value = -(entry_cost * stop_threshold / leverage)


### PR DESCRIPTION
## Summary
- Reuse futures/stop flags in the long rapid exit helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same rapid exit conditions and stop flags are evaluated in the same order.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`