### PR TITLE
Reuse X7 short rapid exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -53367,6 +53367,9 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    is_futures_mode = self.is_futures_mode
+    trade_leverage = trade.leverage
+
     mark_profit_target = self.mark_profit_target
     set_profit_target = self._set_profit_target
     exit_profit_target = self.exit_profit_target
@@ -53491,10 +53494,10 @@ class NostalgiaForInfinityX7(IStrategy):
             entry_cost
             * (
               self.system_v3_2_stop_threshold_rapid_futures
-              if self.is_futures_mode
+              if is_futures_mode
               else self.system_v3_2_stop_threshold_rapid_spot
             )
-            / trade.leverage
+            / trade_leverage
           )
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
@@ -53506,10 +53509,10 @@ class NostalgiaForInfinityX7(IStrategy):
             entry_cost
             * (
               self.system_v3_1_stop_threshold_rapid_futures
-              if self.is_futures_mode
+              if is_futures_mode
               else self.system_v3_1_stop_threshold_rapid_spot
             )
-            / trade.leverage
+            / trade_leverage
           )
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
@@ -53521,10 +53524,10 @@ class NostalgiaForInfinityX7(IStrategy):
             entry_cost
             * (
               self.system_v3_stop_threshold_rapid_futures
-              if self.is_futures_mode
+              if is_futures_mode
               else self.system_v3_stop_threshold_rapid_spot
             )
-            / trade.leverage
+            / trade_leverage
           )
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
@@ -53536,8 +53539,7 @@ class NostalgiaForInfinityX7(IStrategy):
             and (
               profit_stake
               < -(
-                entry_cost
-                * (self.stop_threshold_rapid_futures if self.is_futures_mode else self.stop_threshold_rapid_spot)
+                entry_cost * (self.stop_threshold_rapid_futures if is_futures_mode else self.stop_threshold_rapid_spot)
               )
             )
           )


### PR DESCRIPTION
## Summary
- Reuse futures/stop/leverage context in the short rapid exit helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The short rapid exit checks keep the same order, thresholds, and helper calls.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`