### PR TITLE
Reduce X7 long grind v2 candle reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -45715,6 +45715,14 @@ class NostalgiaForInfinityX7(IStrategy):
   def long_grind_entry_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    previous_ema_26 = previous_candle["EMA_26"]
+    previous_ema_12 = previous_candle["EMA_12"]
+    last_bbl_20_2_0 = last_candle["BBL_20_2.0"]
+    last_aroonu_14_15m = last_candle["AROONU_14_15m"]
+    last_rsi_14_1h = last_candle["RSI_14_1h"]
+    last_low_min_24_4h = last_candle["low_min_24_4h"]
+    last_low_min_12_4h = last_candle["low_min_12_4h"]
+
     last_ema_12 = last_candle["EMA_12"]
     last_ema_26 = last_candle["EMA_26"]
     last_stochrsik_14_14_3_3 = last_candle["STOCHRSIk_14_14_3_3"]
@@ -45761,7 +45769,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_close_max_48 * 0.90))
         and (last_close > (last_high_max_6_1h * 0.85))
         and (last_close > (last_high_max_12_1h * 0.80))
-        and (last_close < (last_candle["low_min_24_4h"] * 1.20))
+        and (last_close < (last_low_min_24_4h * 1.20))
         and (last_close < (last_candle["EMA_16"] * 0.968))
       )
       or (
@@ -45780,7 +45788,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsik_14_14_3_3 < 50.0)
         and (last_ema_26 > last_ema_12)
         and ((last_ema_26 - last_ema_12) > (last_open * 0.020))
-        and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_open / 100.0))
+        and ((previous_ema_26 - previous_ema_12) > (last_open / 100.0))
       )
       or (
         (last_rsi_14 < 36.0)
@@ -45797,7 +45805,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_1d > -10.0)
         # and (last_roc_9_4h < 40.0)
         # and (last_candle["ROC_9_1d"] < 50.0)
-        and (last_candle["AROONU_14_15m"] < 25.0)
+        and (last_aroonu_14_15m < 25.0)
         and (last_close > (last_close_max_48 * 0.90))
         and (last_close > (last_high_max_6_1h * 0.85))
         and (last_close > (last_high_max_12_1h * 0.80))
@@ -45822,7 +45830,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_high_max_6_1h * 0.85))
         and (last_close > (last_high_max_12_1h * 0.80))
         and (last_close < (last_ema_26 * 0.962))
-        and (last_close < (last_candle["BBL_20_2.0"] * 0.999))
+        and (last_close < (last_bbl_20_2_0 * 0.999))
       )
       or (
         (last_rsi_14 < 35.0)
@@ -45844,7 +45852,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and (last_close > (last_candle["close_max_48"] * 0.90))
         # and (last_close > (last_candle["high_max_6_1h"] * 0.85))
         # and (last_close > (last_candle["high_max_12_1h"] * 0.80))
-        and (last_close < (last_candle["low_min_12_4h"] * 1.25))
+        and (last_close < (last_low_min_12_4h * 1.25))
         and (last_close < (last_candle["EMA_9"] * 0.968))
         and (last_close < (last_candle["EMA_20"] * 0.980))
       )
@@ -45890,7 +45898,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsik_14_14_3_3 < 20.0)
         and (last_candle["WILLR_84_1h"] < -70.0)
         # and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 40.0)
-        and (last_close < (last_candle["low_min_24_4h"] * 1.30))
+        and (last_close < (last_low_min_24_4h * 1.30))
         and (last_candle["BBB_20_2.0_1h"] > 12.0)
         and (last_close_max_48 >= (last_close * 1.10))
       )
@@ -45909,7 +45917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # and (last_close < (last_candle["low_min_24_4h"] * 1.50))
         and (last_ema_26 > last_ema_12)
         and ((last_ema_26 - last_ema_12) > (last_open * 0.034))
-        and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_open / 100.0))
+        and ((previous_ema_26 - previous_ema_12) > (last_open / 100.0))
       )
       or (
         (last_rsi_3 > 5.0)
@@ -45923,7 +45931,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 5.0)
         and (last_rsi_3_15m > 5.0)
         and (last_stochrsik_14_14_3_3 < 20.0)
-        and (last_rsi_14 < (last_candle["RSI_14_1h"] - 45.0))
+        and (last_rsi_14 < (last_rsi_14_1h - 45.0))
       )
       or (
         (last_rsi_3 > 10.0)
@@ -45933,7 +45941,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1d > 10.0)
         and (last_stochrsik_14_14_3_3 < 20.0)
         and (last_close < (last_candle["SMA_30"] * 0.978))
-        and (last_close < (last_candle["BBL_20_2.0"] * 0.999))
+        and (last_close < (last_bbl_20_2_0 * 0.999))
       )
       or (
         (last_rsi_14 < 36.0)
@@ -45946,10 +45954,10 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_close_max_48 * 0.85))
         and (last_close > (last_high_max_6_1h * 0.80))
         and (last_close > (last_high_max_12_1h * 0.75))
-        and (last_close < (last_candle["low_min_12_4h"] * 1.25))
+        and (last_close < (last_low_min_12_4h * 1.25))
         and (last_ema_26 > last_ema_12)
         and ((last_ema_26 - last_ema_12) > (last_open * 0.018))
-        and ((previous_candle["EMA_26"] - previous_candle["EMA_12"]) > (last_open / 100.0))
+        and ((previous_ema_26 - previous_ema_12) > (last_open / 100.0))
       )
       or (
         (last_rsi_3 > 5.0)
@@ -45965,10 +45973,10 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_15m > 10.0)
         and (last_rsi_14 < 40.0)
         and (last_aroonu_14 < 25.0)
-        and (last_candle["AROONU_14_15m"] < 30.0)
+        and (last_aroonu_14_15m < 30.0)
         and (last_stochrsik_14_14_3_3 < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_15m"] < 30.0)
-        and (last_candle["RSI_14_1h"] < 50.0)
+        and (last_rsi_14_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       )
       or (
@@ -45977,7 +45985,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 10.0)
         and (last_rsi_3_4h > 10.0)
         and (last_close < (last_ema_12 * 0.999))
-        and (last_close < (last_candle["BBL_20_2.0"] * 0.996))
+        and (last_close < (last_bbl_20_2_0 * 0.996))
       )
     ):
       return True


### PR DESCRIPTION
## Summary
- Reuse the remaining repeated long grind v2 candle fields.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- This stays in v2 entry logic only; v3 grind-entry code is not touched.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series fields that are already read by the same entry condition ladder. Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`