### PR TITLE
Reuse X7 long protection RSI masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4589,17 +4589,35 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_roc_2_4h = df["ROC_2_4h"].to_numpy(copy=False)
     protection_aroond_14_15m = df["AROOND_14_15m"].to_numpy(copy=False)
 
+    # Reused long-global RSI comparison masks
+    rsi_14_15m_lt_30 = protection_rsi_14_15m < 30.0
+    rsi_14_1h_lt_40 = protection_rsi_14_1h < 40.0
+    rsi_14_4h_lt_50 = protection_rsi_14_4h < 50.0
+    rsi_14_15m_lt_40 = protection_rsi_14_15m < 40.0
+    rsi_14_4h_lt_40 = protection_rsi_14_4h < 40.0
+    rsi_14_1h_lt_30 = protection_rsi_14_1h < 30.0
+    rsi_14_1h_lt_50 = protection_rsi_14_1h < 50.0
+    rsi_3_15m_gt_20 = protection_rsi_3_15m > 20.0
+    rsi_3_15m_gt_15 = protection_rsi_3_15m > 15.0
+    rsi_3_15m_gt_10 = protection_rsi_3_15m > 10.0
+    rsi_3_15m_gt_25 = protection_rsi_3_15m > 25.0
+    rsi_14_4h_lt_30 = protection_rsi_14_4h < 30.0
+    rsi_3_15m_gt_30 = protection_rsi_3_15m > 30.0
+    rsi_3_1h_gt_30 = protection_rsi_3_1h > 30.0
+    rsi_14_15m_lt_20 = protection_rsi_14_15m < 20.0
+    rsi_3_4h_gt_60 = protection_rsi_3_4h > 60.0
+
     # Global protections Long
     df["protections_long_global"] = (
       # 5m & 15m & 1h & 4h & 1d down move, 1h & 4h & 1d still not low enough
       (
         (protection_rsi_3 > 1.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_3_1d > 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 30.0)
         | (protection_cci_20_1h < -250.0)
         | (protection_cci_20_4h < -200.0)
@@ -4609,25 +4627,25 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 1.0)
         | (protection_rsi_3_4h > 10.0)
         | (protection_rsi_3_1d > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1d < 50.0)
       )
       # 5m down move, 15m & 1h & 4h still high, 15m high
       & (
         (protection_rsi_3 > 3.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h still high
       & (
         (protection_rsi_3 > 5.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
@@ -4637,10 +4655,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h down move, 1h & 4h still high, 15m still high, 1h high
       & (
         (protection_rsi_3 > 5.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
@@ -4648,22 +4666,22 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h & 4h down move, 4h high
       & (
         (protection_rsi_3 > 5.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 5m & 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h high
       & (
         (protection_rsi_3 > 5.0)
-        | (protection_rsi_3_15m > 30.0)
+        | rsi_3_15m_gt_30
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -4671,11 +4689,11 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h still high
       & (
         (protection_rsi_3 > 5.0)
-        | (protection_rsi_3_15m > 30.0)
+        | rsi_3_15m_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -4691,24 +4709,24 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h stil high, 15m & 4h high
       & (
         (protection_rsi_3 > 10.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 5m & 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high
       & (
         (protection_rsi_3 > 10.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -4716,22 +4734,22 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high
       & (
         (protection_rsi_3 > 10.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
       )
       # 5m & 15m & 1h down move, 15m & 1h still high, 4h high, 15m still not low enough, 5h overbought
       & (
         (protection_rsi_3 > 10.0)
-        | (protection_rsi_3_15m > 25.0)
+        | rsi_3_15m_gt_25
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -4741,11 +4759,11 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h & 1d down move, 1h & 4h still high, 1d downtrend
       & (
         (protection_rsi_3 > 10.0)
-        | (protection_rsi_3_15m > 25.0)
+        | rsi_3_15m_gt_25
         | (protection_rsi_3_1h > 65.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -4754,11 +4772,11 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 4h high
       & (
         (protection_rsi_3 > 10.0)
-        | (protection_rsi_3_15m > 25.0)
+        | rsi_3_15m_gt_25
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
@@ -4766,10 +4784,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m & 4h high
       & (
         (protection_rsi_3 > 10.0)
-        | (protection_rsi_3_15m > 30.0)
+        | rsi_3_15m_gt_30
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
@@ -4779,9 +4797,9 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h down move, 15m still high, 1h & 4h high, 4h high & overbought
       & (
         (protection_rsi_3 > 15.0)
-        | (protection_rsi_3_15m > 30.0)
+        | rsi_3_15m_gt_30
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
@@ -4831,8 +4849,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_roc_9_4h < 15.0)
       )
@@ -4851,7 +4869,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.30)
         | (protection_aroonu_14_4h < 40.0)
       )
@@ -4860,8 +4878,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_4h < 25.0)
       )
@@ -4870,8 +4888,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 25.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still not low enough
@@ -4889,7 +4907,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 1h still high, 1h & 4h still not low enough
       & (
         (protection_rsi_3_15m > 3.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 50.0)
         | (protection_aroonu_14_1h < 50.0)
@@ -4909,7 +4927,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_4h > 10.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -4918,8 +4936,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 25.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
@@ -5090,7 +5108,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.15)
@@ -5100,8 +5118,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
@@ -5113,7 +5131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -5124,8 +5142,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
       )
       # 15m & 1h down move, 1h high, 4h high
@@ -5140,8 +5158,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1d < 90.0)
         | (protection_roc_9_1d < 80.0)
@@ -5159,7 +5177,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -5176,8 +5194,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_roc_9_4h < 25.0)
@@ -5193,18 +5211,18 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 4h high
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 1h high, 4h downtrend
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_4h > -40.0)
@@ -5212,10 +5230,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -5223,10 +5241,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h high, 4h overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -5235,9 +5253,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -5245,10 +5263,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h high
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_1h_gt_30
+        | rsi_3_4h_gt_60
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
@@ -5257,8 +5275,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
@@ -5267,8 +5285,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1d < 70.0)
       )
@@ -5277,9 +5295,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_1d < 60.0)
       )
@@ -5287,10 +5305,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_rsi_14_15m < 10.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
@@ -5298,7 +5316,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 75.0)
@@ -5311,8 +5329,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 65.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.40)
         | (protection_aroonu_14_1h < 50.0)
       )
@@ -5321,8 +5339,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_14_15m < 10.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 20.0)
         | (protection_roc_9_1d < 20.0)
@@ -5330,7 +5348,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m down move, 15m still not low enough, 1h & 4h high, 1h overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -5340,7 +5358,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m down move, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
@@ -5350,7 +5368,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 10.0)
         | (protection_rsi_14_1h < 10.0)
@@ -5363,17 +5381,17 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 4h still high, 15m & 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.25)
@@ -5383,7 +5401,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.30)
@@ -5392,7 +5410,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h downtrend, 1h still high, 1h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_1h > -0.30)
@@ -5402,7 +5420,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_1h < 30.0)
@@ -5411,7 +5429,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still high, 4h still not low enough
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
@@ -5422,7 +5440,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 15m still high, 1h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_1h < 40.0)
@@ -5431,7 +5449,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
@@ -5441,34 +5459,34 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 4h still not low enough, 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 15m still not low enough
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_14_15m < 10.0)
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.15)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 4h still high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.25)
         | (protection_aroonu_14_4h < 40.0)
