### PR TITLE
Reuse X7 entry RSI-3 1h series

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12618,6 +12618,7 @@ class NostalgiaForInfinityX7(IStrategy):
     entry_tags = np.full(len(df), "", dtype=object)
     df.loc[:, "enter_long"] = 0
     df.loc[:, "enter_short"] = 0
+    rsi_3_1h = df["RSI_3_1h"]
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
@@ -12682,15 +12683,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 4h high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_15m"] > 10.0) | (df["AROONU_14_4h"] < 100.0))
             # 5m & 1h down move
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 5.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 5.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((df["RSI_3"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 30.0))
             # 5m & 1h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 30.0))
             # 5m & 4h down move, 4h high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
             # 5m down move, 15m high
@@ -12702,27 +12703,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h downtrend, 1h high
             & ((df["RSI_3_15m"] > 1.0) | (df["CMF_20_1h"] > -0.1) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h & 4h & 1d down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 15.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 15.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 4h down move, 4h high
@@ -12748,13 +12749,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, drop in last half hour, 15m downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["close"] > (df["close_max_6"] * 0.75)) | (df["ROC_9_15m"] > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["ROC_9_1d"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["ROC_9_1d"] < 40.0))
             # 5m & 1h down move, 1h overbought
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 60.0) | (df["ROC_9_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 60.0) | (df["ROC_9_1h"] < 40.0))
             # 15m & 4h down move, 1d still high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 15m & 4h down move, 1d downtrend
@@ -12774,19 +12775,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["RSI_14_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["RSI_14_4h"] < 80.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["ROC_9_4h"] < 80.0))
             # 15m & 4h down move, 1h high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1h"] < 75.0))
             # 15m & 4h down move, 15m still high
@@ -12824,7 +12825,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((df["RSI_3_15m"] > 10.0) | (df["ROC_9_4h"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m down move, 15m still high, 4h overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_14_15m"] < 50.0) | (df["ROC_9_4h"] < 50.0))
             # 15m down move, 15m & 1h high
@@ -12844,109 +12845,109 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 40.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -10.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -10.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 1d down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_1h"] > -0.3))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_1h"] > -0.3))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 1d down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_15m"] < 30.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_14_4h"] < 75.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 75.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_4h"] < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 40.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down mve, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h & 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_4h"] > -30.0))
             # 1h & 4h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["ROC_9_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["ROC_9_4h"] < 80.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 60.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 50.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h high, 15n downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_15m"] > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_4h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["ROC_9_4h"] < 40.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["ROC_9_4h"] < 40.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["CMF_20_1h"] > -0.25) | (df["AROONU_14_1h"] < 90.0))
+            & ((rsi_3_1h > 40.0) | (df["CMF_20_1h"] > -0.25) | (df["AROONU_14_1h"] < 90.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_15m"] > -15.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 20.0))
             # 1h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1h"] < 50.0) | (df["RSI_14_4h"] < 90.0))
+            & ((rsi_3_1h > 60.0) | (df["AROONU_14_1h"] < 50.0) | (df["RSI_14_4h"] < 90.0))
             # 4h & 1d down move, 1d high
             & ((df["RSI_3_4h"] > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
             # 4h down move, 4h & 1d downtrend
@@ -13028,9 +13029,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m still high
             & ((df["ROC_2"] > -10.0) | (df["AROONU_14_15m"] < 50.0))
             # 5m down move, 15m & 1h down move, 15m still high
-            & (
-              (df["ROC_9"] > -15.0) | (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 50.0)
-            )
+            & ((df["ROC_9"] > -15.0) | (df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 50.0))
             # 5m down move, 4h down move, 15m downtrend, 1h high
             & (
               (df["ROC_9"] > -15.0) | (df["RSI_3_4h"] > 45.0) | (df["CMF_20_15m"] > -0.3) | (df["AROONU_14_1h"] < 60.0)
@@ -13042,17 +13041,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, 1d downtrend
             & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.0))
             # 1d green with top wick, 1h down move
-            & ((df["change_pct_1d"] < 20.0) | (df["top_wick_pct_1d"] < 15.0) | (df["RSI_3_1h"] > 20.0))
+            & ((df["change_pct_1d"] < 20.0) | (df["top_wick_pct_1d"] < 15.0) | (rsi_3_1h > 20.0))
             # 1d green with top wick, 4h high
             & ((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 25.0) | (df["AROONU_14_4h"] < 80.0))
             # 1d green, 1h down move, 1d downtrend
-            & ((df["change_pct_1d"] < 40.0) | (df["RSI_3_1h"] > 25.0) | (df["CMF_20_1d"] > -0.2))
+            & ((df["change_pct_1d"] < 40.0) | (rsi_3_1h > 25.0) | (df["CMF_20_1d"] > -0.2))
             # 1d green with top wick, 4h overbought
             & ((df["change_pct_1d"] < 50.0) | (df["top_wick_pct_1d"] < 30.0) | (df["ROC_9_4h"] < 80.0))
             # big drop in the last hour, 15m downtrend
             & ((df["close"] > (df["close_max_12"] * 0.65)) | (df["CMF_20_15m"] > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
-            & ((df["close"] > (df["high_max_6_1h"] * 0.60)) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((df["close"] > (df["high_max_6_1h"] * 0.60)) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 60.0))
             # big drop in the last 24 hours,  1h still high
             & ((df["close"] > (df["high_max_24_1h"] * 0.40)) | (df["STOCHRSIk_14_14_3_3_1h"] < 45.0))
             # big drop in the last 4 days, 1h high
@@ -13081,13 +13080,13 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0))
             # 5m & 4h down move, 15m still not low enough
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 5m & 4h down move, 1d downtrend
@@ -13125,51 +13124,51 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1h overbought
             & ((df["RSI_3"] > 10.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 1.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 1.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 1h down move, 15m downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["CMF_20_15m"] > -0.30))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["CMF_20_15m"] > -0.30))
             # 15m & 1h down move, 15m still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_15m"] < 30.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1h"] < 25.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1h"] < 25.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] > -40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 15m downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["CMF_20_15m"] > -0.40))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["CMF_20_15m"] > -0.40))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 40.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 4h down move, 4h still not low enough
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["RSI_14_4h"] < 30.0))
             # 15m & 4h down move, 4h downtrend
@@ -13195,21 +13194,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -50.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 1d down move, 1d still high, 4h still high
             & ((df["RSI_3_1d"] > 50.0) | (df["RSI_14_1d"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 4h down move, 1d still high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 15m & 4h down move, 15m still not low enough
@@ -13247,41 +13246,41 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 20.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 60.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 75.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 75.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] > -50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] > -50.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["RSI_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["RSI_14_4h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 16m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 4h down move, 4h still not low enough
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 15m & 4h down move, 1d high
@@ -13319,19 +13318,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 4h downtrend
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] > -20.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["ROC_9_4h"] > -20.0))
             # 15m & 1h down move, 1h downtrend
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 90.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 4h down move, 1h high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 4h down move, 4h downtrend
@@ -13367,17 +13366,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_1d"] < 10.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 30.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["ROC_9_4h"] < 50.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 4h down move, 1h high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 4h down move, 4h high
@@ -13395,7 +13394,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["ROC_9_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 4h down move, 1h overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1h"] < 100.0))
             # 15m down move, 15m still not low enough, 1h high
@@ -13425,189 +13424,189 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 40.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 1.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -10.0))
+            & ((rsi_3_1h > 1.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -10.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 4h down move, 15m downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 1d down move, 15m still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] > -30.0))
             # 1h % 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_4h"] > -0.30))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 1d down move, 15m still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 60.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 1d down move, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h high, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -10.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -10.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 85.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.50))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -25.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -25.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1h"] < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 4h & 1d down move, 1d still high
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
             # 4h & 1d down move, 1d still high
@@ -13812,11 +13811,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((df["RSI_3"] > 15.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 90.0))
             # 15m & 1h dowbn move, 1d high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1d down move, 1h high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move, 1h still high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 4h down move, 15m still high
@@ -13832,13 +13831,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -20.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 75.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 75.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 4h down move, 1d downtrend
@@ -13876,13 +13875,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] < 25.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 80.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 4h down move, 15m high
@@ -13938,7 +13937,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["ROC_9_4h"] < 25.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_15m"] < 75.0))
             # 15m & 4h down move, 1h high
