### PR TITLE
Reduce X7 no-derisk adjust reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -50394,6 +50394,7 @@ class NostalgiaForInfinityX7(IStrategy):
     dp = self.dp
     send_msg = self.dp.send_msg
     notification_msg = self.notification_msg
+    scale_stakes_for_min_stake = self.scale_stakes_for_min_stake
     stake_currency = self.config["stake_currency"]
     trade_pair = trade.pair
     trade_amount = trade.amount
@@ -50408,7 +50409,7 @@ class NostalgiaForInfinityX7(IStrategy):
     stake_scale_leverage = trade_leverage if is_futures else 1.0
 
     max_rebuy_sub_grinds = 0
-    regular_mode_rebuy_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_rebuy_stakes = scale_stakes_for_min_stake(
       self.regular_mode_rebuy_stakes_futures if is_futures else self.regular_mode_rebuy_stakes_spot,
       slice_amount,
       min_stake,
@@ -50421,7 +50422,7 @@ class NostalgiaForInfinityX7(IStrategy):
     max_rebuy_sub_grinds = len(regular_mode_rebuy_stakes)
 
     max_grind_1_sub_grinds = 0
-    regular_mode_grind_1_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_1_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_1_stakes_futures if is_futures else self.regular_mode_grind_1_stakes_spot,
       slice_amount,
       min_stake,
@@ -50442,7 +50443,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_2_sub_grinds = 0
-    regular_mode_grind_2_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_2_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_2_stakes_futures if is_futures else self.regular_mode_grind_2_stakes_spot,
       slice_amount,
       min_stake,
@@ -50463,7 +50464,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_3_sub_grinds = 0
-    regular_mode_grind_3_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_3_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_3_stakes_futures if is_futures else self.regular_mode_grind_3_stakes_spot,
       slice_amount,
       min_stake,
@@ -50484,7 +50485,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_4_sub_grinds = 0
-    regular_mode_grind_4_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_4_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_4_stakes_futures if is_futures else self.regular_mode_grind_4_stakes_spot,
       slice_amount,
       min_stake,
@@ -50505,7 +50506,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_5_sub_grinds = 0
-    regular_mode_grind_5_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_5_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_5_stakes_futures if is_futures else self.regular_mode_grind_5_stakes_spot,
       slice_amount,
       min_stake,
@@ -50526,7 +50527,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_6_sub_grinds = 0
-    regular_mode_grind_6_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_6_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_6_stakes_futures if is_futures else self.regular_mode_grind_6_stakes_spot,
       slice_amount,
       min_stake,
@@ -50881,7 +50882,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -50927,13 +50928,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_1_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g1"
         return buy_amount, order_tag, is_derisk
@@ -50964,13 +50965,13 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
           grind_profit_stake=grind_1_current_grind_stake_profit,
           grind_profit_pct=grind_profit,
         )
       )
       log.info(
-        f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {self.config['stake_currency']})"
+        f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {stake_currency})"
       )
       order_tag = "g1"
       return buy_amount, order_tag, is_derisk
@@ -50993,14 +50994,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_1_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g1) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g1) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g1"
           for grind_entry_id in grind_1_buy_orders:
@@ -51038,7 +51039,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_1_total_amount,
@@ -51089,13 +51090,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_2_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g2) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_2_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g2) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_2_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g2"
         return buy_amount, order_tag, is_derisk
@@ -51118,14 +51119,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_2_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g2) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g2) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g2"
           for grind_entry_id in grind_2_buy_orders:
@@ -51163,7 +51164,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_2_total_amount,
@@ -51214,13 +51215,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_3_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g3) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_3_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g3) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_3_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g3"
         return buy_amount, order_tag, is_derisk
@@ -51243,14 +51244,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_3_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g3) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g3) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g3"
           for grind_entry_id in grind_3_buy_orders:
@@ -51288,7 +51289,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_3_total_amount,
@@ -51339,13 +51340,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_4_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g4) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_4_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g4) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_4_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g4"
         return buy_amount, order_tag, is_derisk
@@ -51368,14 +51369,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_4_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g4) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g4) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g4"
           for grind_entry_id in grind_4_buy_orders:
@@ -51413,7 +51414,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_4_total_amount,
@@ -51464,13 +51465,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_5_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g5) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_5_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g5) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_5_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g5"
         return buy_amount, order_tag, is_derisk
@@ -51493,14 +51494,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_5_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g5) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g5) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g5"
           for grind_entry_id in grind_5_buy_orders:
@@ -51538,7 +51539,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_5_total_amount,
@@ -51589,13 +51590,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_6_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g6) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_6_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g6) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_6_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g6"
         return buy_amount, order_tag, is_derisk
@@ -51618,14 +51619,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_6_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g6) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_6_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g6) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_6_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g6"
           for grind_entry_id in grind_6_buy_orders:
@@ -51663,7 +51664,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_6_total_amount,
@@ -51707,7 +51708,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -51749,7 +51750,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -76188,6 +76189,7 @@ class NostalgiaForInfinityX7(IStrategy):
     dp = self.dp
     send_msg = self.dp.send_msg
     notification_msg = self.notification_msg
+    scale_stakes_for_min_stake = self.scale_stakes_for_min_stake
     stake_currency = self.config["stake_currency"]
     trade_pair = trade.pair
     trade_amount = trade.amount