@@ -5476,30 +5494,30 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 1h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_roc_9_15m > -10.0)
         | (protection_roc_9_1h > -20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h down move, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -5507,35 +5525,35 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 15m still not low enough
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still not low enough
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
@@ -5543,26 +5561,26 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_1h < 30.0)
+        | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h & 4h down move, 1h downtrend, 4h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.4)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 1h & 4h downtrend, 15m & 1h & 4h still not low enough
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_14_1h < 20.0)
@@ -5575,7 +5593,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
@@ -5585,11 +5603,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.25)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_cci_20_1h < -200.0)
@@ -5598,7 +5616,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_aroonu_14_15m < 30.0)
@@ -5607,33 +5625,33 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 45.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -5641,12 +5659,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h stil high, 1h & 4h downtrend, 1h & 4h still not low
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_14_15m < 10.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 30.0)
@@ -5654,21 +5672,21 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 1h & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
@@ -5676,11 +5694,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 10.0)
@@ -5688,10 +5706,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h & 4h still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.15)
@@ -5701,12 +5719,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low, 4h still high, 15m & 1h downtrend, 4h not low, 4h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
         | (protection_aroonu_14_4h < 20.0)
@@ -5714,30 +5732,30 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h not low enouhg, 15m downtrend, 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_1d < 25.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high. 1d high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1d < 70.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still not low enough, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
@@ -5750,10 +5768,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 1d down move, 1h still not low enough, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_1h < 30.0)
+        | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -5762,31 +5780,31 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_1d > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 1h downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_10)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.25)
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_10)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_14_1h < 45.0)
         | (protection_rsi_14_4h < 55.0)
@@ -5796,18 +5814,18 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend, 4h high
       & (
-        (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_10)
+        | rsi_3_1h_gt_30
+        | rsi_3_4h_gt_60
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_4h < 80.0)
       )
       # 15m & 1h down move, 4h high, 1d downtrend, 1h still not low enough, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_10)
+        | rsi_3_1h_gt_30
         | (protection_rsi_14_4h < 70.0)
         | (protection_cmf_20_1d > -0.3)
         | (protection_aroonu_14_1h < 30.0)
@@ -5815,58 +5833,58 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h not low enough, 4h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 15.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 35.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 85.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1 & 4h still not low enough, 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
@@ -5874,12 +5892,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h still high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 10.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -5887,9 +5905,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 4h still high, 15m downtrend, 1h & 1d high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.3)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_1d < 90.0)
@@ -5897,10 +5915,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 1h & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -5908,23 +5926,23 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h sitll high, 15m & 1h & 4h downtrend, 1h & 4h still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
@@ -5933,35 +5951,35 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m stil not low enough, 1h & 4h still high, 15m & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 40.0)
@@ -5969,18 +5987,18 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 14h & 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 20.0)
@@ -5990,9 +6008,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 60.0)
@@ -6002,12 +6020,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high, 1h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_4h < 80.0)
@@ -6015,7 +6033,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h downtrend, 15m still high, 1h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_1h > -0.0)
@@ -6025,22 +6043,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -6049,10 +6067,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 10.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -6061,12 +6079,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 15m & 1h high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.0)
         | (protection_cmf_20_4h > -0.0)
         | (protection_aroonu_14_15m < 50.0)
@@ -6074,7 +6092,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 65.0)
         | (protection_aroonu_14_15m < 80.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -6082,11 +6100,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 20.0)
@@ -6094,7 +6112,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h & 1d down move, 15m high, 15m & 4h still high
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_4h > 15.0)
         | (protection_rsi_3_1d > 20.0)
         | (protection_aroonu_14_15m < 70.0)
@@ -6103,28 +6121,28 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h & 1d down move, 15m & 1h still not low enough, 1h still high, 4h & 1d downtrend
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_3_1d > 20.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_roc_9_4h > -25.0)
         | (protection_roc_9_1d > -50.0)
       )
       # 15m & 4h down move, 1h & 4h stil high, 15m high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_10)
+        | rsi_3_4h_gt_60
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_roc_9_4h < 30.0)
       )
       # 15m down move, 15m still not low enough, 1h & 4h high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_14_15m < 30.0)
+        (rsi_3_15m_gt_10)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 85.0)
@@ -6134,9 +6152,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h & 4h still high, 15m still high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        (rsi_3_15m_gt_10)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -6147,10 +6165,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_roc_9_1h > -20.0)
@@ -6158,23 +6176,23 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h high, 15m still not low enough
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
       )
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 4h still high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_4h < 40.0)
@@ -6182,18 +6200,18 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 4h downtrend, 1h still not low enough
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 50.0)
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 20.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 15m & 4h high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 50.0)
@@ -6204,12 +6222,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 4h still not low enough, 15m & 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_rsi_3_1d > 40.0)
         | (protection_rsi_14_15m > 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.0)
@@ -6217,10 +6235,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h high, 1h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_1h < 30.0)
+        | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 45.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -6228,7 +6246,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -6236,11 +6254,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still not low enough, 4h still high, 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 60.0)
@@ -6248,10 +6266,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high. 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -6259,67 +6277,67 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.50)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high, 1h still high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m downtrend, 4h high, 1h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_1h > -10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 85.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend, 1h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 70.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -6327,36 +6345,36 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d < 30.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 1d down move, 15m & 1h still not low enough, 4h high, 1d downtrend, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1h > -10.0)
@@ -6364,18 +6382,18 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high 4h & 1d downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_15m < 25.0)
@@ -6387,8 +6405,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m downtrend, 15m & 1h still not low enough, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -6398,23 +6416,23 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_14_1h < 35.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 25.0)
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h still high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 25.0)
@@ -6422,22 +6440,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 45.0)
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -6445,11 +6463,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -6457,10 +6475,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 1d downtrend, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_1d > -0.10)
         | (protection_aroonu_14_15m < 20.0)