@@ -13974,9 +13973,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["ROC_9_4h"] < 50.0) | (df["ROC_9_1d"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 40.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m down move, 1d high, 15m high
@@ -14014,139 +14013,139 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h down move, 4h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 20.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 60.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 1d down move, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 1d down move, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 60.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 60.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_1d"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] > -40.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_4h"] > -40.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 15m & 1h still high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h down move, 1h still high 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h & 1h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1h"] < 75.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1h"] < 75.0))
             # 1h down move, 15m still high, 4h  high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 15m still high, 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h down move, 15m still high, 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 15m & 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["CMF_20_1h"] > -0.30) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 35.0) | (df["CMF_20_1h"] > -0.30) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -80.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((rsi_3_1h > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((rsi_3_1h > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 1h down move, 15m still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (df["ROC_9_4h"] > -15.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (df["ROC_9_4h"] > -15.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_15m"] < 50.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 50.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 15m & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 90.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 90.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["CMF_20_1d"] > -0.20))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["CMF_20_1d"] > -0.20))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 15m high, 4h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_15m"] < 70.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 70.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 100.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 100.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 15m & 1h high
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 50.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h high, 1d high
-            & ((df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 15m & 1h high
-            & ((df["RSI_3_1h"] > 65.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((rsi_3_1h > 65.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 100.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_1d"] > -30.0))
             # 4h down move, 1h still high, 4h downtrend
@@ -14481,19 +14480,19 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["RSI_3_15m"] > 3.0)
             # 5m & 1h down move, 1d still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 3.0) | (df["AROONU_14_1d"] < 40.0))
             # 5m & 1h & 4h down move
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 70.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 5m & 1h down move, 1d downtrend
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
             # 5m & 4h down move, 4h high
@@ -14507,31 +14506,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1h overbought
             & ((df["RSI_3"] > 10.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 30.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 40.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 4h down move, 1d overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] < 70.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 15m stil high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m & 1h down move, 4h downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -40.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m down move, 4h high, 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 15m down move, 4h & 1d high
@@ -14541,7 +14540,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 15m down move, 4h high & overbought
@@ -14551,7 +14550,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m down move, 4h high, 1d overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 100.0))
             # 15m down move, 4h high, 1h overbought
@@ -14563,119 +14562,119 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_4h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 85.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 40.0) | (df["RSI_3_1h"] > 50.0) | (df["ROC_9_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 40.0) | (rsi_3_1h > 50.0) | (df["ROC_9_4h"] < 50.0))
             # 1h & 4h down move, 15m downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_15m"] > -0.40))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 1h down move, 1h high, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h down move, 15m still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_4h"] < 20.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["RSI_3_1d"] > 10.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["RSI_3_1d"] > 10.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1h"] > -20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_1h"] > -40.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["CMF_20_1h"] > -0.40))
+            & ((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["CMF_20_1h"] > -0.40))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1h"] > -20.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 3h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h down move, 1d high, 15m downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_15m"] > -50.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_15m"] > -50.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -15.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -15.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] > -50.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] > -50.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 200.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (df["AROONU_14_1h"] < 60.0))
             # 1h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
             # 4h down move, 4h high, 4h downtrend
             & ((df["RSI_3_4h"] > 3.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_4h"] > -40.0))
             # 4h & 1d down move, 1h still not low enough
@@ -14773,27 +14772,27 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["RSI_3_15m"] > 20.0)
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 5m & 4h down move, 15m still high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m down move, 15m stil not low enough, 4h high
             & ((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_15m"] < 30.0) | (df["AROONU_14_4h"] < 60.0))
             # 15m down move, 15m high, 1h high
@@ -14805,7 +14804,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m down move, 15m still high, 1d high
             & ((df["RSI_3_15m"] > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 15m down move, 15m high, 4h high
@@ -14827,159 +14826,159 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((df["RSI_3_15m"] > 35.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 20.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 40.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((df["RSI_3_15m"] > 40.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m down move, 15m still high, 1h high
             & ((df["RSI_3_15m"] > 45.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 15.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 15.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1h"] > -15.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1h"] > -20.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h down move, 4h downtrend. 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -20.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -20.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h down move, 15m still high, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_15m"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 1h down move, 15m high, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_15m"] < 70.0) | (df["ROC_9_4h"] > -10.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 70.0) | (df["ROC_9_4h"] > -10.0))
             # 1h down move, 1h still high, 15m downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 40.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 40.0) | (df["CMF_20_15m"] > -0.30))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 4h high, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 60.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 60.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_15m"] < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (df["AROONU_14_1h"] < 60.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 4h downtrend, 1d over
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -25.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -25.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 15m high, 1h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_1h"] < 20.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 20.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1h"] < 40.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 50.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 15m high, 1h high
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 60.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 40.0))
             # 4h & 1d down move, 4h downtrend
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["ROC_9_4h"] > -20.0))
             # 4h & 1d down move, 1h still not low enough
@@ -15130,9 +15129,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 1d downtrend
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_15m"] > 25.0) | (df["ROC_9_1d"] > -30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 5m & 4h down move, 4h still high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 5m & 4h & 1d down move
@@ -15146,9 +15145,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h & 1d overbought
             & ((df["RSI_3"] > 3.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 40.0))
             # 5m & 1h down move, 4h high
-            & ((df["RSI_3"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 60.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 5.0) | (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_1h"] < 80.0))
             # 5m & 4h down move, 1d downtrend
             & ((df["RSI_3"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] > -20.0))
             # 5m & 4h down move, 4h still high
@@ -15170,17 +15169,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d still high
             & ((df["RSI_3"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 20.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["RSI_14_4h"] < 40.0) | (df["ROC_9_1d"] > -10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 25.0) | (df["RSI_14_4h"] < 40.0) | (df["ROC_9_1d"] > -10.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 20.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 4h down move, 1h still not low enough
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 15m & 4h down move, 1d downtrend
@@ -15200,21 +15199,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d downtrend, 1d high
             & ((df["RSI_3_15m"] > 3.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] < 10.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 90.0))
             # 15m & 1h & 4h down move, 15m downtrend
-            & (
-              (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["CMF_20_15m"] > -0.30)
-            )
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["CMF_20_15m"] > -0.30))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 55.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 55.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 4h down move, 15m still not low enough
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_15m"] < 30.0))
             # 15m & 4h down move, 4h high
@@ -15230,33 +15227,33 @@ class NostalgiaForInfinityX7(IStrategy):
               (df["RSI_3_15m"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0)
             )
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] > -40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 45.0) | (df["ROC_9_1d"] < 150.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 45.0) | (df["ROC_9_1d"] < 150.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 65.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 65.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 80.0))
             # 15m & 4h down move, 4h still not low enough
@@ -15314,25 +15311,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_1d"] < 10.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["RSI_3_1h"] > 15.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (rsi_3_1h > 15.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0))
             # 15m & 1h down move, 1h downtrend
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 55.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 55.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 90.0))
             # 15m & 4h down move, 15m still high
@@ -15388,21 +15385,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 1h overbought
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 50.0) | (df["ROC_9_1h"] < 10.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 10.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 4h & 1d down move
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 20.0))
             # 15m & 4h down move, 1d high
@@ -15440,19 +15437,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 15m downtrend
             & ((df["RSI_3_15m"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["CMF_20_15m"] > -0.40))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["ROC_9_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 4h down move, 4h overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 55.0) | (df["ROC_9_4h"] < 30.0))
             # 15m & 1d down move, 1h high
@@ -15480,9 +15477,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 30.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 15m down move, 1h high & overbought
@@ -15494,9 +15491,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 35.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 35.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 35.0) | (df["RSI_3_1h"] > 65.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 35.0) | (rsi_3_1h > 65.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m down move, 15m still not low enough, 1h high
@@ -15512,7 +15509,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((df["RSI_3_15m"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0) | (df["ROC_9_1h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 40.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 40.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 4h down move, 1h high
             & ((df["RSI_3_15m"] > 40.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0))
             # 15m down move, 15m still high, 1d high
@@ -15522,151 +15519,151 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((df["RSI_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 40.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1h still high, 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 40.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 60.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_1d"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1h"] < 60.0))
             # 1h down move, 4h & 1d down move
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 80.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 40.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 40.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1h"] < 75.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1h"] < 75.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 35.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((rsi_3_1h > 40.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h still high, 1d high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 85.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_15m"] > -15.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 30.0) | (df["ROC_9_1d"] > -25.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 30.0) | (df["ROC_9_1d"] > -25.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1h"] < 20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 55.0) | (df["RSI_3_4h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((rsi_3_1h > 55.0) | (df["RSI_3_4h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 60.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 60.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 4 high, 1h overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 60.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1d high, 1h overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 60.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -10.0))
+            & ((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -10.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 65.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 25.0))
+            & ((rsi_3_1h > 65.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 25.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((df["RSI_3_4h"] > 3.0) | (df["AROONU_14_1h"] < 20.0) | (df["ROC_9_4h"] > -10.0))
             # 4h down move, 4h & 1d downtrend
@@ -15891,15 +15888,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["ROC_9_1h"] < 25.0) | (df["ROC_9_4h"] < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 45.0) | (df["ROC_9_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 45.0) | (df["ROC_9_4h"] < 50.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 60.0) | (df["ROC_9_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 60.0) | (df["ROC_9_4h"] < 70.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 55.0) | (df["AROONU_14_4h"] < 90.0))
             # 15m down move, 4h high & overbought
@@ -15911,7 +15908,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0) | (df["ROC_9_1d"] > -15.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["ROC_9_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["ROC_9_4h"] < 100.0))
             # 15m & 1d down move, 1h high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m down move, 15m still high, 4h high
@@ -15933,9 +15930,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["ROC_9_4h"] < 80.0) | (df["ROC_9_1d"] < 200.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 55.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 55.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m down move, 15m still high, 1d downtrend
             & ((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_15m"] < 40.0) | (df["ROC_9_1d"] > -25.0))
             # 15m down move, 1h & 4h high
@@ -15955,59 +15952,59 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 40.0) | (df["ROC_9_4h"] < 100.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h overbought, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] < 50.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] < 50.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 1h & 4h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 50.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] < 40.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 60.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 1h & 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_1h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 25.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 25.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1h"] < 20.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] > -25.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] > -25.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1h & 1d overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["ROC_9_1h"] < 25.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 25.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 80.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 80.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 60.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1h & 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_1d"] < 250.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_1d"] < 250.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 65.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 65.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h overbought
-            & ((df["RSI_3_1h"] > 65.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_1h > 65.0) | (df["ROC_9_1h"] < 40.0))
             # 4h down move, 1h high & overbought
             & ((df["RSI_3_4h"] > 3.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1h"] < 60.0))
             # 1d down move, 4h high & overbought
@@ -16117,35 +16114,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 4h still high
             ((df["RSI_3"] > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 15m & 1h down move, 15m downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["CMF_20_15m"] > -0.40))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_1d"] > -20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["ROC_9_1d"] > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 75.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 75.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["AROONU_14_4h"] < 80.0))
             # 15m & 4h down move, 4h still high
@@ -16169,15 +16166,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["ROC_9_1d"] > -10.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["ROC_9_1d"] > -10.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 80.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 4h down move, 1h still high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 4h down move, 1d downtrend
@@ -16197,25 +16194,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 20.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 20.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m & 1d down move, 4h high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1d down move, 4h high
@@ -16253,11 +16250,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 90.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1d down move, 4h high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 1d down move, 4h high
@@ -16287,11 +16284,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m &4h down move, 4h still high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 4h down move, 1d overbought
@@ -16325,263 +16322,263 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((df["RSI_3_15m"] > 30.0) | (df["AROONU_14_1h"] < 90.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h down move, 15m & 1h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30))
             # 1h down move, 1h still high, 1h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1h"] > -20.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1h"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 20.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 20.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["CMF_20_1h"] > -0.30))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -50.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -50.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -35.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -35.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 15m downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_15m"] > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 1d down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 1d down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 1d down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["CMF_20_1h"] > -0.40))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["CMF_20_1h"] > -0.40))
             # 1h down move, 1d downtrend, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h down move, 1h high, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 1h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1h"] > -15.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -25.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -25.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -70.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 1h downtrend, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["CMF_20_1h"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h high, 1h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 80.0) | (df["CMF_20_1h"] > -0.25))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 80.0) | (df["CMF_20_1h"] > -0.25))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 60.0))
             # 1h down move, 4h high, 15m downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_15m"] > -15.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_1h"] > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_1d"] < 35.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_1d"] < 35.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 1d down move, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_1h"] < 20.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_1h"] < 20.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 15m downtrend, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_15m"] > -25.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_15m"] > -25.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h & 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_1h"] > -50.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -50.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_1h"] > -25.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -25.0) | (df["ROC_9_4h"] < 50.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_1h"] < 30.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] < 30.0) | (df["ROC_9_4h"] < 100.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 90.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["CMF_20_1h"] > -0.25) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((rsi_3_1h > 30.0) | (df["CMF_20_1h"] > -0.25) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1h"] < 50.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 15m & 1h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 100.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -40.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 70.0))
+            & ((rsi_3_1h > 35.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 70.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1h high, 1d high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_15m"] > -10.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_15m"] > -10.0))
             # 1h down move, 1h  high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 100.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 100.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -70.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 1h down move, 1h overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_1h"] < 30.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
             # 4h & 1d down move, 1d still not low enough
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 30.0))
             # 4h down move, 4h high, 1h downtrend
@@ -16741,37 +16738,37 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1d still high
-            ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["ROC_9_1h"] > -50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["ROC_9_1h"] > -50.0))
             # 15m & 1h down move, 1d still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0))
             # 15m & 4h down move, 4h still high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 15m & 4h down move, 1d still high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["ROC_9_1d"] > -30.0))
             # 15m down move, 4h still high, 1d downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1h"] < 40.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 70.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0))
             # 15m & 4h down move, 1h downtrend
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1h"] > -20.0))
             # 15m & 4h down move, 1d downtrend
@@ -16779,21 +16776,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 10.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 10.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1d down move, 4h still high
@@ -16807,9 +16804,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m & 4h down move, 15m still high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m & 4h down move, 4h high
@@ -16833,237 +16830,237 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 4h down move
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] > -50.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] > -50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 75.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 75.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["RSI_14_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["RSI_14_1d"] < 50.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_1h"] > -0.30) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 40.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 40.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 15m high
-            & ((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 40.0) | (df["ROC_9_1d"] > -15.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 40.0) | (df["ROC_9_1d"] > -15.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h & 4h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 1h & 1d down move, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["CMF_20_1h"] > -0.30) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1d still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 50.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 50.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 45.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 45.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_1d"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_15m"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_15m"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 75.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 75.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 1d down move, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_1d"] > 40.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 40.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.40))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -80.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -80.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 30.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_15m"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_15m"] < 90.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 15m high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 60.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 60.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1h still high, 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 35.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
             # 4h & 1d down move
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 15.0))
             # 4h & 1d down move, 1d high
@@ -17290,11 +17287,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m still high
             ((df["RSI_3"] > 3.0) | (df["RSI_3_15m"] > 5.0) | (df["AROONU_14_15m"] < 40.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 5m & 1h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 5m & 1d down move, 1d still not low enough
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 30.0))
             # 5m down move, 1h & 4h high
@@ -17306,45 +17303,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1d high & overbought
             & ((df["RSI_3"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 5m & 1h down move, 1d overbought
-            & ((df["RSI_3"] > 5.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 100.0))
+            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 100.0))
             # 5m & 1d down move, 1h high
             & ((df["RSI_3"] > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1h"] < 90.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3"] > 10.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 1h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0))
             # 15m & 1h & 1d down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 25.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_14_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_1d"] < 50.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0))
             # 15m & 1d down move, 1d overbought
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 10.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 200.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 200.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 90.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
             # 15m & 4h down move, 15m high
@@ -17372,17 +17369,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["ROC_9_4h"] > -70.0) | (df["ROC_9_1d"] > -70.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["RSI_14_4h"] < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 4h down move, 1h still high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 4h down move, 1h downtrend
@@ -17408,37 +17405,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d downtrend
             & ((df["RSI_3_15m"] > 5.0) | (df["ROC_9_1d"] > -60.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1h down move, 4h downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] > -20.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["ROC_9_4h"] > -20.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["ROC_9_1d"] > -40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 80.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 90.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] < 20.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["ROC_9_4h"] < 20.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 90.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 4h down move, 15m still high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
             # 15m & 4h down move, 4h still high
@@ -17474,13 +17471,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 200.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m down move. 15m still high, 1h high
@@ -17508,9 +17505,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 1d down move, 4h high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_4h"] < 90.0))
             # 15m down move, 15m & 1h high
@@ -17522,157 +17519,157 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["ROC_9_1h"] > -30.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -30.0))
             # 15m down move, 1d high & overbought
             & ((df["RSI_3_15m"] > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] > -40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 60.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1h"] > -15.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 75.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 75.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] > -40.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] > -40.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 50.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 90.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_4h"] > -70.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_4h"] > -70.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -60.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 200.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 100.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 100.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((rsi_3_1h > 40.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1h"] < 90.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -70.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -70.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 100.0))
             # 4h & 1d down move, 15m still high
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
             # 4h & 1d down move, 1h still not low enough
@@ -17803,19 +17800,19 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h & 4h down move
-            ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0))
+            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 60.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 4h down move, 4h still high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 4h down move, 15m downtrend
@@ -17835,9 +17832,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 15m downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_15m"] > -30.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1h"] > -20.0))
             # 15m & 4h down move, 1h still not low enough
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 15m down move, 4h overbought
@@ -17853,145 +17850,145 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h down move
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 5.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 5.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 1h down move, 1h & 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h down move, 1h still high, 1h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1h"] > -20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1h"] > -15.0))
             # 1h downtrend, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h down move, 1h & 4h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["ROC_9_1h"] > -20.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (df["ROC_9_1h"] > -20.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 1d down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1h"] < 60.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -25.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -25.0))
             # 1h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1h"] > -25.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1h"] > -25.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 1d down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1h still high, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h high, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1h"] > -10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 4h still high, 15m downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 50.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 50.0) | (df["CMF_20_15m"] > -0.40))
             # 1h down move, 4h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 60.0))
             # 1h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_1d"] < 85.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] > -10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h & 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 20.0) | (df["ROC_9_4h"] > -30.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down ove, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_1h"] > -20.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -20.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 4h down move, 4h still high, 1d high
             & ((df["RSI_3_4h"] > 3.0) | (df["AROONU_14_4h"] < 50.0) | (df["AROONU_14_1d"] < 100.0))
             # 4h down move, 1d still high, 4h downtrend
@@ -18120,15 +18117,11 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] > 3.0) | (df["RSI_3_15m"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
           )
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
           # 5m & 4h & 1d down move
           long_entry_logic.append((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 20.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
           # 15m & 4h down move
           long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 10.0))
           # 15m & 4h down move, 4h still not low enough
@@ -18136,25 +18129,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 15m downtrend
           long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["AROONU_14_4h"] < 40.0) | (df["CMF_20_15m"] > -0.35))
           # 15m & 1h down move
-          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 15m down move, 1h still not low enough
           long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["AROONU_14_1h"] < 30.0))
           # 15m down move, 4h high
           long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["AROONU_14_4h"] < 90.0))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0))
           # 15m & 1h down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 30.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 30.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append(
             (df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
@@ -18182,7 +18171,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1h overbought
           long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 10.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 70.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 15.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
@@ -18190,112 +18179,102 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 50.0))
           # 15m & 1h down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["ROC_9_1d"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["ROC_9_1d"] < 80.0))
           # 15m down move, 4h high & overbought
           long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 10.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0))
           # 1h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_4h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["AROONU_14_4h"] < 30.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 20.0))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["AROONU_14_1h"] < 30.0))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 25.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 25.0))
           # 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 50.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 60.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 60.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_2"] > -0.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
           # 15m & 1d down move, 1d high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
           )
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h down move, 1h still not low enough, 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0) | (df["AROONU_14_1d"] < 85.0)
+            (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0) | (df["AROONU_14_1d"] < 85.0)
           )
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 25.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 25.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 85.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 85.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] < 50.0))
           # 1h down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 100.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1d"] < 100.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 20.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 90.0))
           # 1h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 1h & 1d down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 30.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["RSI_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_14_4h"] < 80.0))
           # 14 down move, 1h high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 80.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 1h down move, 4h & 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
+            (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
           )
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 50.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
           # 1h down move, 1h & 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0)
+            (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0)
           )
           # 4h down move, 1d high
           long_entry_logic.append((df["RSI_3_4h"] > 5.0) | (df["AROONU_14_1d"] < 100.0))
@@ -18401,17 +18380,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 6 days, 1h still high
           long_entry_logic.append((df["close"] > (df["high_max_6_1d"] * 0.25)) | (df["AROONU_14_1h"] < 50.0))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.45)) | (df["RSI_3_1h"] > 5.0))
+          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.45)) | (rsi_3_1h > 5.0))
           # big drop in the last 12 days, 4h down move
           long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.40)) | (df["RSI_3_4h"] > 15.0))
           # big drop in the last 12 days, 1h still high
           long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.25)) | (df["AROONU_14_1h"] < 75.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.35)) | (df["RSI_3_1h"] > 10.0))