@@ -76202,7 +76204,7 @@ class NostalgiaForInfinityX7(IStrategy):
     stake_scale_leverage = trade_leverage if is_futures else 1.0
 
     max_rebuy_sub_grinds = 0
-    regular_mode_rebuy_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_rebuy_stakes = scale_stakes_for_min_stake(
       self.regular_mode_rebuy_stakes_futures if is_futures else self.regular_mode_rebuy_stakes_spot,
       slice_amount,
       min_stake,
@@ -76215,7 +76217,7 @@ class NostalgiaForInfinityX7(IStrategy):
     max_rebuy_sub_grinds = len(regular_mode_rebuy_stakes)
 
     max_grind_1_sub_grinds = 0
-    regular_mode_grind_1_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_1_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_1_stakes_futures if is_futures else self.regular_mode_grind_1_stakes_spot,
       slice_amount,
       min_stake,
@@ -76236,7 +76238,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_2_sub_grinds = 0
-    regular_mode_grind_2_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_2_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_2_stakes_futures if is_futures else self.regular_mode_grind_2_stakes_spot,
       slice_amount,
       min_stake,
@@ -76257,7 +76259,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_3_sub_grinds = 0
-    regular_mode_grind_3_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_3_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_3_stakes_futures if is_futures else self.regular_mode_grind_3_stakes_spot,
       slice_amount,
       min_stake,
@@ -76278,7 +76280,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_4_sub_grinds = 0
-    regular_mode_grind_4_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_4_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_4_stakes_futures if is_futures else self.regular_mode_grind_4_stakes_spot,
       slice_amount,
       min_stake,
@@ -76299,7 +76301,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_5_sub_grinds = 0
-    regular_mode_grind_5_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_5_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_5_stakes_futures if is_futures else self.regular_mode_grind_5_stakes_spot,
       slice_amount,
       min_stake,
@@ -76320,7 +76322,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     max_grind_6_sub_grinds = 0
-    regular_mode_grind_6_stakes = self.scale_stakes_for_min_stake(
+    regular_mode_grind_6_stakes = scale_stakes_for_min_stake(
       self.regular_mode_grind_6_stakes_futures if is_futures else self.regular_mode_grind_6_stakes_spot,
       slice_amount,
       min_stake,
@@ -76675,7 +76677,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -76721,13 +76723,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_1_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g1"
         return buy_amount, order_tag, is_derisk
@@ -76758,13 +76760,13 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
           grind_profit_stake=grind_1_current_grind_stake_profit,
           grind_profit_pct=grind_profit,
         )
       )
       log.info(
-        f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {self.config['stake_currency']})"
+        f"Grinding entry (g1) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {stake_currency})"
       )
       order_tag = "g1"
       return buy_amount, order_tag, is_derisk
@@ -76787,14 +76789,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_1_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g1) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g1) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g1"
           for grind_entry_id in grind_1_buy_orders:
@@ -76832,7 +76834,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_1_total_amount,
@@ -76883,13 +76885,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_2_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g2) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_2_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g2) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_2_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g2"
         return buy_amount, order_tag, is_derisk
@@ -76912,14 +76914,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_2_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g2) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g2) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g2"
           for grind_entry_id in grind_2_buy_orders:
@@ -76957,7 +76959,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_2_total_amount,
@@ -77008,13 +77010,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_3_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g3) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_3_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g3) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_3_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g3"
         return buy_amount, order_tag, is_derisk
@@ -77037,14 +77039,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_3_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g3) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g3) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g3"
           for grind_entry_id in grind_3_buy_orders:
@@ -77082,7 +77084,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_3_total_amount,
@@ -77133,13 +77135,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_4_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g4) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_4_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g4) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_4_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g4"
         return buy_amount, order_tag, is_derisk
@@ -77162,14 +77164,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_4_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g4) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g4) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g4"
           for grind_entry_id in grind_4_buy_orders:
@@ -77207,7 +77209,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_4_total_amount,
@@ -77258,13 +77260,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_5_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g5) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_5_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g5) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_5_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g5"
         return buy_amount, order_tag, is_derisk
@@ -77287,14 +77289,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_5_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g5) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g5) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g5"
           for grind_entry_id in grind_5_buy_orders:
@@ -77332,7 +77334,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_5_total_amount,
@@ -77383,13 +77385,13 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=buy_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_6_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
           )
         )
         log.info(
-          f"Grinding entry (g6) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_6_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding entry (g6) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_6_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "g6"
         return buy_amount, order_tag, is_derisk
@@ -77412,14 +77414,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_6_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (g6) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_6_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (g6) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_6_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "g6"
           for grind_entry_id in grind_6_buy_orders:
@@ -77457,7 +77459,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_6_total_amount,
@@ -77501,7 +77503,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -77543,7 +77545,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(


### PR DESCRIPTION
## Summary
- Reuses the existing `stake_currency` local inside long/short no-derisk adjust paths instead of reading `self.config[...]` repeatedly.
- Reuses a local `scale_stakes_for_min_stake` method reference across the repeated stake-scaling ladder.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same stake arrays, thresholds, leverage, min-stake scaling inputs, order classification, profit arithmetic, return values, and notification behavior.
- The patch only reuses values already read in the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is local config/method reuse inside the same adjust calls and does not change formulas, thresholds, order classification, candle selection, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
