### PR TITLE
Reuse X7 short rebuy exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -52835,6 +52835,9 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    is_futures_mode = self.is_futures_mode
+    trade_leverage = trade.leverage
+
     mark_profit_target = self.mark_profit_target
     set_profit_target = self._set_profit_target
     exit_profit_target = self.exit_profit_target
@@ -52924,10 +52927,10 @@ class NostalgiaForInfinityX7(IStrategy):
           entry_cost
           * (
             self.system_v3_2_stop_threshold_futures_rebuy
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_2_stop_threshold_spot_rebuy
           )
-          / trade.leverage
+          / trade_leverage
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3_1:
@@ -52935,10 +52938,10 @@ class NostalgiaForInfinityX7(IStrategy):
           entry_cost
           * (
             self.system_v3_1_stop_threshold_futures_rebuy
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_1_stop_threshold_spot_rebuy
           )
-          / trade.leverage
+          / trade_leverage
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3:
@@ -52946,10 +52949,10 @@ class NostalgiaForInfinityX7(IStrategy):
           entry_cost
           * (
             self.system_v3_stop_threshold_futures_rebuy
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_stop_threshold_spot_rebuy
           )
-          / trade.leverage
+          / trade_leverage
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       else:
@@ -52957,8 +52960,8 @@ class NostalgiaForInfinityX7(IStrategy):
           profit_stake
           < -(
             entry_cost
-            * (self.stop_threshold_futures_rebuy if self.is_futures_mode else self.stop_threshold_spot_rebuy)
-            / trade.leverage
+            * (self.stop_threshold_futures_rebuy if is_futures_mode else self.stop_threshold_spot_rebuy)
+            / trade_leverage
           )
           # temporary
           and (is_backtest or trade.open_date_utc.replace(tzinfo=None) >= datetime(2024, 9, 13))


### PR DESCRIPTION
## Summary
- Reuse futures-mode and leverage context in the short rebuy exit helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same leverage and futures-mode values are used by the existing exit logic.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`