+          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.35)) | (rsi_3_1h > 10.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.25)) | (df["RSI_3_1h"] > 15.0))
+          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.25)) | (rsi_3_1h > 15.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (df["RSI_3_1h"] > 20.0))
+          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (rsi_3_1h > 20.0))
           # big drop in the last 20 days, 1d high, 1d downtrend
           long_entry_logic.append(
             (df["close"] > (df["high_max_20_1d"] * 0.20))
@@ -18436,7 +18415,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["protections_long_global"] == True)
 
           # 5m & 1h down move
-          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
           # 15m & 4h down move
@@ -18446,17 +18425,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_14_4h"] < 30.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 30.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 40.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
           # 15m & 4h down move, 1d high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
@@ -18476,179 +18453,165 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 1d high
           long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_4h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 60.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 60.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 40.0))
           # 15m & 1h & 1d down move, 1h still not low enough, 1d high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 20.0)
-            | (df["RSI_3_1h"] > 20.0)
+            | (rsi_3_1h > 20.0)
             | (df["RSI_3_1d"] > 30.0)
             | (df["RSI_14_1h"] < 30.0)
             | (df["AROONU_14_1d"] < 80.0)
           )
           # 15m & 1h down move, 4h still high, 4h overbought
           long_entry_logic.append(
-            (df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_4h"] < 10.0)
+            (df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_4h"] < 10.0)
           )
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 70.0))
           # 15m down move, 1h & 4h still high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 20.0) | (df["AROONU_14_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
           )
           # 15m & 1h & 4h down move, 1d high
           long_entry_logic.append(
-            (df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 70.0)
+            (df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 70.0)
           )
           # 15m & 4h down move, 4h high
           long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 85.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 15.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 15.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0))
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 20.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 20.0) | (df["AROONU_14_1d"] < 90.0))
           # 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0))
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h down move, 1d still high
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_3_1d"] > 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 50.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
           # 1h & 1d down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 50.0))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 90.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
           # 1h & 4h down move, 1d stll high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 40.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["RSI_3_1d"] > 25.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["RSI_3_1d"] > 25.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
           # 1h & 4h down move, 1h & 4h still high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["RSI_14_1h"] < 40.0) | (df["RSI_14_4h"] < 50.0)
+            (rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["RSI_14_1h"] < 40.0) | (df["RSI_14_4h"] < 50.0)
           )
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 40.0))
           # 1h & 1d down move, 1d still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] < 50.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 30.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 50.0))
           # 1h & 4h down move, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1d"] < 80.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 65.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 65.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 40.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 40.0) | (df["AROONU_14_1d"] < 90.0))
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 50.0) | (df["AROONU_14_1d"] < 100.0))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -25.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -25.0))
           # 1h down move, 4h & 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
+            (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
           )
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["RSI_14_15m"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+            (rsi_3_1h > 25.0) | (df["RSI_14_15m"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0)
           )
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 80.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1d"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1d"] > -30.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 55.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 55.0) | (df["AROONU_14_4h"] < 80.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
           # 1h down move, 4h high, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.30))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.30))
           # 1h down move, 1d high, 4h overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 40.0))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
           # 1h down move, 1h overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["ROC_9_1h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 40.0))
           # 4h & 1d down move, 1d high
           long_entry_logic.append((df["RSI_3_4h"] > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 70.0))
           # 4h down move, 1h & 4h downtrend
@@ -18704,9 +18667,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d green, 4h down move, 4h still high
           long_entry_logic.append((df["change_pct_1d"] < 40.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 40.0))
           # 4h top wick, 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["top_wick_pct_4h"] < 20.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 50.0)
-          )
+          long_entry_logic.append((df["top_wick_pct_4h"] < 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 50.0))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_6_1d"] - df["low_min_6_1d"]) / df["low_min_6_1d"]) < 2.0)
@@ -18728,13 +18689,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 2 days, 1d down move
           long_entry_logic.append((df["close"] > (df["high_max_12_4h"] * 0.30)) | (df["RSI_3_1d"] > 30.0))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.30)) | (df["RSI_3_1h"] > 20.0))
+          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.30)) | (rsi_3_1h > 20.0))
           # big drop in the last 12 days, 4h still high
           long_entry_logic.append(
             (df["close"] > (df["high_max_12_1d"] * 0.40)) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
           )
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.40)) | (df["RSI_3_1h"] > 10.0))
+          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.40)) | (rsi_3_1h > 10.0))
           # big drop in the last 20 days, 4h down move
           long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (df["RSI_3_4h"] > 25.0))
           # big drop in the last 30 days, 4h down move
@@ -18763,41 +18724,41 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
             # 5m & 4h down move, 4h high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
             # 5m down move, 1d high & overbought
             & ((df["RSI_3"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["RSI_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["RSI_14_4h"] < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 3.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 3.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_14_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_1d"] < 50.0))
             # 15m & 1h down move, 4h downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["CMF_20_4h"] > -0.30))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["CMF_20_4h"] > -0.30))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 4h down move, 4h still high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 40.0) | (df["RSI_14_4h"] < 40.0))
             # 15m down move, 15m downtrend. 4h high
@@ -18809,9 +18770,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 4h down move, 1h downtrend
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1h"] > -20.0))
             # 15m & 4h down move, 1d overbought
@@ -18823,15 +18784,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high
             & ((df["RSI_3_15m"] > 5.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 15m & 1h down move, 4h downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -50.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 50.0))
             # 15m & 4h down move, 4h still not low enough
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 15m & 4h down move, 4h high
@@ -18853,13 +18814,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m down move, 15m still high, 1h high
             & ((df["RSI_3_15m"] > 15.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m down move, 4h high, 4h downtrend
@@ -18873,11 +18834,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 60.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 90.0))
             # 15m down move, 1h high
             & ((df["RSI_3_15m"] > 20.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m down move, 4h high & overbought
@@ -18889,9 +18850,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_1h"] < 100.0) | (df["ROC_9_1d"] < 20.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m down move, 15m high, 4h high
             & ((df["RSI_3_15m"] > 30.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m down move, 1h & 4h high
@@ -18899,93 +18860,93 @@ class NostalgiaForInfinityX7(IStrategy):
               (df["RSI_3_15m"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
             )
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
             # 1h & 4h down move, 15m stil high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 1h & 4h down move, 15m downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_15m"] > -15.0))
             # 1h & 3h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -50.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 15m still high, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_15m"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 4h still high, 4d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h down move, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 75.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 75.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] > -40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] > -40.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1h high, 1h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1h"] < 25.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1h"] < 25.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
             # 4h & 1d down move, 15m still high
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
             # 4h & 1d down move, 1h still not low enough
@@ -19114,25 +19075,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still not low enough
             & ((df["RSI_3"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 20.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_14_4h"] < 30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["RSI_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["RSI_14_4h"] < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 4h down move, 4h still not low enough
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["AROONU_14_4h"] < 20.0))
             # 15m & 4h down move, 4h still high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 4h down move, 15m still not low enough
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 15m & 4h down move, 1h downtrend
@@ -19142,21 +19103,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 60.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 90.0))
             # 15m & 4h down move, 15m still not low enough
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 20.0))
             # 15m & 4h down move, 1d high
@@ -19176,7 +19137,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -25.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 75.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 75.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 60.0))
             # 15m & 4h down move, 4h still high
@@ -19198,153 +19159,153 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m down move, 15m still high, 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1h"] > -20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 30.0))
             # 1h& 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 60.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 4h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 40.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 40.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h down move, 1h still not low enough, 4h stil high
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.50))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["ROC_9_1d"] < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & dh down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] > -25.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 4h & 1h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["CMF_20_4h"] > -0.40))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -80.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -80.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 30.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 1h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 60.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
             # 4h & 1d down move, 1d still high
             & ((df["RSI_3_4h"] > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
             # 4h & 1d down move, 4h still not low enough
@@ -19460,7 +19421,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["RSI_3_15m"] > 5.0)
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 1d down move, 1d downtrend
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["CMF_20_1d"] > -0.25))
             # 5m down move, 1h high, 4h overbought
@@ -19468,19 +19429,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1d high & overbought
             & ((df["RSI_3"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 15m & 1h down move 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 4h overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 10.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 10.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0))
             # 15m & 4h down move, 4h still not low enough
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 15m & 4h down move, 1d high
@@ -19508,9 +19469,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_4h"] < 10.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 4h down move, 15m still high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m & 4h down move, 1d high
@@ -19534,7 +19495,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
             # 15m down move, 1h high
@@ -19546,9 +19507,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["ROC_9_4h"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["ROC_9_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m down move, 1d high, 4h overbought
@@ -19556,9 +19517,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m down move, 15m downtrend, 4h high
             & ((df["RSI_3_15m"] > 30.0) | (df["CMF_20_15m"] > -0.30) | (df["AROONU_14_4h"] < 100.0))
             # 15m down move, 15m still high, 1d high
@@ -19570,7 +19531,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((df["RSI_3_15m"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 35.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 35.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m down move, 15m still high, 4h overbought
@@ -19584,205 +19545,205 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high
             & ((df["RSI_3_15m"] < 40.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 2.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_1h > 2.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_14_4h"] < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 4h stil high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
             # 1h ^ 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 1d down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 1d down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_9_1h"] > -40.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1h"] < 40.0))
             # 1h down move, 15m still not low enough, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_15m"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_15m"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 4h high
-            & ((df["RSI_3_1h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_4h"] < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -30.0))
             # 1h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_4h"] > -20.0))
             # 1h, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_14_4h"] < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 30.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 1d downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_1h"] > -0.20) | (df["AROONU_14_1h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.20) | (df["AROONU_14_1h"] < 30.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_1h"] > -0.20) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.20) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 1h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
             # 1h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 90.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down mov, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h down move, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_1h"] < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -25.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -25.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 50.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 50.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h still not low enough, 4h still high
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1h still high, 1h downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1h"] > -50.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1h"] > -50.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] < 70.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_4h"] > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 80.0))
             # 1h down move, 1h & 4h still high
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h down move, 1h highm 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 50.0))
             # 4h down move, 1d downtrend
             & ((df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] > -50.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -25.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -25.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 85.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["RSI_14_1d"] < 80.0) | (df["ROC_9_1d"] < 150.0))
+            & ((rsi_3_1h > 40.0) | (df["RSI_14_1d"] < 80.0) | (df["ROC_9_1d"] < 150.0))
             # 1h down move, 15m high, 1h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h & 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 10.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0) | (df["ROC_9_1d"] > -60.0))
             # 1h down move, 15m high, 1h high
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 1h down move, 1h high & overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0) | (df["ROC_9_4h"] > -30.0))
             # 4h down move, 1h & 4h downtrend
@@ -19981,19 +19942,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h & 4h high
           long_entry_logic.append((df["RSI_3"] > 10.0) | (df["AROONU_14_1h"] < 85.0) | (df["AROONU_14_4h"] < 90.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 40.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["RSI_14_4h"] < 40.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 75.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 75.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append(
             (df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0)
@@ -20017,31 +19974,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 30.0))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 20.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0))
           # 15m down move, 1h still not low enough, 1d high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["AROONU_14_1d"] < 90.0)
           )
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
           # 15m & 4h down move, 1d still high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0)
@@ -20067,29 +20014,19 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0)
           )
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 25.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 25.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 80.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append(
             (df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 10.0)
@@ -20124,18 +20061,14 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append(
-            (df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0)
+            (df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0)
           )
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0))
           # 15m & 4h & 1d down move
           long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 15.0))
           # 15m & 4h down move, 1h high
@@ -20151,7 +20084,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 50.0))
           # 1h & 1d down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["ROC_9_1d"] < 10.0))
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 15.0) | (df["AROONU_14_15m"] < 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0)
@@ -20163,9 +20096,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_4h"] < 85.0)
           )
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
           # 15m & 1d down move, 1h high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -20181,11 +20112,9 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] < 20.0)
           )
           # 15m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1h"] < 85.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_1h"] < 85.0))
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 25.0) | (df["AROONU_14_15m"] < 25.0) | (df["AROONU_14_4h"] < 60.0)
@@ -20195,85 +20124,67 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (df["AROONU_14_1h"] < 80.0)
           )
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 70.0))
           # 1h & 4h down move, 15m downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["ROC_9_15m"] > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 25.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 25.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_4h"] > -20.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_4h"] > -20.0))
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_4h"] > -30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 20.0))
           # 1h & 4h down move, 1d low
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_1d"] > -0.2))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_1d"] > -0.2))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 20.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_2"] > -0.0))
           # 1h down move, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["ROC_9_4h"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["ROC_9_4h"] > -30.0))
           # 1h down move, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["ROC_9_1d"] > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1h"] < 40.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0) | (df["AROONU_14_4h"] < 80.0)
+            (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0) | (df["AROONU_14_4h"] < 80.0)
           )
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 40.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 80.0) | (df["AROONU_14_1d"] < 100.0))
           # 1h down move, 15m high
-          long_entry_logic.append((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
           # 1h down move, 1h high & overbought
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["AROONU_14_4h"] < 90.0))
           # 4h down move, 15m still high
           long_entry_logic.append((df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
           # 4h down move, 1d still high, 1d downtrend
@@ -20370,7 +20281,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1h down move, drop but not yet near the previous lows
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 30.0)
+            (rsi_3_1h > 30.0)
             | (df["close"] > (df["high_max_12_4h"] * 0.50))
             | (df["close"] < (df["low_min_24_4h"] * 1.25))
           )
@@ -20405,7 +20316,7 @@ class NostalgiaForInfinityX7(IStrategy):
             | (df["ROC_9_1d"] > -15.0)
           )
           # big drop in the last 30 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_30_1d"] * 0.25)) | (df["RSI_3_1h"] > 15.0))
+          long_entry_logic.append((df["close"] > (df["high_max_30_1d"] * 0.25)) | (rsi_3_1h > 15.0))
 
           # Logic
           long_entry_logic.append(df["RSI_3"] > 3.0)
@@ -20423,7 +20334,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(df["RSI_3"] < 46.0)
           long_entry_logic.append(df["RSI_3_15m"] > 5.0)
-          long_entry_logic.append(df["RSI_3_1h"] > 10.0)
+          long_entry_logic.append(rsi_3_1h > 10.0)
           long_entry_logic.append(df["RSI_3_4h"] > 10.0)
           # 5m & 15m down move, 4h still high
           long_entry_logic.append(
@@ -20436,7 +20347,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] > 3.0) | (df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
           )
           # 5m & 1h down move, 4h still high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 50.0))
+          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 50.0))
           # 5m & 4h & 1d down move
           long_entry_logic.append((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 20.0))
           # 5m & 1d down move, 15m still high
@@ -20454,9 +20365,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] > 3.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
           )
           # 5m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3"] > 5.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-          )
+          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
           # 5m & 4h down move, 4h high
           long_entry_logic.append((df["RSI_3"] > 5.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
           # 5m down move, 15m still high, 1h high
@@ -20480,9 +20389,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] > 10.0) | (df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0)
           )
           # 5m & 1h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 5m down move, 1h & 4h high
           long_entry_logic.append((df["RSI_3"] > 10.0) | (df["AROONU_14_1h"] < 85.0) | (df["AROONU_14_4h"] < 90.0))
           # 5m down move, 4h high, 1d high
