### PR TITLE
Collapse X7 entry mask reductions

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -19,6 +19,63 @@ log = logging.getLogger(__name__)
 # log.setLevel(logging.DEBUG)
 warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
 
+
+def _is_entry_bool_scalar(condition) -> bool:
+  return isinstance(condition, (bool, np.bool_))
+
+
+def _entry_bool_array(condition):
+  if isinstance(condition, np.ndarray):
+    return condition.astype(bool, copy=False)
+  if isinstance(condition, (pd.Series, pd.Index)):
+    return condition.to_numpy(dtype=bool, copy=False)
+  return np.asarray(condition, dtype=bool)
+
+
+def _and_entry_conditions(conditions):
+  arrays = []
+  has_false = False
+  for condition in conditions:
+    if _is_entry_bool_scalar(condition):
+      if not condition:
+        has_false = True
+      continue
+    arrays.append(_entry_bool_array(condition))
+  if not arrays:
+    return not has_false
+  if has_false:
+    return np.zeros_like(arrays[0], dtype=bool)
+  if len(arrays) == 1:
+    return arrays[0]
+  return np.logical_and.reduce(arrays)
+
+
+def _or_entry_conditions(conditions):
+  arrays = []
+  has_true = False
+  for condition in conditions:
+    if _is_entry_bool_scalar(condition):
+      if condition:
+        has_true = True
+      continue
+    arrays.append(_entry_bool_array(condition))
+  if not arrays:
+    return has_true
+  if has_true:
+    return np.ones_like(arrays[0], dtype=bool)
+  if len(arrays) == 1:
+    return arrays[0]
+  return np.logical_or.reduce(arrays)
+
+
+def _append_entry_tag(entry_tags, mask, tag: str) -> None:
+  if _is_entry_bool_scalar(mask):
+    if mask:
+      entry_tags[:] = entry_tags + tag
+    return
+  entry_tags[mask] = entry_tags[mask] + tag
+
+
 #############################################################################################################
 ##                 NostalgiaForInfinityX7 by iterativ                                                      ##
 ##            https://github.com/iterativv/NostalgiaForInfinity                                            ##
@@ -12558,7 +12615,7 @@ class NostalgiaForInfinityX7(IStrategy):
     long_entry_conditions = []
     short_entry_conditions = []
 
-    df.loc[:, "enter_tag"] = ""
+    entry_tags = np.full(len(df), "", dtype=object)
     df.loc[:, "enter_long"] = 0
     df.loc[:, "enter_short"] = 0
 
@@ -24076,13 +24133,13 @@ class NostalgiaForInfinityX7(IStrategy):
         ###############################################################################################
 
         long_entry_logic.append(df["volume"] > 0)
-        item_long_entry = reduce(lambda x, y: x & y, long_entry_logic)
-        df.loc[item_long_entry, "enter_tag"] += f"{long_entry_condition_index} "
+        item_long_entry = _and_entry_conditions(long_entry_logic)
+        _append_entry_tag(entry_tags, item_long_entry, f"{long_entry_condition_index} ")
         long_entry_conditions.append(item_long_entry)
         df.loc[:, "enter_long"] = item_long_entry.astype(int)
 
     if long_entry_conditions:
-      df.loc[:, "enter_long"] = reduce(lambda x, y: x | y, long_entry_conditions).astype(int)
+      df.loc[:, "enter_long"] = _or_entry_conditions(long_entry_conditions).astype(int)
 
     ###############################################################################################
 
@@ -26007,14 +26064,15 @@ class NostalgiaForInfinityX7(IStrategy):
         ###############################################################################################
 
         short_entry_logic.append(df["volume"] > 0)
-        item_short_entry = reduce(lambda x, y: x & y, short_entry_logic)
-        df.loc[item_short_entry, "enter_tag"] += f"{short_entry_condition_index} "
+        item_short_entry = _and_entry_conditions(short_entry_logic)
+        _append_entry_tag(entry_tags, item_short_entry, f"{short_entry_condition_index} ")
         short_entry_conditions.append(item_short_entry)
         df.loc[:, "enter_short"] = item_short_entry.astype(int)
 
     if short_entry_conditions:
-      df.loc[:, "enter_short"] = reduce(lambda x, y: x | y, short_entry_conditions).astype(int)
+      df.loc[:, "enter_short"] = _or_entry_conditions(short_entry_conditions).astype(int)
 
+    df.loc[:, "enter_tag"] = entry_tags
     return df
 
   ###############################################################################################


### PR DESCRIPTION
## Summary
- Replaces the long/short entry `reduce(lambda x, y: x & y, ...)` / `|` mask folds with small numpy-based entry mask helpers.
- Accumulates `enter_tag` in an object array and writes it back once at the end of `populate_entry_trend()` instead of updating the dataframe for every enabled entry condition.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same indicators, candle selection, entry formulas, thresholds, condition order, tag text, signal columns, order classification, profit arithmetic, and return values.
- The helpers only normalize already-built boolean masks before applying the same all/any entry condition logic.
- `.shift()` and dataframe comparison formulas are not changed.
- No global-protection formulas and no v3 grind-entry code are touched.

## Backtest scope
- A full trading-output backtest was not required for formula-change validation because this patch does not change indicators, thresholds, condition formulas, candle selection, order classification, or profit arithmetic.
- Ran targeted baseline-vs-patched live-style analyze parity over 80 pairs / 1200 rows, comparing protection and signal columns (`protections_*`, `global_protections_*`, `enter_*`, `exit_*`, tags): `parity=true`.
- Latest-main 80-pair timing in the same harness: `baseline_seconds=149.679009`, `patched_seconds=143.473493`, `speedup_ratio=1.043252`.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py`
- `docker compose run --rm -v /tmp/nfi_entry_masks_baseline:/tmp/nfi_entry_masks_baseline:ro -v /tmp/nfi_entry_masks_patched:/tmp/nfi_entry_masks_patched:ro -v /tmp/compare_nfi_global_protection_parity.py:/tmp/compare_nfi_global_protection_parity.py:ro -v /home/user/project/NFI_X7_Optimization:/work -w /work --entrypoint python3 freqtrade /tmp/compare_nfi_global_protection_parity.py --baseline /tmp/nfi_entry_masks_baseline/NostalgiaForInfinityX7.py --patched /tmp/nfi_entry_masks_patched/NostalgiaForInfinityX7.py --config /work/user_data/config-test-x7.example.json --config-extra /work/user_data/config-test-x7-80pairs.example.json --config-extra /work/user_data/config-test-x7-live-speed-safe.example.json --data-dir /work/user_data/data/binance --rows 1200`
