### PR TITLE
Reduce X7 long rebuy adjust config reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -51565,6 +51565,8 @@ class NostalgiaForInfinityX7(IStrategy):
     **kwargs,
   ) -> Optional[float]:
     # min/max stakes include leverage. The return amounts is before leverage.
+    config = self.config
+
     dp = self.dp
     is_futures_mode = self.is_futures_mode
     trade_pair = trade.pair
@@ -51614,7 +51616,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if dp.runmode.value in ("live", "dry_run"):
       ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
-        exit_price_side = self.config["exit_pricing"]["price_side"]
+        exit_price_side = config["exit_pricing"]["price_side"]
         if trade.is_short:
           if exit_price_side in ["ask", "other"]:
             if ticker["ask"] is not None:
@@ -51700,7 +51702,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=config["stake_currency"],
           )
         )
         log.info(


### PR DESCRIPTION
## Summary
- Reuse config access in the long rebuy adjust helper.
- Keeps the patch independent on top of the latest upstream `main`.

## Safety
- Order/profit snapshot inputs, stake math, and adjust return values are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local object references inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`