@@ -20502,21 +20409,17 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 3.0) | (df["AROONU_14_15m"] < 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
           )
           # 15m & 1h down move, 1d high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 70.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 30.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 30.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 50.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 70.0))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
           # 15m& 4h down move, 15m still high
@@ -20560,18 +20463,16 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1d high & overbought
           long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 20.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 40.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 40.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_4h"] < 80.0))
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append(
-            (df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0)
+            (df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0)
           )
           # 15m & 4h & 1d down move
           long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 15.0))
@@ -20614,13 +20515,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high 1d overbought
           long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 50.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 30.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_15m"] < 60.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 60.0))
           # 15m & 4h down move, 1h high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -20654,17 +20553,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h high
           long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 15m & 1h down move, 1d high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1h"] < 85.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_1h"] < 85.0))
           # 15m & 4h down move, 15m still high
           long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_15m"] < 50.0))
           # 15m & 1d down move, 4h high
@@ -20696,7 +20591,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 50.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 60.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 60.0))
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 30.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_4h"] < 50.0)
@@ -20730,61 +20625,49 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high
           long_entry_logic.append((df["RSI_3_15m"] > 45.0) | (df["AROONU_14_15m"] < 90.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_14_4h"] < 40.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 40.0))
           # 1h & 1d down move, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["CMF_20_4h"] > -0.40))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["CMF_20_4h"] > -0.40))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+            (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0)
           )
           # 1h down move, 1d still high, 1d downtrend
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (df["ROC_9_1d"] > -20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (df["ROC_9_1d"] > -20.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] > -50.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["RSI_14_4h"] < 75.0) | (df["ROC_9_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["RSI_14_4h"] < 75.0) | (df["ROC_9_1d"] < 100.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 85.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 85.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 20.0))
           # 1h down move 1h high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1h"] < 10.0))
           # 1h down move, 1h high & overbought
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
           # 1h down move, 1d high, 1h overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 10.0))
           # 4h down move, 4h still not low enough, 1d overbought
           long_entry_logic.append((df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0) | (df["ROC_9_1d"] < 100.0))
           # 4h down move, 15m still high, 1d downtrend
@@ -20942,19 +20825,19 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_1d"] < 80.0)
           )
           # 15m & 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
           )
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0))
           # 15m down move, 4h high & overbought
           long_entry_logic.append(
             (df["RSI_3_15m"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0) | (df["ROC_9_4h"] < 30.0)
           )
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 45.0) | (df["AROONU_14_15m"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 70.0))
           # 15m & 4h down move, 15m still high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0)
@@ -21000,7 +20883,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1h"] < 20.0)
           )
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
           # 15m down move, 15m & 1h high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 30.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 90.0)
@@ -21010,9 +20893,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0)
           )
           # 15m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 35.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 35.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 35.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 80.0)
@@ -21024,57 +20905,51 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((df["RSI_3_15m"] > 35.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_4h"] < 80.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 40.0))
           # 1h & 4h down move, 15m still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 10.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
           # 1h down move, 4h still high, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_4h"] > -20.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_4h"] > -20.0))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 25.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 25.0) | (df["AROONU_14_4h"] < 80.0))
           # 1h down move, 4h & 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
+            (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
           )
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 10.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 40.0))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 40.0))
           # 1h down move, 15m & 1h still high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+            (rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
           )
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
           # 1h down move, 1h high, 4h overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 30.0))
           # 1h down move, 1h overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["ROC_9_1h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 30.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 60.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_4h"] < 80.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 4h down move, 1h & 4h downtrend
           long_entry_logic.append((df["RSI_3_4h"] > 5.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_4h"] > -30.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append((df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] > -40.0))
           # 1h down move, 15m & 1h still high
@@ -21207,53 +21082,43 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h down move, 1d downtrend
           long_entry_logic.append((df["RSI_3"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
           # 5m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 15m & 4h & 1d down move
           long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
           # 15m & 1h down move
-          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_14_4h"] < 35.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["RSI_14_4h"] < 35.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 50.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 30.0) | (df["RSI_14_4h"] < 40.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0))
           # 15m & 1h & 4h down move, 15m downtrend
           long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["CMF_20_15m"] > -0.20)
+            (df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["CMF_20_15m"] > -0.20)
           )
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 20.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 20.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 50.0))
           # 15m & 1h down move, 15m & 1h downtrend
           long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["CMF_20_1h"] > -0.40)
+            (df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["CMF_20_1h"] > -0.40)
           )
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 15m & 1h down move, 4h overbought
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 40.0) | (df["ROC_9_4h"] < 50.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 40.0) | (df["ROC_9_4h"] < 50.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0))
           # 15m & 4h down move, 1h & 4h downtrend
           long_entry_logic.append(
             (df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_1h"] > -0.20) | (df["CMF_20_4h"] > -0.20)
@@ -21285,15 +21150,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h high
           long_entry_logic.append((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 80.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 40.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 70.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 40.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 40.0))
           # 15m down move, 4h still high, 4h downtrend
           long_entry_logic.append((df["RSI_3_15m"] > 15.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_4h"] > -20.0))
           # 15m down move, 1d high, 4h overbought
@@ -21303,7 +21166,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0)
           )
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["RSI_14_1h"] < 40.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["RSI_14_1h"] < 40.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 70.0))
           # 15m down move, 15m still not low enough, 1d overbought
@@ -21311,105 +21174,81 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0) | (df["ROC_9_1d"] < 80.0)
           )
           # 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 50.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["AROONU_14_1h"] < 50.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 85.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 85.0))
           # 1h & 4h down move
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h & 4h down move, 1d still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
           # 1h & 1d down move, 1h still moving lower
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["CCI_20_change_pct_1h"] > -0.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["CCI_20_change_pct_1h"] > -0.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_4h"] > -10.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_4h"] > -10.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 30.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["RSI_3_1d"] > 25.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["RSI_3_1d"] > 25.0))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1h"] < 80.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 60.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 60.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 70.0))
           # 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_4h"] < 80.0))
           # 1h & dh down move, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 85.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
           # 1h down move, 1h still not low enough, 4h downtrend
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_4h"] > -20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_4h"] > -20.0))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["ROC_9_1d"] > -20.0))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
           # 4h down move, 15m not low enough, 1h still high
           long_entry_logic.append(
             (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
@@ -21518,7 +21357,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(is_pair_long_grind_mode)
           long_entry_logic.append(df["RSI_3"] <= 50.0)
           long_entry_logic.append(df["RSI_3_15m"] >= 20.0)
-          long_entry_logic.append(df["RSI_3_1h"] >= 10.0)
+          long_entry_logic.append(rsi_3_1h >= 10.0)
           long_entry_logic.append(df["RSI_3_4h"] >= 10.0)
           long_entry_logic.append(df["RSI_14_1h"] < 80.0)
           long_entry_logic.append(df["RSI_14_4h"] < 80.0)
@@ -21552,9 +21391,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_15m"] > 20.0) | (df["AROONU_14_15m"] < 70.0))
             # 5m & 1h down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 40.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 5m & 4h down move, 15m still high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["AROONU_14_15m"] < 40.0))
             # 5m & 4h down move, 15m still high
@@ -21576,31 +21415,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((df["RSI_3"] > 10.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 60.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 25.0) | (df["RSI_14_4h"] < 40.0) | (df["ROC_9_1d"] > -10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 25.0) | (df["RSI_14_4h"] < 40.0) | (df["ROC_9_1d"] > -10.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 15m & 4h down move, 15m downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 3.0) | (df["CMF_20_15m"] > -0.30))
             # 15m & 4h down move, 4h still high
@@ -21610,11 +21449,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((df["RSI_3_15m"] > 3.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] < 10.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 70.0))
             # 15m & 4h down move, 1d high
@@ -21626,23 +21465,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 10.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 85.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 1d still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 60.0))
             # 15m & 4h down move, 15m still high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m & 4h down move, 1d high
@@ -21690,11 +21529,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 50.0))
             # 15m & 4h down move, 1h high
