### PR TITLE
Reuse X7 long scalp futures flag

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -27890,6 +27890,8 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    is_futures_mode = self.is_futures_mode
+
     mark_profit_target = self.mark_profit_target
     set_profit_target = self._set_profit_target
     exit_profit_target = self.exit_profit_target
@@ -27939,7 +27941,7 @@ class NostalgiaForInfinityX7(IStrategy):
       if is_system_v3_2:
         threshold = (
           self.system_v3_2_stop_threshold_scalp_futures
-          if self.is_futures_mode
+          if is_futures_mode
           else self.system_v3_2_stop_threshold_scalp_spot
         )
 
@@ -27948,7 +27950,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif is_system_v3_1:
         threshold = (
           self.system_v3_1_stop_threshold_scalp_futures
-          if self.is_futures_mode
+          if is_futures_mode
           else self.system_v3_1_stop_threshold_scalp_spot
         )
 
@@ -27956,15 +27958,13 @@ class NostalgiaForInfinityX7(IStrategy):
 
       elif is_system_v3:
         threshold = (
-          self.system_v3_stop_threshold_scalp_futures
-          if self.is_futures_mode
-          else self.system_v3_stop_threshold_scalp_spot
+          self.system_v3_stop_threshold_scalp_futures if is_futures_mode else self.system_v3_stop_threshold_scalp_spot
         )
 
         stoploss_hit = profit_stake < -(entry_cost * threshold / leverage)
 
       else:
-        threshold = self.stop_threshold_scalp_futures if self.is_futures_mode else self.stop_threshold_scalp_spot
+        threshold = self.stop_threshold_scalp_futures if is_futures_mode else self.stop_threshold_scalp_spot
 
         stoploss_hit = profit_stake < -(entry_cost * threshold)
 


### PR DESCRIPTION
## Summary
- Reuse futures-mode state in the long scalp exit helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- Scalp exit conditions and target behavior are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`