### PR TITLE
Reuse X7 short scalp exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -54014,6 +54014,9 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     enter_tags,
   ) -> tuple:
+    is_futures_mode = self.is_futures_mode
+    trade_leverage = trade.leverage
+
     mark_profit_target = self.mark_profit_target
     set_profit_target = self._set_profit_target
     exit_profit_target = self.exit_profit_target
@@ -54105,10 +54108,10 @@ class NostalgiaForInfinityX7(IStrategy):
             entry_cost
             * (
               self.system_v3_2_stop_threshold_scalp_futures
-              if self.is_futures_mode
+              if is_futures_mode
               else self.system_v3_2_stop_threshold_scalp_spot
             )
-            / trade.leverage
+            / trade_leverage
           )
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
@@ -54118,10 +54121,10 @@ class NostalgiaForInfinityX7(IStrategy):
           entry_cost
           * (
             self.system_v3_1_stop_threshold_scalp_futures
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_1_stop_threshold_scalp_spot
           )
-          / trade.leverage
+          / trade_leverage
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3:
@@ -54130,16 +54133,16 @@ class NostalgiaForInfinityX7(IStrategy):
           entry_cost
           * (
             self.system_v3_stop_threshold_scalp_futures
-            if self.is_futures_mode
+            if is_futures_mode
             else self.system_v3_stop_threshold_scalp_spot
           )
-          / trade.leverage
+          / trade_leverage
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       else:
         # Stoplosses
         if profit_stake < -(
-          entry_cost * (self.stop_threshold_scalp_futures if self.is_futures_mode else self.stop_threshold_scalp_spot)
+          entry_cost * (self.stop_threshold_scalp_futures if is_futures_mode else self.stop_threshold_scalp_spot)
           # / (trade.leverage if self.is_futures_mode else 1.0)
         ):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"


### PR DESCRIPTION
## Summary
- Reuse futures-mode and leverage context in the short scalp exit helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The short scalp exit checks and target handling are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`