@@ -21742,107 +21581,107 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 10.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -10.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -10.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 1h high, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 1d down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_9_4h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_9_4h"] > -30.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 1h still high, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 15m still high, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_1d"] < 80.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 1h high , 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 75.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 75.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 25.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 25.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 60.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 60.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1h"] < 70.0))
             # 4h & 1d down move, 1d still high
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["RSI_14_1d"] < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -21994,23 +21833,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h high
             & ((df["RSI_3"] > 10.0) | (df["AROONU_14_15m"] < 85.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 15.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 15.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["ROC_9_1d"] < 60.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1d"] < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 75.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 75.0))
             # 15m & 4h down move, 1d downtrend
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 15m & 4h down move, 4h still high
@@ -22024,37 +21863,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((df["RSI_3_15m"] > 3.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 70.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 85.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
             # 15m down move, 4h high, 1h overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 10.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 85.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 60.0))
             # 15m & 4h down move, 1d still high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
             # 15m & 4h down move, 15m still high
@@ -22096,11 +21935,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 4h down move, 1d downtrend
@@ -22122,7 +21961,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 4h down move, 15m still high
@@ -22152,87 +21991,87 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1h overbought
             & ((df["RSI_3_15m"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1h"] < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 25.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["RSI_3_1d"] > 25.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 1d downtrend, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h down move. 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 15m & 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 60.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 1h & 4g down move, 4h still high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 100.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 100.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 75.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 75.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 25.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 25.0))
             # 4h & 1d down move, 1d downtrend
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["ROC_9_1d"] > -20.0))
             # 4h & 1d down move, 1d still high
@@ -22403,23 +22242,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 25.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 25.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 35.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 35.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 85.0))
             # 15m & 4h down move, 4h still high
             & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 50.0))
             # 15m & 4h down move, 15m still high
@@ -22429,9 +22268,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d still high
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["RSI_14_1d"] < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["RSI_14_4h"] < 40.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 40.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 4h down move, 15m still not low enough
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_15m"] < 30.0))
             # 15m & 4h down move, 4h high
@@ -22453,15 +22292,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((df["RSI_3_15m"] > 5.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 60.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 80.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 4h down move, 1h still high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 4h down move, 1h high
@@ -22485,51 +22324,51 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 90.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((df["RSI_3_1h"] > 5.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h down move, 1h still not low enough, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 40.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 40.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 30.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1h"] < 85.0))
             # 1h & 1d down move, 1h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1h"] < 80.0))
             # 4h & 1d down move, 15m still not low enough
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_15m"] < 20.0))
             # 4h & 1d down move, 1d high
@@ -22557,7 +22396,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 4h still not low enough
             & ((df["RSI_3_4h"] > 15.0) | (df["RSI_14_1d"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] > -30.0))
             # 4h down move, 4h & 1d high
             & ((df["RSI_3_4h"] > 15.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 70.0))
             # 4h down move, 1h still not low enough, 1d downtrend
@@ -22612,7 +22451,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((df["RSI_3"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1h"] < 30.0))
+            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1h"] < 30.0))
             # 5m & 4h down move, 15m still high
             & ((df["RSI_3"] > 3.0) | (df["RSI_3_4h"] > 5.0) | (df["AROONU_14_15m"] < 40.0))
             # 5m & 4h & 1d down move
@@ -22622,13 +22461,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m high
             & ((df["RSI_3"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["AROONU_14_1h"] < 25.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["AROONU_14_1h"] < 25.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 70.0))
             # 15m & 1h down move, 1d high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 4h down move, 4h downtrend
             & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["ROC_9_4h"] > -20.0))
             # 15m & 4h down move, 4h still high
@@ -22642,29 +22481,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1d"] < 50.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 4h down move, 15m still high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 200.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m down move, 4h high, 1d downtrend
             & ((df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 45.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 45.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 15m down move, 4h high, 1d overbought
             & ((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_1d"] < 100.0))
             # 15m & 4h down move, 1d downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -20.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 30.0))
             # 15m down move, 15m still high, 4h high
@@ -22680,97 +22519,97 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h & 4h down move, 1h downtrend
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_1h"] > -0.20))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["CMF_20_1h"] > -0.20))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_1d"] < 50.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1d"] < 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 15.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] > -10.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1d"] < 10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h & 4h down move, 4h overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 70.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 40.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] < 100.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["RSI_14_1d"] < 80.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_1h"] < 10.0))
             # 1h down move, 1h high, 15m high
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
             # 4h & 1d down move, 15m still not low enough
             & ((df["RSI_3_4h"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_15m"] < 20.0))
             # 4h & 1d down move, 1d still high
@@ -22880,21 +22719,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h high
             & ((df["RSI_3"] > 10.0) | (df["AROONU_14_15m"] < 85.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m & 1h & 4h down move
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 5.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 5.0))
             # 15m & 1h down move, 1h downtrend
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 3.0) | (df["ROC_9_1h"] > -20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 3.0) | (df["ROC_9_1h"] > -20.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((df["RSI_3_15m"] > 3.0) | (df["RSI_3_1h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
+            & ((df["RSI_3_15m"] > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 20.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 5.0) | (df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((df["RSI_3_15m"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 4h down move, 4h still not low enough
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 30.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 90.0))
             # 15m & 4h down move, 1d high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_1d"] < 90.0))
             # 15m & 4h down move, 1h high
@@ -22906,13 +22745,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 1h down move, 1d downtrend
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 20.0) | (df["ROC_9_1d"] > -30.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 20.0) | (df["ROC_9_1d"] > -30.0))
             # 15m & 4h down move, 15m still high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m down move, 15m & 1h high
             & ((df["RSI_3_15m"] > 20.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 15m down move, 15m still high, 1d overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 4h down move, 1h high
@@ -22928,101 +22767,101 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((df["RSI_3_15m"] > 35.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 80.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h down move, 4h still high, 1d high
-            & ((df["RSI_3_1h"] > 3.0) | (df["AROONU_14_4h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 3.0) | (df["AROONU_14_4h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 20.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["RSI_3_1d"] > 15.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 40.0))
             # 1h & 4h down move, 4h downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -10.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_4h"] > -10.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 15m high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1h"] < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_4h"] < 40.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 10.0) | (df["AROONU_14_1d"] < 50.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 50.0) | (df["ROC_9_1d"] > -20.0))
             # 1h & 4h & 1d down move
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 20.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["RSI_3_1d"] > 20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 15.0) | (df["AROONU_14_15m"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 40.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h & 1d down move, 4h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1h & 1d down move, 1h still high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 50.0))
             # 1h down move, 15m still high, 1h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (df["AROONU_14_4h"] < 80.0) | (df["ROC_9_4h"] < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] > -30.0))
             # 1h & 4h down move, 1h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 20.0))
             # 1h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 85.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 85.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_1d"] < 30.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 40.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 60.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 60.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 80.0) | (df["ROC_9_4h"] < 10.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 25.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_4h"] < 25.0))
             # 4h down move, 4h & 1d downtrend
             & ((df["RSI_3_4h"] > 5.0) | (df["ROC_9_4h"] > -15.0) | (df["ROC_9_1d"] > -20.0))
             # 4h & 1d down move, 1d still high
@@ -23110,7 +22949,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m high
           long_entry_logic.append((df["RSI_3"] > 15.0) | (df["AROONU_14_15m"] < 80.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_4h"] < 70.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((df["RSI_3_15m"] > 25.0) | (df["RSI_3_4h"] > 50.0) | (df["AROONU_14_4h"] < 50.0))
           # 15m down move, 15m high
@@ -23120,7 +22959,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["AROONU_14_1d"] < 90.0)
           )
           # 15m & 1h down move, 15m still high
-          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_15m"] < 50.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 30.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_15m"] < 50.0))
           # 15m down move, 15m & 4h still high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -23128,13 +22967,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h high
           long_entry_logic.append((df["RSI_3_15m"] > 35.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_4h"] < 80.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_15m"] > 40.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 40.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 40.0) | (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 40.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((df["RSI_3_15m"] > 40.0) | (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((df["RSI_3_15m"] > 40.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_4h"] < 80.0))
           # 15m & 4h down move, 15m high
           long_entry_logic.append(
             (df["RSI_3_15m"] > 40.0) | (df["RSI_3_4h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0)
@@ -23154,9 +22991,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 1d overbought
           long_entry_logic.append((df["RSI_3_15m"] > 40.0) | (df["AROONU_14_4h"] < 50.0) | (df["ROC_9_1d"] < 100.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_15m"] > 45.0) | (df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
-          )
+          long_entry_logic.append((df["RSI_3_15m"] > 45.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
           # 15m down move, 15m high, 1d overbought
           long_entry_logic.append((df["RSI_3_15m"] > 45.0) | (df["AROONU_14_15m"] < 60.0) | (df["ROC_9_1d"] < 50.0))
           # 15m down move, 15m high, 4h still high
@@ -23191,110 +23026,104 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
+            (rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
           )
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 65.0) | (df["AROONU_14_1h"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 65.0) | (df["AROONU_14_1h"] < 50.0))
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
+            (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
           )
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 55.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
           # 1h down move, 15m & 1h still high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+            (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
           )
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+            (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0)
           )
           # 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_4h"] < 85.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_4h"] < 85.0) | (df["AROONU_14_1d"] < 90.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
           # 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3_1h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0))
           # 1h & 4h down move, 15m high
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_15m"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["RSI_3_4h"] > 60.0) | (df["AROONU_14_15m"] < 70.0))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 80.0))
           # 1h down move, 15m high, 1h still high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
+            (rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0)
           )
           # 1h down move, 15m still high, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+            (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0)
           )
           # 1h down move, 15m & 1h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (df["AROONU_14_1h"] < 60.0)
+            (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (df["AROONU_14_1h"] < 60.0)
           )
           # 1h down move, 1h & 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
+            (rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0)
           )
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
+            (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
           )
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_1h"] < 50.0) | (df["AROONU_14_1d"] < 90.0))
           # 1h down move, 4h overbought
-          long_entry_logic.append((df["RSI_3_1h"] > 50.0) | (df["ROC_9_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (df["ROC_9_4h"] < 40.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 100.0))
           # 1h down move, 5m up move, 1h still high
-          long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["RSI_3"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["RSI_3"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+            (rsi_3_1h > 60.0) | (df["AROONU_14_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
           )
           # 1h down move, 15m still not low enough, 1h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (df["AROONU_14_1h"] < 70.0)
+            (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (df["AROONU_14_1h"] < 70.0)
           )
           # 1h down move, 15m still not low enough, 1h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+            (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 60.0)
           )
           # 1h down move, 15m & 4h still high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+            (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0)
           )
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1h"] < 90.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+            (rsi_3_1h > 60.0) | (df["AROONU_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0)
           )
           # 1h down move, 1h high, 4h still high
-          long_entry_logic.append((df["RSI_3_1h"] > 60.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 40.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["AROONU_14_4h"] < 70.0)
+            (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0) | (df["AROONU_14_4h"] < 70.0)
           )
           # 1h down move, 1h & 1d high
           long_entry_logic.append(
-            (df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0)
+            (rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0) | (df["AROONU_14_1d"] < 90.0)
           )
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((df["RSI_3_1h"] > 60.0) | (df["RSI_14_4h"] < 70.0) | (df["RSI_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (df["RSI_14_4h"] < 70.0) | (df["RSI_14_1d"] < 80.0))
           # 15m & 1h & 4h down move, 4h high
           long_entry_logic.append(
-            (df["RSI_3_15m"] > 50.0) | (df["RSI_3_1h"] > 65.0) | (df["RSI_3_4h"] > 65.0) | (df["AROONU_14_4h"] < 85.0)
+            (df["RSI_3_15m"] > 50.0) | (rsi_3_1h > 65.0) | (df["RSI_3_4h"] > 65.0) | (df["AROONU_14_4h"] < 85.0)
           )
           # 4h down move, 15m high
           long_entry_logic.append((df["RSI_3_4h"] > 20.0) | (df["AROONU_14_15m"] < 80.0))
@@ -23463,7 +23292,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 15m & 1h down move, 4h high
-            ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            ((df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 15m & 4h down move, 1h still high
             & ((df["RSI_3_15m"] > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["RSI_14_1h"] < 50.0))
             # 15m & 1d down move, 4h high
@@ -23479,73 +23308,73 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((df["RSI_3_15m"] > 10.0) | (df["AROONU_14_1d"] < 85.0) | (df["CMF_20_1d"] > -0.40))
             # 15m & 1h down move, 15m still not low enough
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
             # 15m & 1h down nove, 1h still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 50.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m down move, 4h high, 4h downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_4h"] > -20.0))
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] > -10.0) | (df["ROC_9_1d"] > -40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m down move, 4h high & overbought
             & ((df["RSI_3_15m"] > 20.0) | (df["AROONU_14_4h"] < 70.0) | (df["ROC_9_4h"] < 20.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 25.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((df["RSI_3_15m"] > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 15m down move, 15m high, 1d overbought
             & ((df["RSI_3_15m"] > 25.0) | (df["AROONU_14_15m"] < 60.0) | (df["ROC_9_1d"] < 150.0))
             # 15m down move, 1h & 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["AROONU_14_1h"] < 80.0) | (df["RSI_14_4h"] < 80.0))
             # 1h & 4h down move, 15m stil high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 60.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 5.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 5.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
+            & ((rsi_3_1h > 5.0) | (df["AROONU_14_4h"] < 60.0) | (df["ROC_9_1d"] < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 10.0) | (df["AROONU_14_4h"] < 50.0))
             # 1h & 3h down move, 1d high
-            & ((df["RSI_3_1h"] > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 20.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (df["ROC_9_1d"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (df["RSI_3_4h"] > 35.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((df["RSI_3_1h"] > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (df["RSI_3_4h"] > 25.0) | (df["ROC_9_1d"] > -30.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_1d"] < 85.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 1d high & overbought
-            & ((df["RSI_3_1h"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_1d"] < 100.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 90.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_4h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 60.0) | (df["ROC_9_4h"] < 50.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] > -20.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_4h"] > -20.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_15m"] < 50.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 50.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
+            & ((rsi_3_1h > 45.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 50.0))
             # 1h down move,  4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] < 150.0))
+            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] < 150.0))
             # 4h down move, 1d high
             & ((df["RSI_3_4h"] > 3.0) | (df["AROONU_14_1d"] < 90.0))
             # 4h down move, 15m still high
@@ -23603,13 +23432,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought
             & ((df["ROC_9_1h"] < 100.0) | (df["ROC_9_4h"] < 100.0))
             # 1h P&D, 1h down move
-            & ((df["change_pct_1h"] > -10.0) | (df["change_pct_1h"].shift(12) < 10.0) | (df["RSI_3_1h"] > 50.0))
+            & ((df["change_pct_1h"] > -10.0) | (df["change_pct_1h"].shift(12) < 10.0) | (rsi_3_1h > 50.0))
             # 4h P&D, 4h high
             & ((df["change_pct_4h"] > -15.0) | (df["change_pct_4h"].shift(48) < 30.0) | (df["AROONU_14_4h"] < 90.0))
             # 4h green, 15m & 1h down move
-            & ((df["change_pct_4h"] < 10.0) | (df["RSI_3_15m"] > 10.0) | (df["RSI_3_1h"] > 35.0))
+            & ((df["change_pct_4h"] < 10.0) | (df["RSI_3_15m"] > 10.0) | (rsi_3_1h > 35.0))
             # 4h green, 1h down move
-            & ((df["change_pct_4h"] < 40.0) | (df["RSI_3_1h"] > 50.0))
+            & ((df["change_pct_4h"] < 40.0) | (rsi_3_1h > 50.0))
             # 4h green with top wick
             & ((df["change_pct_4h"] < 50.0) | (df["change_pct_4h"] < 50.0))
             # 1d green with top wick, 15m still high
@@ -23649,7 +23478,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
           long_entry_logic.append(df["protections_long_global"] == True)
 
-          long_entry_logic.append((df["RSI_3"] > 10.0) & (df["RSI_3_15m"] > 10.0) & (df["RSI_3_1h"] > 20.0))
+          long_entry_logic.append((df["RSI_3"] > 10.0) & (df["RSI_3_15m"] > 10.0) & (rsi_3_1h > 20.0))
 
           long_entry_logic.append(
             # 5m & 15m & 4h down mnove, 4h high
@@ -23657,73 +23486,63 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m & 1d down move, 1h high
             & ((df["RSI_3"] > 15.0) | (df["RSI_3_15m"] > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1h"] < 90.0))
             # 5m & 1h down move, 15m still high, 4h high
-            & (
-              (df["RSI_3"] > 20.0) | (df["RSI_3_1h"] > 40.0) | (df["RSI_14_15m"] < 40.0) | (df["AROONU_14_4h"] < 100.0)
-            )
+            & ((df["RSI_3"] > 20.0) | (rsi_3_1h > 40.0) | (df["RSI_14_15m"] < 40.0) | (df["AROONU_14_4h"] < 100.0))
             # 5m & 1h & 15m down move, 1h still not low enough
-            & ((df["RSI_3"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1h"] < 30.0))
+            & ((df["RSI_3"] > 15.0) | (rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1h"] < 30.0))
             # 15m & 4h down move, 4h high
             & ((df["RSI_3"] > 15.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 70.0))
             # 5m & 4h down move, 15m high
             & ((df["RSI_3"] > 15.0) | (df["RSI_3_4h"] > 45.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 12.0) | (df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 100.0))
+            & ((df["RSI_3_15m"] > 12.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 100.0))
             # 15m & 1h & 4h & 1d down move
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["RSI_3_1d"] > 25.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 25.0) | (df["RSI_3_1d"] > 25.0))
             # 15m & 1h down move, 1h & 4h high
             & (
-              (df["RSI_3_15m"] > 15.0)
-              | (df["RSI_3_1h"] > 25.0)
-              | (df["AROONU_14_1h"] < 75.0)
-              | (df["AROONU_14_4h"] < 100.0)
+              (df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 75.0) | (df["AROONU_14_4h"] < 100.0)
             )
             # 15m & 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 40.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 35.0) | (df["ROC_9_1d"] < 40.0))
             # 15m & 1h & 4h down move, 1h downtrend, 4h high
             & (
               (df["RSI_3_15m"] > 15.0)
-              | (df["RSI_3_1h"] > 30.0)
+              | (rsi_3_1h > 30.0)
               | (df["RSI_3_4h"] > 55.0)
               | (df["CMF_20_1h"] > -0.10)
               | (df["AROONU_14_4h"] < 80.0)
             )
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["RSI_14_4h"] < 85.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["RSI_14_4h"] < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 40.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 30.0) | (df["ROC_9_1d"] < 30.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 30.0) | (df["ROC_9_1d"] < 30.0))
             # 15m & 1h & 4h down move, 4h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 65.0) | (df["MFI_14_4h"] < 85.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 65.0) | (df["MFI_14_4h"] < 85.0))
             # 15m & 1h & 1d down move, 15m high
-            & (
-              (df["RSI_3_15m"] > 15.0)
-              | (df["RSI_3_1h"] > 35.0)
-              | (df["RSI_3_1d"] > 40.0)
-              | (df["AROONU_14_15m"] < 60.0)
-            )
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 1h down move, 15m high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 70.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 85.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 85.0))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
               (df["RSI_3_15m"] > 15.0)
-              | (df["RSI_3_1h"] > 40.0)
+              | (rsi_3_1h > 40.0)
               | (df["AROONU_14_15m"] < 30.0)
               | (df["AROONU_14_1h"] < 80.0)
               | (df["AROONU_14_4h"] < 80.0)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 45.0) | (df["RSI_14_4h"] < 70.0) | (df["ROC_9_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 45.0) | (df["RSI_14_4h"] < 70.0) | (df["ROC_9_4h"] < 50.0))
             # 15m & 1h down move, 1h high
-            & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0))
+            & ((df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 15.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 4h down move, 4h high
@@ -23803,17 +23622,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((df["RSI_3_15m"] > 15.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -20.0))
             # 16m & 1h down move, 1h still high
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 40.0))
             # 15m & 1h down move, 1h downtrend, 1h downtrend, 15m still high, 1h high
             & (
               (df["RSI_3_15m"] > 20.0)
-              | (df["RSI_3_1h"] > 35.0)
+              | (rsi_3_1h > 35.0)
               | (df["CMF_20_1h"] > -0.10)
               | (df["AROONU_14_15m"] < 40.0)
               | (df["AROONU_14_1h"] < 85.0)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_1h"] > 45.0) | (df["RSI_14_4h"] < 70.0) | (df["ROC_9_4h"] < 50.0))
+            & ((df["RSI_3_15m"] > 20.0) | (rsi_3_1h > 45.0) | (df["RSI_14_4h"] < 70.0) | (df["ROC_9_4h"] < 50.0))
             # 15m & 4h down move, 15m high
             & ((df["RSI_3_15m"] > 20.0) | (df["RSI_3_4h"] > 25.0) | (df["AROONU_14_15m"] < 60.0))
             # 15m & 4h down move, 1h high
@@ -23849,7 +23668,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
               (df["RSI_3_15m"] > 30.0)
-              | (df["RSI_3_1h"] > 45.0)
+              | (rsi_3_1h > 45.0)
               | (df["RSI_14_15m"] < 30.0)
               | (df["RSI_14_1h"] < 50.0)
               | (df["RSI_14_4h"] < 70.0)
@@ -23862,107 +23681,104 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((df["RSI_3_15m"] > 35.0) | (df["RSI_3_4h"] > 35.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 40.0) | (df["AROONU_14_4h"] < 70.0))
             # 1h & 4h down move, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 45.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 80.0))
             # 1h & 4h down move, 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_4h"] > 65.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_4h"] > 65.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 25.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0))
             # 1h down move, 15m downtrend, 4h still high
-            & ((df["RSI_3_1h"] > 25.0) | (df["CMF_20_15m"] > -0.4) | (df["AROONU_14_4h"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_15m"] > -0.4) | (df["AROONU_14_4h"] < 50.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["CMF_20_4h"] > -0.25) | (df["AROONU_14_4h"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.25) | (df["AROONU_14_4h"] < 70.0))
             # 1h down move, 15m still high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_15m"] < 40.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_15m"] < 40.0) | (df["ROC_9_1d"] > -20.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 90.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 90.0) | (df["CMF_20_1d"] > -0.2))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 25.0) | (df["AROONU_14_4h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 30.0) | (df["ROC_9_1d"] > -40.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_1h"] > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] < 25.0))
+            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0) | (df["ROC_9_1d"] < 25.0))
             # 1h & 4h down move, 1h still high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_4h"] > 30.0) | (df["AROONU_14_1h"] < 40.0))
             # 1h & 1d down move, 1d still high
-            & ((df["RSI_3_1h"] > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 40.0))
             # 1h down move, 15m & 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 95.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 95.0))
             # 1h down move, 15m & 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["MFI_14_1h"] < 80.0) | (df["AROONU_14_1h"] < 90.0))
+            & ((rsi_3_1h > 30.0) | (df["MFI_14_1h"] < 80.0) | (df["AROONU_14_1h"] < 90.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 50.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 90.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 90.0) | (df["CMF_20_1d"] > -0.2))
             # 1h down move, 1h highm 1d overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_1d"] < 40.0))
             # 1h down move, 4h high & overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 30.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_4h"] < 30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 20.0))
+            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_4h"] < 20.0))
             # 1h & 4h down move, 1h still high, 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["RSI_3_4h"] > 60.0) | (df["RSI_14_1h"] < 50.0) | (df["RSI_14_4h"] < 70.0))
+            & ((rsi_3_1h > 35.0) | (df["RSI_3_4h"] > 60.0) | (df["RSI_14_1h"] < 50.0) | (df["RSI_14_4h"] < 70.0))
             # 1h down move, 15m still not low enough, 1h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_15m"] < 30.0) | (df["AROONU_14_1h"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 30.0) | (df["AROONU_14_1h"] < 80.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 25.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 25.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0) | (df["AROONU_14_4h"] < 90.0))
             # 1h down move, 1h & 1d high
-            & ((df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 90.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 90.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 4h & 1d overbought
-            & ((df["RSI_3_1h"] > 35.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 80.0))
             # 1h & 1d down move, 1d high
-            & ((df["RSI_3_1h"] > 40.0) | (df["RSI_3_1d"] > 55.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (df["RSI_3_1d"] > 55.0) | (df["AROONU_14_1d"] < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 70.0) | (df["ROC_9_4h"] < 40.0))
             # 1h down move, 1h & 4h high
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 80.0) | (df["AROONU_14_4h"] < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 85.0) | (df["ROC_9_1d"] < 80.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_15m"] > -10.0))
+            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1h"] < 90.0) | (df["ROC_9_15m"] > -10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
+            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0) | (df["ROC_9_1d"] > -40.0))
             # 1h & 4h down move, 1d overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_4h"] > 65.0) | (df["ROC_9_1d"] < 200.0))
             # 1h & 1d down move, 4h high
-            & ((df["RSI_3_1h"] > 45.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
+            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 90.0))
             # 1h down move, 1h high, 4h overbought
-            & ((df["RSI_3_1h"] > 45.0) | (df["AROONU_14_1h"] < 100.0) | (df["ROC_9_4h"] < 10.0))
+            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1h"] < 100.0) | (df["ROC_9_4h"] < 10.0))
             # 1h & 4h down move, 1h & 4h high
             & (
-              (df["RSI_3_1h"] > 50.0)
-              | (df["RSI_3_4h"] > 65.0)
-              | (df["AROONU_14_1h"] < 85.0)
-              | (df["AROONU_14_4h"] < 100.0)
+              (rsi_3_1h > 50.0) | (df["RSI_3_4h"] > 65.0) | (df["AROONU_14_1h"] < 85.0) | (df["AROONU_14_4h"] < 100.0)
             )
             # 1h down move, 15m & 1h high
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 1h down move, 4h & 1d high
-            & ((df["RSI_3_1h"] > 50.0) | (df["AROONU_14_4h"] < 90.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 50.0) | (df["AROONU_14_4h"] < 90.0) | (df["AROONU_14_1d"] < 90.0))
             # 1h down move, 4h high, 1h overbought
-            & ((df["RSI_3_1h"] > 55.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 55.0) | (df["AROONU_14_4h"] < 100.0) | (df["ROC_9_1h"] < 20.0))
             # 1h down move, 15m & 1h high, 1d downtrend
             & (
-              (df["RSI_3_1h"] > 60.0)
+              (rsi_3_1h > 60.0)
               | (df["AROONU_14_15m"] < 65.0)
               | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0)
               | (df["CMF_20_1d"] > -0.0)
             )
             # 1h down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
+            & ((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 90.0) | (df["ROC_9_1d"] > -20.0))
             # 4h down move, 15m high
             & ((df["RSI_3_4h"] > 3.0) | (df["AROONU_14_15m"] < 50.0))
             # 4h & 1d down move, 1d high
@@ -24038,16 +23854,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((df["RSI_3_1d"] > 65.0) | (df["ROC_9_4h"] < 10.0) | (df["ROC_9_1d"] < 10.0))
             # 5m still high, 1h down move, 15m still high, 1h high
-            & (
-              (df["RSI_3"] < 40.0)
-              | (df["RSI_3_1h"] > 30.0)
-              | (df["AROONU_14_15m"] < 50.0)
-              | (df["AROONU_14_4h"] < 90.0)
-            )
+            & ((df["RSI_3"] < 40.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_4h"] < 90.0))
             # 5m still high, 15m high
             & ((df["RSI_3"] < 45.0) | (df["AROONU_14_15m"] < 70.0))
             # 5m still high, 1h down move, 4h high
-            & ((df["RSI_3"] < 50.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_4h"] < 100.0))
+            & ((df["RSI_3"] < 50.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_4h"] < 100.0))
             # 15m down move, 1h high
             & ((df["RSI_14_15m"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 80.0))
             # 15m down move, 4h & 1d high
@@ -24067,11 +23878,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 4h & 1d downtrend
             & ((df["AROONU_14_1d"] < 50.0) | (df["ROC_9_4h"] > -20.0) | (df["ROC_9_1d"] > -30.0))
             # 4h top wick, 15m & 1h down move
-            & ((df["top_wick_pct_4h"] < 10.0) | (df["RSI_3_15m"] > 15.0) | (df["RSI_3_1h"] > 40.0))
+            & ((df["top_wick_pct_4h"] < 10.0) | (df["RSI_3_15m"] > 15.0) | (rsi_3_1h > 40.0))
             # 4h top wick, 1h down move, 1h high
-            & ((df["top_wick_pct_4h"] < 10.0) | (df["RSI_3_1h"] > 30.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1h"] < 70.0))
             # 1d red, 1h down move, 1h still high
-            & ((df["change_pct_1d"] > -15.0) | (df["RSI_3_1h"] > 25.0) | (df["AROONU_14_1h"] < 50.0))
+            & ((df["change_pct_1d"] > -15.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1h"] < 50.0))
             # 1d P&D, 1h high
             & (
               (df["change_pct_1d"] > -15.0)
@@ -24099,14 +23910,12 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 4h still high
             & ((df["top_wick_pct_1d"] < 30.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 50.0))
             # 1d top wick, 1h down move
-            & ((df["top_wick_pct_1d"] < 50.0) | (df["RSI_3_1h"] > 30.0))
+            & ((df["top_wick_pct_1d"] < 50.0) | (rsi_3_1h > 30.0))
             # big drop in the last 12 days, 1h down move, 1h high
-            & ((df["close"] > (df["high_max_12_1d"] * 0.35)) | (df["RSI_3_1h"] > 35.0) | (df["AROONU_14_1h"] < 70.0))
+            & ((df["close"] > (df["high_max_12_1d"] * 0.35)) | (rsi_3_1h > 35.0) | (df["AROONU_14_1h"] < 70.0))
             # big drop in the last 20 days, 1h down move, 1h high
             & (
-              (df["close"] > (df["high_max_20_1d"] * 0.30))
-              | (df["RSI_3_1h"] > 30.0)
-              | (df["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+              (df["close"] > (df["high_max_20_1d"] * 0.30)) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1h"] < 75.0)
             )
             # big drop in the last 20 days, 1d high, 1d downtrend
             & (
@@ -24177,7 +23986,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["global_protections_short_pump"] == True)
           short_entry_logic.append(df["global_protections_short_dump"] == True)
 
-          short_entry_logic.append(df["RSI_3_1h"] >= 5.0)
+          short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(df["RSI_3_4h"] >= 20.0)
           short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
@@ -24190,7 +23999,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m strong up move
           short_entry_logic.append((df["RSI_3"] < 95.0) | (df["RSI_3_15m"] < 95.0))
           # 5m & 1h up move, 1d uptrend
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (df["RSI_3_1h"] < 90.0) | (df["ROC_9_1d"] < 100.0))
+          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 90.0) | (df["ROC_9_1d"] < 100.0))
           # 5m up move, 15m & 1h still not high enough
           short_entry_logic.append((df["RSI_3"] < 95.0) | (df["AROOND_14_15m"] < 25.0) | (df["AROOND_14_1h"] < 25.0))
           # 4m up move, 1h & 4h still low
@@ -24198,11 +24007,9 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 4m & 1h up move, 1h still low
-          short_entry_logic.append(
-            (df["RSI_3"] < 90.0) | (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
-          )
+          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["RSI_3_1h"] < 80.0) | (df["AROONU_14_4h"] > 20.0))
+          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 80.0) | (df["AROONU_14_4h"] > 20.0))
           # 5m up move, 15m & 1h uptrend
           short_entry_logic.append((df["RSI_3"] < 90.0) | (df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30))
           # 5m up move, 15m stil low
@@ -24214,20 +24021,18 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low
           short_entry_logic.append((df["RSI_3_15m"] < 97.0) | (df["AROONU_14_1h"] > 30.0))
           # 15m & 1h up move, 4h still going up
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0))
+          # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
           )
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-          )
-          # 15m & 1h up move, 4h still not high enough
-          short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m & 1h up move, 1h still low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
           )
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append(
@@ -24261,17 +24066,17 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
+            (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
           )
           # 15m & 1h up move, 1h not high enough
-          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 90.0) | (df["AROOND_14_1h"] < 50.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 90.0) | (df["AROOND_14_1h"] < 50.0))
           # 15m & 1h up move, 1d stil not high enough
-          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 90.0) | (df["RSI_14_1h"] > 80.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 90.0) | (df["RSI_14_1h"] > 80.0))
           # 15m & 1h up move, 1d uptrend
-          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 80.0) | (df["ROC_9_1d"] < 40.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 80.0) | (df["ROC_9_1d"] < 40.0))
           # 15m & 1h up move, 15m still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0)
+            (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0)
           )
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append(
@@ -24311,19 +24116,19 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h up move, 4h low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 85.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0)
+            (df["RSI_3_15m"] < 85.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0)
           )
           # 15m & 1h up move, 1d still low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 85.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 60.0)
+            (df["RSI_3_15m"] < 85.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 60.0)
           )
           # 15m & 1h up move, 1h low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 85.0) | (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0)
+            (df["RSI_3_15m"] < 85.0) | (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0)
           )
           # 15m & 1h up move, 4h low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 85.0) | (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
+            (df["RSI_3_15m"] < 85.0) | (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
           )
           # 15m & 4h down move, 4h still not high enough
           short_entry_logic.append(
@@ -24340,89 +24145,73 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h overbought
           short_entry_logic.append((df["RSI_3_15m"] < 85.0) | (df["ROC_9_4h"] < 50.0))
           # 15m & 1h up move, 1h still not high enough
-          short_entry_logic.append((df["RSI_3_15m"] < 80.0) | (df["RSI_3_1h"] < 70.0) | (df["AROONU_14_1h"] > 60.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 80.0) | (rsi_3_1h < 70.0) | (df["AROONU_14_1h"] > 60.0))
           # 15m & 4h up move, 15m still low
           short_entry_logic.append((df["RSI_3_15m"] < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["AROONU_14_15m"] > 50.0))
           # 15m up move, 1h low
           short_entry_logic.append((df["RSI_3_15m"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 20.0))
           # 15m & 1h up move, 1h low
-          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (df["RSI_3_1h"] < 70.0) | (df["AROONU_14_1h"] > 30.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (rsi_3_1h < 70.0) | (df["AROONU_14_1h"] > 30.0))
           # 15m up move, 15m still not high enough, 1h still low
           short_entry_logic.append(
             (df["RSI_3_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
           )
           # 1h & 4h up move, 1h still not high enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0))
           # 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0))
           # 1h & 4h up move, 4h still not high enough
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["UO_7_14_28_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["UO_7_14_28_4h"] > 60.0))
           # 1h & 4h up move, 4h still low
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0))
           # 1h & 4h up move, 4h uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["ROC_9_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["ROC_9_4h"] < 40.0))
           # 1h & 1d strong up move
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_1d"] < 95.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_1d"] < 95.0))
           # 1h up move, 4h still low
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_14_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_14_1d"] > 50.0) | (df["ROC_9_1h"] < 30.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 50.0) | (df["ROC_9_1h"] < 30.0))
           # 1h & 4h strong up move
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["MFI_14_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0) | (df["ROC_9_1h"] < 20.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0) | (df["ROC_9_1h"] < 20.0))
           # 1h strong up move, 15m still move higher
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h & 4h up move, 1h still low
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0))
           # 1h & 4h up move, 1d still not high enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0))
           # 1h up move, 4h low, 1d overbought
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["AROONU_14_4h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROONU_14_4h"] > 20.0) | (df["ROC_9_1d"] < 50.0))
           # 1h up move, 1h still low, 1d uptrend
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0) | (df["ROC_9_1d"] < 50.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0) | (df["ROC_9_1d"] < 50.0))
           # 1h up move, 1h still not high enough, 1d low
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0)
+            (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0)
           )
           # 1h up move, 4h low, 1h uptrend
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0) | (df["ROC_9_1h"] < 10.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0) | (df["ROC_9_1h"] < 10.0))
           # 1h up move, 4h low, 1h overbought
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 40.0) | (df["ROC_9_1h"] < 30.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 40.0) | (df["ROC_9_1h"] < 30.0))
           # 1h up move, 15m & 1h uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["ROC_9_15m"] < 15.0) | (df["ROC_9_1h"] < 15.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_15m"] < 15.0) | (df["ROC_9_1h"] < 15.0))
           # 1h up move, 15m & 4h still low
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((df["RSI_3_1h"] < 85.0) | (df["RSI_3_4h"] < 85.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["RSI_3_4h"] < 85.0) | (df["AROOND_14_15m"] < 50.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 90.0)
+            (rsi_3_1h < 85.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 90.0)
           )
           # 1h up move, 15m still not high enough, 1h still low
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+            (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
           )
           # 1h up move, 1h still low
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0))
           # 4h & 1d strong up move
           short_entry_logic.append((df["RSI_3_4h"] < 95.0) | (df["RSI_3_1d"] < 95.0))
           # 4h up move, 15m still low, 1h not high enough
@@ -24522,7 +24311,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # 5m & 15m & 1h & 4h up move
           short_entry_logic.append(
-            (df["RSI_3"] < 97.0) | (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 80.0)
+            (df["RSI_3"] < 97.0) | (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 80.0)
           )
           # 5m & 4h up move
           short_entry_logic.append((df["RSI_3"] < 97.0) | (df["RSI_3_4h"] < 95.0))
@@ -24533,47 +24322,45 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m up move, 4h low
           short_entry_logic.append((df["RSI_3"] < 95.0) | (df["RSI_3_15m"] < 90.0) | (df["AROONU_14_4h"] > 30.0))
           # 5m & 1h & 4h up move
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 90.0))
+          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 90.0))
           # 5m & 1h up move, 15m still not high enough
-          short_entry_logic.append(
-            (df["RSI_3"] < 95.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0)
-          )
+          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0))
           # 5m up move, 15m still low
           short_entry_logic.append((df["RSI_3"] < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0))
           # 5m up move, 4h low
           short_entry_logic.append((df["RSI_3"] < 90.0) | (df["AROONU_14_4h"] > 20.0))
           # 15m & 1h down move, 4h still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 97.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
+            (df["RSI_3_15m"] < 97.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
           )
           # 15m up move, 1h still low
           short_entry_logic.append((df["RSI_3_15m"] < 97.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0))
           # 15m & 1h & 4h up move
-          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 85.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 85.0))
           # 15m & 1h up move, 4h still low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0)
           )
           # 15m up move, 1h still low
           short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 40.0))
           # 15m up move, 4h still not high enough
           short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["AROONU_14_4h"] > 70.0))
           # 15m & 1h & 4h up move
-          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 90.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 90.0))
           # 15m & 1h up move, 15m still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0)
+            (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0)
           )
           # 15m & 1h up move, 1d low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 40.0)
+            (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 40.0)
           )
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0)
+            (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0)
           )
           # 15m & 1h up move, 4h stil low
-          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 80.0) | (df["AROONU_14_4h"] > 50.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 80.0) | (df["AROONU_14_4h"] > 50.0))
           # 15m & 4h up move, 1d low
           short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["RSI_14_1d"] > 40.0))
           # 15m & 4h up move, 1d low