@@ -6470,68 +6488,68 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
       )
       # 15m & 1h down move, 15m still high, 1h & dh high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 40.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 1d high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_rsi_3_1d > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 40.0)
         | (protection_aroonu_14_1d < 70.0)
         | (protection_roc_9_4h > -40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 1d downtrend, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h high & overbought, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -6539,21 +6557,21 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1d > -20.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 1h & 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -6562,11 +6580,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d downtrend, 1h & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.1)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -6574,10 +6592,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
@@ -6587,12 +6605,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 1h still high, 4h still not low enough, 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_3_1d > 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_cci_20_1h < -250.0)
         | (protection_cci_20_4h < -250.0)
@@ -6600,7 +6618,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h downtrend, 1h & 4h still not low enough, 1d downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 30.0)
@@ -6615,12 +6633,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h overbought, 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_1h < 10.0)
@@ -6628,12 +6646,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -6642,7 +6660,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 4h downtrend, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_4h > -0.10)
@@ -6651,12 +6669,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h & 1d still high, 1h downtrend, 1d downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_rsi_14_1d < 40.0)
         | (protection_cmf_20_1h > -0.15)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
@@ -6666,10 +6684,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still not low enough, 1h & 4h still high, 15m still high, 1h high
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_15)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -6677,12 +6695,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h downtrend, 15m & 4h still not low, 1h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.25)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 30.0)
@@ -6690,21 +6708,21 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m ^ 1h down move, 15m & 1h & 4h still not low enough, 1h & 4h high, 1h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_1h < 10.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -6714,12 +6732,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -6727,12 +6745,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
@@ -6741,22 +6759,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_1d > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 14m & 1h down move, 15m & 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 65.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
@@ -6765,12 +6783,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 5h still high, 15m still high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h < 20.0)
@@ -6778,21 +6796,21 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 60.0)
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m & 1h stil high, 4h high, 15m & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 70.0)
@@ -6800,11 +6818,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m downtrend, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -6812,11 +6830,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 1h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -6824,14 +6842,14 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 3.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
         | (protection_roc_9_4h > -15.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 5.0)
         | (protection_rsi_14_15m < 10.0)
         | (protection_rsi_14_1h < 10.0)
@@ -6845,22 +6863,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m & 1d downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 15.0)
         | (protection_rsi_3_1d > 25.0)
         | (protection_rsi_14_15m > 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.3)
         | (protection_cmf_20_1d > -0.3)
         | (protection_aroonu_14_15m < 30.0)
       )
       # 15m & 4h down move, 15m & 1h still high, 1h high, 1h over
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_aroonu_14_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
@@ -6868,11 +6886,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 20)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -6880,40 +6898,40 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 4h down move, 1h high & overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 45.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
         | (protection_roc_9_1h < 10.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_15)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -6921,17 +6939,17 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1d down move, 15m still not low enough, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1d > 5.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1d down move, 15m still not low enough, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
@@ -6942,10 +6960,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 15m & 1h high
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_aroonu_14_15m < 60.0)
@@ -6953,7 +6971,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 1d downtrend, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_rsi_14_15m < 35.0)
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
@@ -6963,7 +6981,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -6971,9 +6989,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h still high, 1h high, 1h overbought, 4h & 1d downtrend
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        (rsi_3_15m_gt_15)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_roc_9_1h < 40.0)
@@ -6982,8 +7000,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still high, 1h & 4h high, 1h & 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_14_15m < 40.0)
+        (rsi_3_15m_gt_15)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -6992,8 +7010,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_14_15m < 30.0)
+        (rsi_3_15m_gt_15)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 30.0)
@@ -7003,10 +7021,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h & 4h still high, 1h & 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_15)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -7016,14 +7034,14 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 15.0)
+        (rsi_3_15m_gt_15)
         | (protection_aroonu_14_15m < 75.0)
         | (protection_roc_9_1h < 50.0)
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 1h still high, 15m still not low enough, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 5.0)
         | (protection_aroonu_14_1h < 50.0)
@@ -7032,7 +7050,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 1h & 4h still not low enough
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
@@ -7045,7 +7063,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m downtrend, 1h & 4h till high, 15m still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.3)
@@ -7056,11 +7074,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 4h & 1d still not low enough, 1d downtrend, 1h & 4h still high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 30.0)
         | (protection_cmf_20_1d > -0.20)
         | (protection_aroonu_14_1h < 40.0)
@@ -7069,12 +7087,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 70.0)
@@ -7083,7 +7101,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 25.0)
@@ -7091,11 +7109,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 1d still high, 1d downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 45.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 50.0)
         | (protection_cmf_20_1d > -0.0)
         | (protection_mfi_14_1d < 70.0)
@@ -7106,12 +7124,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 15m & 1h downtrend, 1h & 4h still not low enough
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
@@ -7119,35 +7137,35 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h down move, 15m & 1h still not low enough, 4h still high, 15m still not low enough, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
@@ -7155,11 +7173,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h high, 1h & 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -10.0)
@@ -7167,12 +7185,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.15)
         | (protection_aroonu_14_15m < 20.0)
@@ -7181,12 +7199,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.15)
@@ -7194,21 +7212,21 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 75.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
       # 15m & 1h down move, 1h still not low enough, 1h still high, 4h high & overbought, 1d downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_4h < 40.0)
@@ -7216,28 +7234,28 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1d < 150.0)
       )
       # 15m & 1h & 1d down move, 1h & 4h still high, 15m downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_1d > 55.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.3)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -7246,11 +7264,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h still high, 1h & 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 40.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_aroonu_14_4h < 40.0)
