### PR TITLE
Reduce X7 short buyback v2 candle reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -71760,6 +71760,14 @@ class NostalgiaForInfinityX7(IStrategy):
   def short_buyback_entry_v2(
     self, last_candle: Series, previous_candle: Series, slice_profit: float, is_derisk: bool
   ) -> float:
+    last_rsi_3_1d = last_candle["RSI_3_1d"]
+    last_roc_9_1h = last_candle["ROC_9_1h"]
+    last_roc_9_4h = last_candle["ROC_9_4h"]
+    last_close_min_48 = last_candle["close_min_48"]
+    last_low_min_6_1h = last_candle["low_min_6_1h"]
+    last_low_min_12_1h = last_candle["low_min_12_1h"]
+    last_open = last_candle["open"]
+
     last_ema_12 = last_candle["EMA_12"]
     last_ema_26 = last_candle["EMA_26"]
     last_roc_9_1d = last_candle["ROC_9_1d"]
@@ -71792,9 +71800,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_15m"] > 80.0)
         # and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         # and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-        and (last_close < (last_candle["close_min_48"] * 1.10))
-        and (last_close < (last_candle["low_min_6_1h"] * 1.18))
-        and (last_close < (last_candle["low_min_12_1h"] * 1.25))
+        and (last_close < (last_close_min_48 * 1.10))
+        and (last_close < (last_low_min_6_1h * 1.18))
+        and (last_close < (last_low_min_12_1h * 1.25))
         # and (last_candle["close"] < (last_candle["low_min_24_4h"] * 1.20))
         and (last_close > (last_candle["EMA_16"] * 1.120))
       )
@@ -71811,8 +71819,8 @@ class NostalgiaForInfinityX7(IStrategy):
         # and (last_candle["ROC_9_4h"] > -10.0)
         and (last_roc_9_1d < 5.0)
         and (last_ema_12 > last_ema_26)
-        and ((last_ema_12 - last_ema_26) > (last_candle["open"] * 0.020))
-        and ((previous_candle["EMA_12"] - previous_candle["EMA_26"]) > (last_candle["open"] / 100.0))
+        and ((last_ema_12 - last_ema_26) > (last_open * 0.020))
+        and ((previous_candle["EMA_12"] - previous_candle["EMA_26"]) > (last_open / 100.0))
       )
       or (
         (last_rsi_14 > 64.0)
@@ -71820,19 +71828,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_15m < 90.0)
         and (last_rsi_3_1h < 90.0)
         and (last_rsi_3_4h < 90.0)
-        and (last_candle["RSI_3_1d"] < 90.0)
+        and (last_rsi_3_1d < 90.0)
         and (last_roc_2_1h < 5.0)
         and (last_roc_2_4h < 5.0)
         and (last_candle["ROC_2_1d"] < 5.0)
-        and (last_candle["ROC_9_1h"] < 5.0)
-        and (last_candle["ROC_9_4h"] < 5.0)
+        and (last_roc_9_1h < 5.0)
+        and (last_roc_9_4h < 5.0)
         and (last_roc_9_1d < 10.0)
         # and (last_candle["ROC_9_4h"] < 40.0)
         # and (last_candle["ROC_9_1d"] < 50.0)
         and (last_candle["AROOND_14_15m"] < 25.0)
-        and (last_close < (last_candle["close_min_48"] * 1.10))
-        and (last_close < (last_candle["low_min_6_1h"] * 1.18))
-        and (last_close < (last_candle["low_min_12_1h"] * 1.25))
+        and (last_close < (last_close_min_48 * 1.10))
+        and (last_close < (last_low_min_6_1h * 1.18))
+        and (last_close < (last_low_min_12_1h * 1.25))
         # and (last_candle["close"] < (last_candle["low_min_24_4h"] * 1.20))
         and (last_close > (last_ema_12 * 1.020))
       )
@@ -71841,12 +71849,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_15m < 90.0)
         and (last_rsi_3_1h < 90.0)
         and (last_rsi_3_4h < 90.0)
-        and (last_candle["RSI_3_1d"] < 90.0)
+        and (last_rsi_3_1d < 90.0)
         and (last_roc_2_1h < 5.0)
         and (last_roc_2_4h < 5.0)
         # and (last_candle["ROC_2_1d"] > -5.0)
-        and (last_candle["ROC_9_1h"] < 5.0)
-        and (last_candle["ROC_9_4h"] < 5.0)
+        and (last_roc_9_1h < 5.0)
+        and (last_roc_9_4h < 5.0)
         and (last_roc_9_1d < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)


### PR DESCRIPTION
## Summary
- Reuse the remaining repeated short buyback v2 candle fields.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- The same Series values are read once per call and reused; entry thresholds and order stay unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series fields that are already read by the same entry condition ladder. Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`