@@ -24592,7 +24379,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["ROC_9_4h"] < 20.0))
           # 15m & 1h up move, 1h still low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 85.0) | (df["RSI_3_1h"] < 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0)
+            (df["RSI_3_15m"] < 85.0) | (rsi_3_1h < 65.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0)
           )
           # 15m up move, 1h low
           short_entry_logic.append((df["RSI_3_15m"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0))
@@ -24607,53 +24394,49 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h uptrend
           short_entry_logic.append((df["RSI_3_15m"] < 75.0) | (df["ROC_9_1h"] < 40.0))
           # 1h & 1d strong up move
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_1d"] < 95.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_1d"] < 95.0))
           # 1h up move, 1h still not high enough
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0))
           # 1h up move, 4h still low, 1h moving higher
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0)
+            (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0)
           )
           # 1h up move, 1d low
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_14_1d"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 40.0))
           # 1h strong up move, 15m still move higher
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h up move, relative stable before the hour
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["close_min_12"] > (df["close_min_48"] * 1.10)))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["close_min_12"] > (df["close_min_48"] * 1.10)))
           # 1h up move, 15m uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["AROONU_14_15m"] < 100.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROONU_14_15m"] < 100.0))
           # 1h up move, 1d low
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0))
           # 1h up move, 1h & 4h uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["ROC_9_1h"] < 30.0) | (df["ROC_9_4h"] < 30.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_1h"] < 30.0) | (df["ROC_9_4h"] < 30.0))
           # 1h up move, 4h uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["ROC_9_4h"] < 20.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_4h"] < 20.0))
           # 1h up move, 4h still low