@@ -7260,12 +7278,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m stil high, 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
@@ -7273,10 +7291,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_4h > -0.25)
@@ -7285,11 +7303,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m & 1h downtrend, 1h & 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
@@ -7299,43 +7317,43 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -7344,10 +7362,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
@@ -7356,9 +7374,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 1h still high, 1h & 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_1h_gt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -7367,19 +7385,19 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h still not low enough, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_roc_9_4h > -50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h still high, 15m still not low enough, 1h still high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.10)
@@ -7392,7 +7410,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 1d still high, 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 25.0)
@@ -7402,34 +7420,34 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_rsi_3_1d > 55.0)
         | (protection_rsi_14_15m < 25.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
         | (protection_aroonu_14_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 1h & 4h still high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -7438,32 +7456,32 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m still not lowenough, 1h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 25.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h down move, 15m & 1h sitll high, 4h high, 1h & 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -7472,11 +7490,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h downtrend, 15m & 1h still high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -7485,7 +7503,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m downtrend, 15m still high, 1h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.20)
@@ -7494,7 +7512,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_15m < 50.0)
@@ -7505,7 +7523,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 4d downtrend, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_4h > -0.40)
@@ -7514,12 +7532,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 15m high, 4h & 1d downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_4h > -0.40)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_roc_9_4h > -20.0)
@@ -7527,10 +7545,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -7538,12 +7556,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_cci_20_1h < 0.0)
@@ -7552,11 +7570,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still high, 4h high, 15m stil high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -7564,11 +7582,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -7576,11 +7594,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 4h & 1d downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_aroonu_14_15m < 40.0)
@@ -7590,48 +7608,48 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high, 1h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_1d > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_4h > -20.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low, 1h & 4h sitll high, 15m & 1h downtrend, 15m still high, 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -7639,10 +7657,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m still high, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
@@ -7650,30 +7668,30 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_roc_9_1h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m & 1h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
@@ -7684,22 +7702,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h > -40.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 75.0)
         | (protection_roc_9_4h < 25.0)
@@ -7707,10 +7725,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h stil high, 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_1h < 40.0)
@@ -7718,10 +7736,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m & 1h & 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
@@ -7729,10 +7747,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m & 4h high, 15m & 1h still not low enough, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 65.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -7742,10 +7760,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 1h & 4h high, 1h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -7753,19 +7771,19 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still high, 1h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1h < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 65.0)
         | (protection_rsi_14_15m < 35.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 75.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -7774,11 +7792,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
@@ -7787,9 +7805,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 15m still high, 1h & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 50.0)
@@ -7799,11 +7817,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h sitll high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 15.0)
@@ -7811,29 +7829,29 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h & 1d down move, 15m & 1h & 4h s till high, 15m & 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 15m still high, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
         | (protection_aroonu_14_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -25.0)
       )
       # 15m & 4h down move, 15m & 1h still high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -7841,7 +7859,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m &4d down move, 15m & 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -7849,7 +7867,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 4h still high, 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h > -30.0)
@@ -7857,22 +7875,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still not low enough, 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15, & 4h still high, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -7880,22 +7898,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still high, 1h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 1h still high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_4h > 60.0)
+        (rsi_3_15m_gt_20)
+        | rsi_3_4h_gt_60
         | (protection_rsi_14_15m < 35.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -7904,10 +7922,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m still high, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 60.0)
@@ -7915,9 +7933,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h high, 15m & 1h & 4h high
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
@@ -7926,8 +7944,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_14_15m < 30.0)
+        (rsi_3_15m_gt_20)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 85.0)
@@ -7937,8 +7955,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_14_15m < 40.0)
+        (rsi_3_15m_gt_20)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -7948,7 +7966,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h & 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 20.0)
+        (rsi_3_15m_gt_20)
         | (protection_rsi_14_15m < 50.0)
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
@@ -7959,69 +7977,69 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 60.0)
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m high, 1h & 4h still high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 85.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 55.0)
         | (protection_rsi_14_15m < 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_roc_9_1d < 30.0)
       )
       # 15m & 1h & 1d down move, 1h & 4h still high, 1d downtrend, 1h high, 1h & 4h still high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1d > -0.20)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -8030,10 +8048,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h stil high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -8041,10 +8059,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -8052,20 +8070,20 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h stil high, 15m still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h downtrend, 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_cmf_20_15m > -0.30)
@@ -8075,34 +8093,34 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h still high
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 15m downtrend, 15m still not low enough
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 30.0)
@@ -8110,12 +8128,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h stil high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -8123,22 +8141,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m still not low, 4h high, 1h still high
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -8146,57 +8164,57 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_roc_9_4h > -20.0)
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h still high, 15m still high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h still high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -8205,12 +8223,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1d downtrend, 1h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_1d > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.20)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
@@ -8218,11 +8236,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
@@ -8231,7 +8249,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 1d down move, 4h & 1d downtrend, 1h & 4h high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_1d > 35.0)
         | (protection_cmf_20_4h > -0.1)
@@ -8242,11 +8260,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
@@ -8255,10 +8273,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 80.0)
@@ -8266,10 +8284,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -8280,10 +8298,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 10.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.15)
@@ -8294,12 +8312,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -8307,33 +8325,33 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 15.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h down move, 15m sitll not low enough, 1h still high, 4h high, 15m & 1h downtrend, 15m & 1h still high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
@@ -8342,10 +8360,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
@@ -8353,12 +8371,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
@@ -8366,12 +8384,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 15m high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
@@ -8380,36 +8398,36 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m & 4h high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -8417,10 +8435,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 1d down move, 15m & 1h & 4h still high, 15m & 1d downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_1d > 55.0)
-        | (protection_rsi_14_15m < 40.0)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 45.0)
         | (protection_rsi_14_4h < 45.0)
         | (protection_aroonu_14_15m < 25.0)
@@ -8430,11 +8448,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h & 4h stil high, 15m & 1h & 4h high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 60.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -8442,11 +8460,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
@@ -8455,25 +8473,25 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 4h downtrend, 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1d < 30.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -8482,23 +8500,23 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -8506,10 +8524,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h < 20.0)
@@ -8517,11 +8535,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_roc_9_1h < 10.0)
@@ -8529,10 +8547,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
@@ -8542,7 +8560,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -8551,11 +8569,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 1h overbought, 1d downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
@@ -8563,9 +8581,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 60.0)
@@ -8574,10 +8592,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -8587,10 +8605,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1hstill high, 4h downtrend, 15m still high, 1h high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 60.0)
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
@@ -8599,9 +8617,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -8609,9 +8627,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 1h & 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -8622,7 +8640,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m high, 1h still not low enough, 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 3.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
@@ -8631,7 +8649,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 10.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
@@ -8640,10 +8658,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h & 1d down move, 15m still high, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 15.0)
         | (protection_rsi_3_1d > 15.0)