-          short_entry_logic.append((df["RSI_3_1h"] < 85.0) | (df["AROONU_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["AROONU_14_4h"] > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
           # 1h up move, 1h still not high enough
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["RSI_14_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_14_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0))
           # 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["AROONU_14_4h"] > 10.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["AROONU_14_4h"] > 10.0))
           # 1h up move, 1h still low
-          short_entry_logic.append((df["RSI_3_1h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0))
           # 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_1h"] < 70.0) | (df["RSI_14_4h"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (df["RSI_14_4h"] > 40.0))
           # 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 40.0))
           # 1h up move, 1h uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 70.0) | (df["ROC_9_1h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (df["ROC_9_1h"] < 40.0))
           # 1h up move, 1h low
-          short_entry_logic.append((df["RSI_3_1h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 20.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 20.0))
           # 4h up move, 1d still low
           short_entry_logic.append((df["RSI_3_4h"] < 97.0) | (df["RSI_14_1d"] > 50.0))
           # 4h up move, 1h still not high enough
@@ -24713,7 +24496,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big pump in the last 6 days, 4h still not high enough
           short_entry_logic.append((df["close"] < (df["low_min_6_1d"] * 4.0)) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0))
           # big pump in the last 20 days, 1h up move
-          short_entry_logic.append((df["close"] < (df["low_min_20_1d"] * 6.0)) | (df["RSI_3_1h"] < 90.0))
+          short_entry_logic.append((df["close"] < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h < 90.0))
 
           # Logic
           short_entry_logic.append(df["AROOND_14"] < 25.0)
@@ -24727,7 +24510,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Protections
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
-          short_entry_logic.append(df["RSI_3_1h"] >= 5.0)
+          short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(df["RSI_3_4h"] >= 20.0)
           short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
@@ -24740,17 +24523,13 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] < 90.0) | (df["MFI_14"] > 10.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
           )
           # 5m & 1h down move, 1h still high
-          short_entry_logic.append(
-            (df["RSI_3"] < 90.0) | (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-          )
+          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0))
           # 5m down move, 4h downtrend, 1h still high
           short_entry_logic.append(
             (df["RSI_3"] < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0)
           )
           # 5m & 4h strong down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0)
-          )
+          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0))
           # 5m down move, 1h high, 1d overbought
           short_entry_logic.append((df["RSI_3"] < 90.0) | (df["ROC_9_1h"] < 15.0) | (df["ROC_9_1d"] > -40.0))
           # 5m down move, 1h & 4h high
@@ -24762,14 +24541,14 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] < 98.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 10.0) | (df["ROC_9_4h"] < 10.0)
           )
           # 5m & 1h down move, 4h down
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["RSI_3_1h"] < 85.0) | (df["CMF_20_4h"] > -0.2))
+          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 85.0) | (df["CMF_20_4h"] > -0.2))
           # 5m down move, 1h high
           short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0))
           # 5m down move, 1h high
           short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0))
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m down move, 15m still not low enough, 1h & 4h still not low enough
           short_entry_logic.append(
@@ -24780,7 +24559,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 5m & 1h down move, 1h still high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
           )
           # 15m & 4h down move, 1h still not low
           short_entry_logic.append(
@@ -24835,9 +24614,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["ROC_9_15m"] < 10.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m & 1h & 4h down move
-          short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0)
-          )
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 15m strong down move
           short_entry_logic.append((df["RSI_3_15m"] < 90.0) | (df["MFI_14_15m"] < 85.0) | (df["AROOND_14_15m"] < 25.0))
           # 14m down move, 4h still high
@@ -24852,24 +24629,20 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1h & 4h down move, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] < 10.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["AROOND_14_4h"] < 25.0) | (df["ROC_9_1d"] > -120.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROOND_14_4h"] < 25.0) | (df["ROC_9_1d"] > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0) | (df["RSI_14_4h"] > 50.0)
+            (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0) | (df["RSI_14_4h"] > 50.0)
           )
           # 1h down move, 4h still high
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_14_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0) | (df["ROC_9_1d"] < 50.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0) | (df["ROC_9_1d"] < 50.0))
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append(
             (df["RSI_3_change_pct_1h"] > -65.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0) | (df["ROC_9_1d"] < 50.0)
@@ -24885,7 +24658,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 1h & 4h down move, 4h still high
           short_entry_logic.append(
             (df["AROOND_14_15m"] < 50.0)
-            | (df["RSI_3_1h"] < 85.0)
+            | (rsi_3_1h < 85.0)
             | (df["RSI_3_4h"] < 80.0)
             | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
           )
@@ -24950,9 +24723,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(
             (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (df["AROOND_14_4h"] < 50.0)
           )
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
 
           # Logic
           short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
@@ -24965,7 +24736,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Protections
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
-          short_entry_logic.append(df["RSI_3_1h"] >= 5.0)
+          short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(df["RSI_3_4h"] >= 20.0)
           short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
@@ -24975,7 +24746,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(
             (df["RSI_3_15m"] < 95.0)
             | (df["MFI_14_15m"] < 90.0)
-            | (df["RSI_3_1h"] < 80.0)
+            | (rsi_3_1h < 80.0)
             | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m & 1h down move, 4h still high
@@ -24992,20 +24763,18 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1h strong down move, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_14_change_pct_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
+            (rsi_3_1h < 95.0) | (df["RSI_14_change_pct_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
           )
           # 1h strong down move, 4h down move, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 75.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 75.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 75.0) | (df["AROOND_14_4h"] < 50.0))
           # 15m down move, 1h strong downtrend
-          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["MFI_14_1h"] > 5.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
           short_entry_logic.append(
             (df["ROC_9_15m"] > -20.0) | (df["RSI_3_4h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
@@ -25027,20 +24796,18 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3"] < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (df["RSI_14_4h"] > 50.0)
           )
           # 5m & 15m & 1h down move
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0))
+          short_entry_logic.append((df["RSI_3"] < 95.0) | (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0))
           # 5m strong down move
           short_entry_logic.append((df["RSI_3"] < 98.0) | (df["ROC_9"] < 50.0))
           # 15m & 1h strong down move & downtrend
-          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["MFI_14_1h"] > 5.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
           # 15m strong down move, 4h high
           short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 10.0))
           # 15m & 1h down move
-          short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["CCI_20_change_pct_1h"] > 0.0)
-          )
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_1h"] > 0.0))
           # 15m & 1h down move, 4h high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
           )
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
@@ -25052,7 +24819,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 1h not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0)
           )
           # 15m down move, 1h strong down move
           short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["RSI_14_change_pct_1h"] < 70.0))
@@ -25060,7 +24827,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["ROC_9_4h"] < 30.0) | (df["ROC_9_1d"] < 50.0))
           # 15m down move, 1h strong down move, 4h stil high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m down move, 1h & 4h still high
           short_entry_logic.append(
@@ -25072,7 +24839,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 4h high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 90.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
+            (df["RSI_3_15m"] < 90.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0)
           )
           # 15m down move, 1h down move, 4h high
           short_entry_logic.append(
@@ -25085,37 +24852,35 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high
           short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 10.0))
           # 1h strong down move, 4h high
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 10.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 10.0))
           # 1h down move, 4h downtrend, 4h not low enough
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["CMF_20_4h"] > -0.25) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+            (rsi_3_1h < 95.0) | (df["CMF_20_4h"] > -0.25) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 1h down move, 4h high, 1d overbought
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["RSI_14_4h"] > 40.0) | (df["ROC_9_1d"] > -50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_14_4h"] > 40.0) | (df["ROC_9_1d"] > -50.0))
           # 1h down move, 4h strong down move
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_14_change_pct_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_4h"] < 40.0))
           # 1h & 4h down move, 4h still going down
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+            (rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 1h down move, 4h down move, 4h P&D
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_change_pct_4h"] < 70.0) | (df["RSI_14_4h"].shift(48) > 30.0)
+            (rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 70.0) | (df["RSI_14_4h"].shift(48) > 30.0)
           )
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0)
+            (rsi_3_1h < 90.0)
             | (df["RSI_3_change_pct_4h"] < 50.0)
             | (df["AROOND_14_4h"] < 25.0)
             | (df["STOCHRSIk_14_14_3_3_1d"] > 60.0)
           )
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0) | (df["ROC_2_1d"] > -50.0)
+            (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0) | (df["ROC_2_1d"] > -50.0)
           )
           # 4h downtrend, 4h still high, 1d strong downtrend
           short_entry_logic.append(
@@ -25192,15 +24957,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m up move, 15m stil low
           short_entry_logic.append((df["RSI_3"] < 90.0) | (df["RSI_3_15m"] < 80.0) | (df["AROONU_14_15m"] > 60.0))
           # 15m & 1h up move, 4h still low
-          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["RSI_14_4h"] > 60.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0))
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
           )
           # 15m & 1h up move, 1h still moving higher
-          short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 90.0) | (df["CCI_20_change_pct_1h"] < -0.0)
-          )
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 90.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 15m & 4h up move, 4h still moving higher
           short_entry_logic.append(
             (df["RSI_3_15m"] < 90.0) | (df["RSI_3_4h"] < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0)
@@ -25230,77 +24993,65 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h overbought
           short_entry_logic.append((df["RSI_3_15m"] < 85.0) | (df["ROC_9_4h"] < 50.0))
           # 15m & 1h up move, 15m still low
-          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (df["RSI_3_1h"] < 70.0) | (df["AROONU_14_15m"] > 40.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (rsi_3_1h < 70.0) | (df["AROONU_14_15m"] > 40.0))
           # 15m & 1h up move, 15m still low
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 70.0) | (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 40.0)
+            (df["RSI_3_15m"] < 70.0) | (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 40.0)
           )
           # # 15m & 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (df["RSI_3_1h"] < 60.0) | (df["AROONU_14_4h"] > 40.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (rsi_3_1h < 60.0) | (df["AROONU_14_4h"] > 40.0))
           # 1h & 1d up move, 1h still moving higher
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 97.0) | (df["RSI_3_1d"] < 95.0) | (df["CCI_20_change_pct_1h"] < -0.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 97.0) | (df["RSI_3_1d"] < 95.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0)
+            (rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0)
           )
           # 1h & 4h up move, 1d uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["ROC_9_1d"] < 100.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["ROC_9_1d"] < 100.0))
           # 1h & 4h up move, 1d still low
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["RSI_14_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["RSI_14_1d"] > 50.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_14_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["AROONU_14_4h"] > 10.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["AROONU_14_4h"] > 10.0))
           # 1h & 4h up move, 1h still moving higher
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["CCI_20_change_pct_1h"] < -0.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h & 4h up move, 4h still not high enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0))
           # 1h & 1d up move, 15m still low
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_1d"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0)
+            (rsi_3_1h < 90.0) | (df["RSI_3_1d"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0)
           )
           # 1h up move, 15m high
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["AROONU_14_15m"] < 100.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROONU_14_15m"] < 100.0))
           # 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 30.0))
           # 1h up move, 4h still low, 1h still moving higher
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0)
+            (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0)
           )
           # 1h up move, 15m uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["ROC_9_15m"] < 30.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_15m"] < 30.0))
           # 1h up move, 15m & 4h uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 90.0) | (df["ROC_9_15m"] < 20.0) | (df["ROC_9_4h"] < 20.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_15m"] < 20.0) | (df["ROC_9_4h"] < 20.0))
           # 1h & 4h up move, 4h still moving higher
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["RSI_3_4h"] < 80.0) | (df["CCI_20_change_pct_4h"] < -0.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["RSI_3_4h"] < 80.0) | (df["CCI_20_change_pct_4h"] < -0.0))
           # 1h up move, 15m low