-        | (protection_rsi_14_15m < 40.0)
+        | rsi_14_15m_lt_40
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 50.0)
@@ -8651,7 +8669,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h & 1d down move, 15m high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_aroonu_14_15m < 60.0)
@@ -8659,10 +8677,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h still high, 15m & 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 3.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
@@ -8670,11 +8688,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 4h still high,  1h & 4h downtrend, 15m & 1h & 4h still high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 30.0)
@@ -8683,7 +8701,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 25.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -8693,22 +8711,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -8716,11 +8734,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_25)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 25.0)
@@ -8728,11 +8746,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -8740,10 +8758,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 4h still high
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_mfi_14_1h < 40.0)
         | (protection_mfi_14_4h < 50.0)
         | (protection_cmf_20_1h > -0.0)
@@ -8754,10 +8772,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h & 4h still high, 15m & 1h & 4h high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_25)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
@@ -8767,10 +8785,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h & 4h still high, 15m & 1h downtrend, 4h high, 15m & 1h still high
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_25)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.10)
         | (protection_aroonu_14_4h < 70.0)
@@ -8779,8 +8797,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still high, 1h >& 4h high, 15m & 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_14_15m < 40.0)
+        (rsi_3_15m_gt_25)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
@@ -8792,8 +8810,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_14_15m < 40.0)
+        (rsi_3_15m_gt_25)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_15m < 60.0)
@@ -8803,8 +8821,8 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m still high, 1h & 4h high, 1d downtrend, 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_14_15m < 40.0)
+        (rsi_3_15m_gt_25)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 75.0)
         | (protection_cmf_20_1d > -0.0)
@@ -8813,7 +8831,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_15m > 25.0)
+        (rsi_3_15m_gt_25)
         | (protection_aroonu_14_15m < 80.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
@@ -8822,7 +8840,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h still not low enough
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_rsi_14_15m < 10.0)
@@ -8835,12 +8853,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enugh, 4h still high, 15m still high, 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 10.0)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -8849,10 +8867,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_aroonu_14_15m < 30.0)
@@ -8863,20 +8881,20 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 1h & 4h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.35)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -15.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high, 1h & 4h & 1d downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_15m < 25.0)
@@ -8889,12 +8907,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 4h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 40.0)
@@ -8903,13 +8921,13 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.15)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_cci_20_1h < -100.0)
@@ -8917,58 +8935,58 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1d high
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_1d < 90.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still not low enough, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 25.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend, 15m & 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
@@ -8976,34 +8994,34 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_roc_9_4h > -40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 20.0)
@@ -9011,12 +9029,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1h still not low enough, 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -9024,11 +9042,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h downtrend, 15m & 1h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 60.0)
@@ -9036,10 +9054,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still not low enough, 1h sitll high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -9047,12 +9065,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h still high, 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -9060,19 +9078,19 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15h & 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 1h & 4h down move, 15m high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_15m < 70.0)
@@ -9080,12 +9098,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -9093,30 +9111,30 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still low, 1h & 4h still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h high, 1d downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
@@ -9127,47 +9145,47 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_roc_9_4h > -20.0)
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m & 4h still high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_roc_9_4h < 10.0)
@@ -9175,44 +9193,44 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cci_20_1h < 0.0)
         | (protection_cci_20_4h < 0.0)
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m still high, 1h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h stil high, 4h high, 1h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_cmf_20_1h > -0.10)
         | (protection_aroonu_14_1h < 40.0)
@@ -9220,30 +9238,30 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1h & 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 4h downtrend, 15m & 1h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_rsi_3_1d > 55.0)
@@ -9254,22 +9272,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_1h < 80.0)
@@ -9277,12 +9295,12 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -9291,33 +9309,33 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 4h downtrend, 1h still high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 50.0)
         | (protection_roc_9_1d < 150.0)
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high & overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -9326,9 +9344,9 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -9336,17 +9354,17 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_4h > 5.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
       )
       # 15m & 4h down move, 15m & 1h high, 4h downtrend
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -9355,10 +9373,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h still high, 1h & 4h downtrend, 15m & 1h still high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
@@ -9367,19 +9385,19 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high & overbought
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 75.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -9389,21 +9407,21 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h stil high, 14m & 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
+        (rsi_3_15m_gt_30)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -9411,19 +9429,19 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 1d overbought
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_30)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_roc_9_1d < 200.0)
       )
       # 15m down move, 15m still not low enough, 1h & 4h high
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_14_15m < 30.0)
+        (rsi_3_15m_gt_30)
+        | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -9433,10 +9451,10 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m down move, 15m & 1h & 4h still high, 15m high, 15m & 1h still high, 4h high, 4h overbought
       & (
-        (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_15m_gt_30)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -9447,8 +9465,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -9459,9 +9477,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -9472,8 +9490,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_roc_9_1d < 200.0)
       )
@@ -9482,8 +9500,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
@@ -9493,8 +9511,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
@@ -9517,9 +9535,9 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1d < 50.0)
@@ -9529,9 +9547,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -9542,9 +9560,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 10.0)
@@ -9555,9 +9573,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -9567,9 +9585,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_1h > -0.30)
         | (protection_aroonu_14_1h < 50.0)
@@ -9579,8 +9597,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_stochk_14_3_3_1h < 60.0)
         | (protection_stochk_14_3_3_4h < 90.0)
@@ -9597,10 +9615,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -9609,9 +9627,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -9621,9 +9639,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -9634,9 +9652,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h < 80.0)
@@ -9645,10 +9663,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_1d < 75.0)
@@ -9657,10 +9675,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -9670,10 +9688,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
@@ -9682,10 +9700,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -9713,7 +9731,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 40.0)
+        | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
@@ -9722,9 +9740,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
       )
@@ -9732,9 +9750,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_15m < 50.0)
@@ -9745,9 +9763,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
@@ -9769,8 +9787,8 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m down move, 15m & 1h still high, 4h high, 15m downtrend, 15m high, 1h & 4h overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_15m > -0.10)
         | (protection_aroonu_14_15m < 70.0)