-          short_entry_logic.append((df["RSI_3_1h"] < 85.0) | (df["AROONU_14_15m"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["AROONU_14_15m"] > 40.0))
           # 1h up move, 4h still not high enough, 1d low
-          short_entry_logic.append((df["RSI_3_1h"] < 85.0) | (df["AROONU_14_4h"] > 80.0) | (df["RSI_14_1d"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["AROONU_14_4h"] > 80.0) | (df["RSI_14_1d"] > 40.0))
           # 1h & 4h up move, 4h still low
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["AROONU_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["AROONU_14_4h"] > 50.0))
           # 1h & 4h up move, 1d still low
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["AROONU_14_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["AROONU_14_1d"] > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
           # 1h up move, 1d still low, 1d uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["AROONU_14_1d"] > 50.0) | (df["ROC_9_1d"] < 30.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["AROONU_14_1d"] > 50.0) | (df["ROC_9_1d"] < 30.0))
           # 1h up move, 1d low
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
           # 1h up move, 4h & 1d uptrend
-          short_entry_logic.append((df["RSI_3_1h"] < 80.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["ROC_9_4h"] < 20.0) | (df["ROC_9_1d"] < 40.0))
           # 4h up move, 1d low
           short_entry_logic.append((df["RSI_3_4h"] < 95.0) | (df["RSI_14_1d"] > 40.0))
           # 4h down move, 15m still not high enough, 1d low
@@ -25410,23 +25161,23 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 5m & 1h strong down move, 1h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
           )
           # 5m & 1h strong downtrend
-          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["MFI_14_1h"] < 90.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 90.0))
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
             (df["RSI_3_15m"] < 95.0)
-            | (df["RSI_3_1h"] < 80.0)
+            | (rsi_3_1h < 80.0)
             | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
             | (df["AROOND_14_4h"] < 50.0)
           )
           # 15m & 1h down move, 4h still high, 4h downtrend
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 90.0) | (df["UO_7_14_28_4h"] > 60.0) | (df["ROC_9_4h"] < 20.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 90.0) | (df["UO_7_14_28_4h"] > 60.0) | (df["ROC_9_4h"] < 20.0)
           )
           # 15m & 1h down move, 1d strong downtrend
-          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 90.0) | (df["ROC_9_1d"] < 50.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 90.0) | (df["ROC_9_1d"] < 50.0))
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append(
             (df["RSI_3_15m"] < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 55.0)
@@ -25437,7 +25188,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 1h still high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 85.0) | (df["RSI_3_1h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0)
+            (df["RSI_3_15m"] < 85.0) | (rsi_3_1h < 75.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0)
           )
           # 15m down move, 15m still not low enoug, 1h high
           short_entry_logic.append(
@@ -25446,24 +25197,22 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h downtrend, 4h overbought
           short_entry_logic.append((df["RSI_3_15m"] < 85.0) | (df["ROC_9_1h"] < 5.0) | (df["ROC_9_4h"] > -35.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 75.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 75.0))
           # 1h & 4h down move, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+            (rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0) | (df["RSI_14_4h"] > 50.0)
+            (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0) | (df["RSI_14_4h"] > 50.0)
           )
           # 1h down move, 1h not low enough, 1h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["AROOND_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 85.0) | (df["AROOND_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 4h down move, 15m still not low enough, 1h still high
           short_entry_logic.append(
@@ -25508,7 +25257,7 @@ class NostalgiaForInfinityX7(IStrategy):
         #   short_entry_logic.append(is_pair_short_grind_mode)
         #   short_entry_logic.append(df["RSI_3"] <= 40.0)
         #   short_entry_logic.append(df["RSI_3_15m"] >= 10.0)
-        #   short_entry_logic.append(df["RSI_3_1h"] >= 5.0)
+        #   short_entry_logic.append(rsi_3_1h >= 5.0)
         #   short_entry_logic.append(df["RSI_3_4h"] >= 5.0)
         #   short_entry_logic.append(df["RSI_14_1h"] < 85.0)
         #   short_entry_logic.append(df["RSI_14_4h"] < 85.0)
@@ -25527,7 +25276,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
-          short_entry_logic.append(df["RSI_3_1h"] >= 5.0)
+          short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(df["RSI_3_4h"] >= 20.0)
           short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
@@ -25547,11 +25296,11 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 1d still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0)
           )
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 85.0) | (df["RSI_3_1h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
+            (df["RSI_3_15m"] < 85.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 70.0)
           )
           # 15m down move, 1h high, 4h still high
           short_entry_logic.append(
@@ -25559,41 +25308,33 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 80.0) | (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (df["RSI_3_15m"] < 80.0) | (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m down move, 1h still not low enough, 4h still high
           short_entry_logic.append(
             (df["RSI_3_15m"] < 75.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0)
           )
           # 1h & 4h & 1d down move
-          short_entry_logic.append((df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 90.0) | (df["RSI_3_1d"] < 80.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 90.0) | (df["RSI_3_1d"] < 80.0))
           # 1h & 4h down move, 15m not low enough
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 75.0)
+            (rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 75.0)
           )
           # 1h down move, 1h still not low enough, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["RSI_3_4h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["RSI_3_4h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["RSI_3_4h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["RSI_3_4h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 75.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 75.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 75.0))
           # 1h down move, 1h & 4h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+            (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 4h down move, 15m still high, 1h still not low enough
           short_entry_logic.append(
@@ -25618,7 +25359,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
           # 5m & 1h & 4h down move
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 90.0))
+          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 90.0))
           # 5m down move, 15m & 4h still high
           short_entry_logic.append(
             (df["RSI_3"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0)
@@ -25629,17 +25370,17 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0)
           )
           # 15m & 1h down move, 1d still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0)
           )
           # 15m strong down move, 4h high
           short_entry_logic.append((df["RSI_3_15m"] < 95.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0)
           )
           # 15m down move, 15m stil high, 1h still not low enough
           short_entry_logic.append(
@@ -25651,7 +25392,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 95.0) | (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (df["RSI_3_15m"] < 95.0) | (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m down move, 15m still not low enough, 4h high
           short_entry_logic.append(
@@ -25667,11 +25408,11 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 80.0) | (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+            (df["RSI_3_15m"] < 80.0) | (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 75.0) | (df["RSI_3_1h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+            (df["RSI_3_15m"] < 75.0) | (rsi_3_1h < 75.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append(
@@ -25710,56 +25451,36 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_3_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 10.0)
           )
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 95.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 90.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 80.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 85.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 85.0))
           # 1h & 4h down move, 1d still high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 85.0) | (df["RSI_3_4h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 85.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 85.0) | (df["RSI_3_4h"] < 75.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 85.0))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0)
+            (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0)
           )
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 75.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 75.0))
           # 1h & 4h down move, 15m still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0)
+            (rsi_3_1h < 80.0) | (df["RSI_3_4h"] < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0)
           )
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 75.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 75.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 75.0) | (df["RSI_3_4h"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 75.0))
           # 1h & 4h down move, 1h still high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 70.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 70.0) | (df["RSI_3_4h"] < 85.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0))
           # 1h down move, 1h still not low enough, 4h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 80.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 4h down move, 15m still high, 1h still not low enough
           short_entry_logic.append(
@@ -25829,19 +25550,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high
           short_entry_logic.append((df["RSI_3_15m"] < 75.0) | (df["AROOND_14_15m"] < 80.0))
           # 15m & 1h down move, 15m still high
-          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (df["RSI_3_1h"] < 40.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 70.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 50.0))
           # 15m down move, 15m & 4h still high
           short_entry_logic.append(
             (df["RSI_3_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 15m & 1h down move, 1h high
-          short_entry_logic.append((df["RSI_3_15m"] < 60.0) | (df["RSI_3_1h"] < 60.0) | (df["AROOND_14_1h"] < 70.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 60.0) | (rsi_3_1h < 60.0) | (df["AROOND_14_1h"] < 70.0))
           # 15m & 1h down move, 1h still high
           short_entry_logic.append(
-            (df["RSI_3_15m"] < 60.0) | (df["RSI_3_1h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+            (df["RSI_3_15m"] < 60.0) | (rsi_3_1h < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
           )
           # 15m & 1h down move, 4h high
-          short_entry_logic.append((df["RSI_3_15m"] < 60.0) | (df["RSI_3_1h"] < 40.0) | (df["AROOND_14_4h"] < 80.0))
+          short_entry_logic.append((df["RSI_3_15m"] < 60.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_4h"] < 80.0))
           # 15m & 4h down move, 15m high
           short_entry_logic.append(
             (df["RSI_3_15m"] < 60.0) | (df["RSI_3_4h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0)
@@ -25874,93 +25595,85 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 75.0) | (df["AROOND_14_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0)
+            (rsi_3_1h < 75.0) | (df["AROOND_14_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0)
           )
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0)
+            (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0)
           )
           # 1h & 4h down move, 4h high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 65.0) | (df["RSI_3_4h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 65.0) | (df["RSI_3_4h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0))
           # 1h down move, 15m & 1h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+            (rsi_3_1h < 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
           )
           # 1h down move, 1h still high, 4h high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+            (rsi_3_1h < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 70.0)
           )
           # 1h down move, 1h high
-          short_entry_logic.append((df["RSI_3_1h"] < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 40.0))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((df["RSI_3_1h"] < 60.0) | (df["AROOND_14_4h"] < 85.0) | (df["AROOND_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (df["AROOND_14_4h"] < 85.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((df["RSI_3_1h"] < 55.0) | (df["AROOND_14_1h"] < 50.0) | (df["AROOND_14_4h"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 55.0) | (df["AROOND_14_1h"] < 50.0) | (df["AROOND_14_4h"] < 90.0))
           # 1h down move, 1h high
-          short_entry_logic.append((df["RSI_3_1h"] < 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 55.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 40.0))
           # 1h & 4h down move, 15m high
-          short_entry_logic.append((df["RSI_3_1h"] < 50.0) | (df["RSI_3_4h"] < 40.0) | (df["AROOND_14_15m"] < 70.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (df["RSI_3_4h"] < 40.0) | (df["AROOND_14_15m"] < 70.0))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 50.0) | (df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_4h"] < 80.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_4h"] < 80.0))
           # 1h down move, 15m high, 1h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 50.0) | (df["AROOND_14_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0)
+            (rsi_3_1h < 50.0) | (df["AROOND_14_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0)
           )
           # 1h down move, 15m still high, 4h high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0)
+            (rsi_3_1h < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 20.0)
           )
           # 1h down move, 15m & 1h high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 40.0) | (df["AROOND_14_1h"] < 60.0)
+            (rsi_3_1h < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 40.0) | (df["AROOND_14_1h"] < 60.0)
           )
           # 1h down move, 1h & 1d high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 50.0) | (df["AROOND_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0)
+            (rsi_3_1h < 50.0) | (df["AROOND_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0)
           )
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0)
+            (rsi_3_1h < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0)
           )
           # 1h down move, 5m up move, 1h still high
+          short_entry_logic.append((rsi_3_1h < 40.0) | (df["RSI_3"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0))
+          # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["RSI_3"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+            (rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (df["AROOND_14_1h"] < 70.0)
           )
           # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (df["AROOND_14_1h"] < 70.0)
-          )
-          # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 40.0)
+            (rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 40.0)
           )
           # 1h down move, 15m & 4h still high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
+            (rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 50.0)
           )
           # 1h down move, 15m & 1h high
-          short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_1h"] < 90.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_1h"] < 90.0))
           # 1h down move, 1h still high, 4h high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["AROOND_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 10.0)
+            (rsi_3_1h < 40.0) | (df["AROOND_14_1h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_4h"] > 10.0)
           )
           # 1h down move, 1h high, 4h still high
-          short_entry_logic.append((df["RSI_3_1h"] < 40.0) | (df["AROOND_14_1h"] < 80.0) | (df["AROOND_14_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_1h"] < 80.0) | (df["AROOND_14_4h"] < 40.0))
           # 1h down move, 1h still high, 4h high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0) | (df["AROOND_14_4h"] < 70.0)
+            (rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 60.0) | (df["AROOND_14_4h"] < 70.0)
           )
           # 1h down move, 1h & 1d high
           short_entry_logic.append(
-            (df["RSI_3_1h"] < 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0) | (df["AROOND_14_1d"] < 90.0)
+            (rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_1h"] > 30.0) | (df["AROOND_14_1d"] < 90.0)
           )
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((df["RSI_3_1h"] < 40.0) | (df["RSI_14_4h"] > 30.0) | (df["RSI_14_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (df["RSI_14_4h"] > 30.0) | (df["RSI_14_1d"] > 20.0))
           # 4h down move, 15m high
           short_entry_logic.append((df["RSI_3_4h"] < 80.0) | (df["AROOND_14_15m"] < 80.0))
           # 4h down move, 1h high


### PR DESCRIPTION
## Summary
- Reuses one `rsi_3_1h` Series local in `populate_entry_trend()` instead of reading `df["RSI_3_1h"]` throughout the entry matrix.
- Replaces 2,433 repeated direct dataframe column reads with the local Series reference.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same entry formulas, thresholds, condition order, candle selection, output columns, and return behavior.
- The patch only reuses the same `df["RSI_3_1h"]` Series already available inside the same `populate_entry_trend()` call.
- A normalized AST check was used for the large diff: after removing the new local and replacing `rsi_3_1h` back to `df["RSI_3_1h"]`, the function AST matches the base version.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact same-call Series reuse: the same dataframe column is read once and reused by existing comparisons without changing thresholds, formulas, condition order, candle selection, or signal outputs.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- normalized AST equivalence check for `populate_entry_trend()` after inverting the local-Series substitution