@@ -9782,9 +9800,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 70.0)
@@ -9794,9 +9812,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
@@ -9825,10 +9843,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 50.0)
@@ -9837,18 +9855,18 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 90.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h high & overbought
       & (
-        (protection_rsi_3_15m > 10.0)
+        (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -9859,9 +9877,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
         | (protection_roc_9_1h > -30.0)
         | (protection_roc_9_4h > -40.0)
@@ -9871,9 +9889,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
       )
@@ -9890,11 +9908,11 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_roc_9_1d < 50.0)
@@ -9903,10 +9921,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_4h > -0.15)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -9918,9 +9936,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -9929,9 +9947,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 65.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 20.0)
@@ -9943,8 +9961,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 65.0)
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -9955,9 +9973,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_15m < 10.0)
@@ -9967,9 +9985,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_1h < 20.0)
@@ -9979,8 +9997,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1d > 20.0)
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -9990,7 +10008,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 90.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -10011,8 +10029,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -10022,9 +10040,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
@@ -10034,9 +10052,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
@@ -10047,9 +10065,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_cmf_20_1d > -0.30)
@@ -10060,7 +10078,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -10073,9 +10091,9 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -10084,9 +10102,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 40.0)
@@ -10096,7 +10114,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 60.0)
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -10117,9 +10135,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.35)
@@ -10153,10 +10171,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 55.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -10179,12 +10197,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 4h still not low enough
       & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | (protection_aroonu_14_4h < 20.0))
       # 1h & 4h down move, 15m still not low enough, 4h downtrend
-      & (
-        (protection_rsi_3_1h > 3.0)
-        | (protection_rsi_3_4h > 5.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_cmf_20_4h > -0.30)
-      )
+      & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 5.0) | rsi_14_15m_lt_30 | (protection_cmf_20_4h > -0.30))
       # 1h & 4h down move, 1h downtrend, 4h still high
       & (
         (protection_rsi_3_1h > 3.0)
@@ -10196,8 +10209,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 3.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_roc_9_1d < 80.0)
       )
       # 1h & 4h & 1d down move, 1d still not low enough, 1d downtrend
@@ -10255,9 +10268,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -10302,10 +10315,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend
       & (
         (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
@@ -10333,8 +10346,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_rsi_3_1d > 60.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 40.0)
         | (protection_aroonu_14_1d < 70.0)
         | (protection_roc_9_1d < 100.0)
@@ -10345,7 +10358,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_15m < 10.0)
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -10363,9 +10376,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -20.0)
         | (protection_roc_9_1d < 80.0)
@@ -10382,8 +10395,8 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h & 4h high, 4h overbought
       & (
         (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -10391,20 +10404,20 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h still high
       & (
-        (protection_rsi_3_1h > 30.0)
+        (rsi_3_1h_gt_30)
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 5.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
       # 1h & 4h down move, 1h & 4h still high, 1h still not low enough, 4h still high, 1h downtrend, 4h & 1d overbought
       & (
-        (protection_rsi_3_1h > 30.0)
+        (rsi_3_1h_gt_30)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 25.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1h > -10.0)
@@ -10413,22 +10426,22 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h down move, 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
-        (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        (rsi_3_1h_gt_30)
+        | rsi_3_4h_gt_60
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h < 25.0)
       )
       # 1h down move, 1h still high, 4h overbought
-      & ((protection_rsi_3_1h > 55.0) | (protection_rsi_14_1h < 40.0) | (protection_roc_9_4h < 300.0))
+      & ((protection_rsi_3_1h > 55.0) | rsi_14_1h_lt_40 | (protection_roc_9_4h < 300.0))
       # 1h & 1d down move, 1h & 4h & 1d still high, 1h & 4h high, 4h overbought
       & (
         (protection_rsi_3_1h > 60.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_mfi_14_1d < 50.0)
         | (protection_aroonu_14_1h < 70.0)
@@ -10436,12 +10449,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h < 25.0)
       )
       # 4h down move, 15m & 1h & 4h still not low enough
-      & (
-        (protection_rsi_3_4h > 3.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 30.0)
-      )
+      & ((protection_rsi_3_4h > 3.0) | rsi_14_15m_lt_20 | (protection_rsi_14_1h < 20.0) | rsi_14_4h_lt_30)
       # 4h down move, 1h & 4h downtrend, 1h still not low enough
       & (
         (protection_rsi_3_4h > 3.0)
@@ -10499,7 +10507,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 4h & 15m still not low enough
       & (
         (protection_rsi_3_4h > 5.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.20)
@@ -10528,9 +10536,9 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h down move, 15m & 1h & 4h still high, 15m high
       & (
         (protection_rsi_3_4h > 10.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
@@ -10538,9 +10546,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 15.0)
         | (protection_rsi_3_1d > 65.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_roc_9_4h > -40.0)
         | (protection_roc_9_1d < 200.0)
       )
@@ -10548,8 +10556,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1d > -40.0)
@@ -10557,8 +10565,8 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h down move, 1h & 4h still not low enough, 15m high, 4h downtrend
       & (
         (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h > -50.0)
@@ -10567,7 +10575,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 40.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_4h > -0.25)
@@ -10578,8 +10586,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 35.0)
         | (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -10599,7 +10607,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d down move, 15m & 1h still not low enough, 4h & 1d downtrend
       & (
         (protection_rsi_3_1d > 3.0)
-        | (protection_rsi_14_15m < 20.0)
+        | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -10609,8 +10617,8 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d down move, 1h & 4h still not low enough, 1h still high & overbought, 1d downtrend
       & (
         (protection_rsi_3_1d > 3.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1h < 10.0)
@@ -10619,9 +10627,9 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d down move, 15m & 1h & 4h still not low enough, 15m still not low enough, 1h high
       & (
         (protection_rsi_3_1d > 5.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -10629,7 +10637,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d down move, 15m still not low enough, 1h high, 1d downtrend
       & (
         (protection_rsi_3_1d > 5.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_14_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_2_1d > -40.0)
       )
@@ -10660,8 +10668,8 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d down move, 1h & 4h still high, 1h & 4h downtrend, 1h & 4h high, 1d downtrend
       & (
         (protection_rsi_3_1d > 10.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 50.0)
@@ -10671,7 +10679,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h still high, 4h downtrend, 4h overbought
       & (
         (protection_rsi_14_15m < 50.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_4h > -0.2)
         | (protection_roc_9_4h < 250.0)
@@ -10679,11 +10687,11 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h red, 15m & 1h & 4h down move, 1h & 4h still high, 4h high
       & (
         (protection_change_pct_4h > -30.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 70.0)
       )
       # 4h P&D, 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
@@ -10693,9 +10701,9 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
       )
@@ -10705,9 +10713,9 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_4h < 10.0)
         | (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 90.0)
       )
@@ -10716,7 +10724,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_4h < 10.0)
         | (protection_top_wick_pct_4h < 10.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -10726,7 +10734,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_4h < 15.0)
         | (protection_top_wick_pct_4h < 15.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 35.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -10735,7 +10743,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_4h < 15.0)
         | (protection_top_wick_pct_4h < 10.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 40.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -10743,10 +10751,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h green, 15m & 1h down move, 15m still not low enough, 1h & 4h high
       & (
         (protection_change_pct_4h < 15.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -10763,7 +10771,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -20.0)
         | (protection_change_pct_1d.shift(288) < 20.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_4h > 25.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -10771,11 +10779,11 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d red, 15m & 1h & 4h down move, 1h still not low enough, 4h & 1d still high
       & (
         (protection_change_pct_1d > -20.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_14_1h < 35.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_1d < 50.0)
       )
@@ -10785,8 +10793,8 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_rsi_14_1d < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
         | (protection_roc_9_1d > -20.0)
@@ -10794,7 +10802,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d red, 15m & 1h & 4h down move, 1d high, 15m & 1h still high
       & (
         (protection_change_pct_1d > -20.0)
-        | (protection_rsi_3_15m > 30.0)
+        | rsi_3_15m_gt_30
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_1d < 85.0)
@@ -10808,9 +10816,9 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_15m > 50.0)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
       )
@@ -10818,20 +10826,20 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 10.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 10.0)
         | (protection_rsi_3_1d > 40.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_14_4h_lt_30
       )
       # 1d P&D, 15m & 1h down move, 1h still not low enough, 4h still high, 15m downtrend, 1h still high
       & (
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 10.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 50.0)
       )
@@ -10847,24 +10855,24 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 20.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_roc_9_1d < 25.0)
       )
       # 1d P&D, 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend, 1d overbought
       & (
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 50.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -10.0)
         | (protection_roc_9_1d < 100.0)
@@ -10873,7 +10881,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
         | (protection_cmf_20_1h > -0.2)
         | (protection_aroonu_14_1h < 70.0)
@@ -10883,19 +10891,19 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -5.0)
         | (protection_change_pct_1d.shift(288) < 10.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_roc_9_1d < 100.0)
       )
       # 1d P&D, 15m & 1h & 4h down move, 1h & 4h still not low enough, 1h & 4h downtrend, 1d overbought
       & (
         (protection_change_pct_1d > -5.0)
         | (protection_change_pct_1d.shift(288) < 10.0)
-        | (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_15m_gt_25
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 30.0)
@@ -10906,11 +10914,11 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d red, 15m & 1h & 4h down move, 1h & 4h still not low enough, 1d high, 4h downtrend, 1d overbought
       & (
         (protection_change_pct_1d > -5.0)
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_1d < 85.0)
         | (protection_roc_9_4h > -30.0)
         | (protection_roc_9_1d < 20.0)
@@ -10919,11 +10927,11 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_15m_gt_15
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_1d > 65.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d < 20.0)
       )
@@ -10931,11 +10939,11 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 60.0)
       )
@@ -10943,7 +10951,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
@@ -10953,9 +10961,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_3_15m_gt_10
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 75.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_aroonu_14_1d < 90.0)
@@ -10965,11 +10973,11 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 60.0)
@@ -10978,9 +10986,9 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_3_15m_gt_15
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 80.0)
@@ -10998,11 +11006,11 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 20.0)
         | (protection_top_wick_pct_1d < 20.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 20.0)
       )
@@ -11012,8 +11020,8 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 20.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 50.0)
@@ -11023,8 +11031,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 25.0)
         | (protection_top_wick_pct_1d < 25.0)
         | (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -11036,8 +11044,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_15m > 30.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_15m_gt_30
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 70.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 25.0)
@@ -11048,7 +11056,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 20.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_1h < 20.0)
@@ -11060,8 +11068,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 20.0)
         | (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 50.0)
@@ -11071,7 +11079,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 20.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 40.0)
@@ -11081,10 +11089,10 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 30.0)
-        | (protection_rsi_3_15m > 25.0)
+        | rsi_3_15m_gt_25
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -11093,7 +11101,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 30.0)
         | (protection_rsi_3_15m > 50.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1d < 100.0)
@@ -11101,9 +11109,9 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d green, 15m & 4h down move, 4h still high, 4h & 1d overbought
       & (
         (protection_change_pct_1d < 50.0)
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_roc_9_4h < 40.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -11111,11 +11119,11 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 50.0)
         | (protection_top_wick_pct_1d < 50.0)
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 70.0)
       )
       # 1d green with top wick, 1d down move, 4h still high & overbought
@@ -11123,7 +11131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 50.0)
         | (protection_top_wick_pct_1d < 50.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -11132,7 +11140,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 50.0)
         | (protection_top_wick_pct_1d < 50.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_4h_lt_40
         | (protection_roc_9_1d < 200.0)
       )
       # 1d green, 15m & 4h down move, 15m & 1h & 4h still high, 15m high, 4h & 1d overbought
@@ -11140,9 +11148,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 50.0)
         | (protection_rsi_3_15m > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_roc_9_4h < 30.0)
         | (protection_roc_9_1d < 200.0)
@@ -11150,10 +11158,10 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h top wick, 15m down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
         (protection_top_wick_pct_4h < 20.0)
-        | (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_3_15m_gt_25
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 50.0)
@@ -11163,8 +11171,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_top_wick_pct_4h < 20.0)
         | (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
@@ -11190,8 +11198,8 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d top wick, 15m & 1h & 4h down move, 15m & 1h downtrend, 4h still high
       & (
         (protection_top_wick_pct_1d < 25.0)
-        | (protection_rsi_3_15m > 10.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_15m_gt_10
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 50.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
@@ -11200,12 +11208,12 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d top wick, 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high
       & (
         (protection_top_wick_pct_1d < 25.0)
-        | (protection_rsi_3_15m > 30.0)
+        | rsi_3_15m_gt_30
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -11215,8 +11223,8 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_top_wick_pct_1d < 25.0)
         | (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 50.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -11228,9 +11236,9 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 65.0)
         | (protection_rsi_3_4h > 65.0)
-        | (protection_rsi_14_15m < 40.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_40
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 50.0)
       )
       # pump, drop but not yet near the previous lows, 15m & 1h & 4h & 1d down move, 1d overbought
@@ -11238,7 +11246,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (((protection_high_max_6_1d - protection_low_min_6_1d) / protection_low_min_6_1d) < 1.5)
         | (protection_close > (protection_high_max_6_4h * 0.70))
         | (protection_close < (protection_low_min_6_1d * 1.25))
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 45.0)
@@ -11250,19 +11258,19 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_close > (protection_high_max_24_4h * 0.70))
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_1d > 50.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_roc_9_1d < 20.0)
       )
       # pump, 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h downtrend, 1h high
       & (
         (((protection_high_max_12_1d - protection_low_min_12_1d) / protection_low_min_12_1d) < 3.0)
-        | (protection_rsi_3_15m > 20.0)
-        | (protection_rsi_3_1h > 30.0)
+        | rsi_3_15m_gt_20
+        | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_14_15m < 20.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 40.0)
+        | rsi_14_15m_lt_20
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
         | (protection_aroonu_14_1h < 70.0)
       )
@@ -11271,9 +11279,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (((protection_high_max_30_1d - protection_low_min_30_1d) / protection_low_min_30_1d) < 10.0)
         | (protection_close > (protection_high_max_6_1d * 0.50))
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_3_4h_gt_60
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_cmf_20_4h > -0.10)
         | (protection_roc_9_4h > -15.0)
         | (protection_roc_9_1d > -25.0)
@@ -11287,12 +11295,12 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 12 hours, 14m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (protection_close > (protection_high_max_12_1h * 0.50))
-        | (protection_rsi_3_15m > 20.0)
+        | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
-        | (protection_rsi_14_4h < 50.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
+        | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -11307,19 +11315,19 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 4 days, 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h overbought
       & (
         (protection_close > (protection_high_max_24_4h * 0.40))
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_14_15m < 30.0)
-        | (protection_rsi_14_1h < 40.0)
+        | rsi_14_15m_lt_30
+        | rsi_14_1h_lt_40
         | (protection_roc_9_4h < 20.0)
       )
       # drop in last 4 days, 15m & 1h & 4h & 1d down move, 4h high
       & (
         (protection_close > (protection_high_max_24_4h * 0.40))
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 10.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
@@ -11336,7 +11344,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 4 days, 15m & 1d down move, 15m still not low enough, 1h still high, 1d high, 4h downtrend
       & (
         (protection_close > (protection_high_max_24_4h * 0.35))
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1d > 30.0)
         | (protection_aroonu_14_15m < 25.0)
         | (protection_aroonu_14_1h < 40.0)
@@ -11365,7 +11373,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 6 days, 15m & 1d down move, 1h still high, 4h high, 4h downtrend
       & (
         (protection_close > (protection_high_max_6_1d * 0.25))
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_1d > 15.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
@@ -11374,9 +11382,9 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 6 days, 15m & 1h down move, 15m & 1h still not low enough, 15m & 1h & 4h & 1d downtrend
       & (
         (protection_close > (protection_high_max_6_1d * 0.25))
-        | (protection_rsi_3_15m > 25.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_15m < 30.0)
+        | rsi_3_15m_gt_25
+        | rsi_3_1h_gt_30
+        | rsi_14_15m_lt_30
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.40)
@@ -11411,7 +11419,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 12 days. 15m & 1h & 4h & 1d down move, 4h still high, 1d downtrend
       & (
         (protection_close > (protection_high_max_12_1d * 0.25))
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 35.0)
@@ -11421,17 +11429,17 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 12 days, 15m & 1h down move, 1h still not low enough, 4h high
       & (
         (protection_close > (protection_high_max_12_1d * 0.25))
-        | (protection_rsi_3_15m > 15.0)
-        | (protection_rsi_3_1h > 30.0)
-        | (protection_rsi_14_1h < 30.0)
-        | (protection_rsi_14_4h < 30.0)
+        | rsi_3_15m_gt_15
+        | rsi_3_1h_gt_30
+        | rsi_14_1h_lt_30
+        | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # drop in last 20 days, 15m & 1h & 1d down move, 15m still not low enough, 1h high
       & (
         (protection_close > (protection_high_max_20_1d * 0.05))
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_1d > 25.0)
         | (protection_aroonu_14_15m < 30.0)
@@ -11441,7 +11449,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_20_1d * 0.01))
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 60.0)
+        | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 15.0)
         | (protection_rsi_14_1h < 15.0)
         | (protection_rsi_14_4h < 20.0)
@@ -11456,7 +11464,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 30 days, 15m & 1h down move, 1h still high, 4h high & overbought
       & (
         (protection_close > (protection_high_max_30_1d * 0.10))
-        | (protection_rsi_3_15m > 10.0)
+        | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 55.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -11465,7 +11473,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 30 days, 15m down move, 15m & 1h high
       & (
         (protection_close > (protection_high_max_30_1d * 0.05))
-        | (protection_rsi_3_15m > 15.0)
+        | rsi_3_15m_gt_15
         | (protection_rsi_3_4h > 50.0)
         | (protection_aroonu_14_15m < 80.0)
         | (protection_stochrsik_14_14_3_3_1h < 85.0)
@@ -11473,7 +11481,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 30 days, 15m & 1h & 4h down move, 15m still not low enough, 1h high
       & (
         (protection_close > (protection_high_max_30_1d * 0.05))
-        | (protection_rsi_3_15m > 25.0)
+        | rsi_3_15m_gt_25
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)


### PR DESCRIPTION
## Summary
- Reuses the high-repeat long-global RSI comparison masks in `populate_indicators()`.
- Expands this PR from the first few repeated RSI masks to the practical remaining high-repeat long-protection RSI slice.
- Builds on the merged global-protection column-view work from #847 and stays independent on latest upstream `main`.

## Safety
- Behavior is preserved: the patch reuses exact local boolean comparison results inside the same long global-protection expression.
- Same indicators, thresholds, comparison operators, condition order, protection output columns, candle selection, entry/exit columns, order classification, profit arithmetic, and return values.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this patch does not change indicators, formulas, thresholds, condition assembly order, candle selection, order classification, or profit arithmetic.
- Static inspection after the update: 16 concrete long-protection RSI masks cover 1,581 exact comparison uses, avoiding 1,565 repeated vector comparisons by reusing the same boolean masks.
- This does not claim measured wall-clock speedup; it only removes repeated identical vector comparisons in the hot global-protection block.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- Diff scan confirmed no touches to `long_grind_entry_v3`, `short_grind_entry_v3`, CMF formula, `rolling_sum`, or `ta.SUM` paths.
