### PR TITLE
Reuse X7 long-exit RSI-3 field

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -29859,6 +29859,7 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
+    last_rsi_3 = last_candle["RSI_3"]
     if 0.01 > current_profit >= 0.001:
       if (
         (last_candle["WILLR_14"] > -1.0)
@@ -29916,7 +29917,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -29941,7 +29942,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3"] > 99.0)
+        and (last_rsi_3 > 99.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -29955,7 +29956,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_10"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -29963,26 +29964,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_0_12"
-      elif (last_candle["RSI_3"] > 99.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 99.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_0_13"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_14"
-      elif (last_candle["RSI_3"] > 99.0) and (last_candle["RSI_14"] > 78.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 99.0) and (last_candle["RSI_14"] > 78.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -29990,7 +29991,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -29998,14 +29999,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_17"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] > 75.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 78.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -30015,21 +30016,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_19"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_20"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_21"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -30037,14 +30038,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_22"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 78.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -30052,7 +30053,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -30063,14 +30064,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_25"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -30078,14 +30079,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_27"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -30093,14 +30094,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_29"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -30108,14 +30109,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_31"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -30123,21 +30124,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_34"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -30145,7 +30146,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -30153,21 +30154,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_37"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_38"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -30178,7 +30179,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_40"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -30186,7 +30187,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -30197,7 +30198,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -30208,24 +30209,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_43"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_candle["RSI_3"] > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_0_45"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_0_46"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -30233,7 +30234,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_47"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -30241,7 +30242,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -30252,21 +30253,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_50"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -30274,7 +30275,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -30286,7 +30287,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -30294,7 +30295,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -30302,7 +30303,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -30311,14 +30312,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 34.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -30326,7 +30327,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -30334,7 +30335,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_59"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -30342,14 +30343,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_60"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_61"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -30358,42 +30359,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_62"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_65"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -30401,35 +30402,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_70"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_71"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -30437,7 +30438,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -30445,7 +30446,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -30455,21 +30456,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_75"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -30477,14 +30478,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_78"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -30492,7 +30493,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -30500,7 +30501,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -30508,7 +30509,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_82"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -30516,14 +30517,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_83"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -30531,7 +30532,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -30539,7 +30540,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -30547,7 +30548,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -30555,14 +30556,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -30571,7 +30572,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_90"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -30583,7 +30584,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_91"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -30592,7 +30593,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_92"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -30606,7 +30607,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_93"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -30618,7 +30619,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_94"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -30627,7 +30628,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -30635,7 +30636,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -30643,7 +30644,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_97"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_15m"] > 74.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -30652,7 +30653,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -30662,14 +30663,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_99"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 78.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -30677,7 +30678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_101"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -30686,7 +30687,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_102"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -30694,7 +30695,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_103"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -30703,7 +30704,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -30711,7 +30712,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -30720,7 +30721,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -30728,14 +30729,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_107"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -30743,14 +30744,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_109"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -30760,7 +30761,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -30770,7 +30771,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -30779,7 +30780,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_113"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -30787,7 +30788,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -30795,28 +30796,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_115"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_116"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_117"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -30824,35 +30825,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_119"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_120"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_0_121"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_122"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -30861,7 +30862,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_124"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -30870,29 +30871,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_126"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_candle["RSI_3"] > 96.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -30906,7 +30907,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -30914,7 +30915,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -30977,7 +30978,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -31002,7 +31003,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_8"
       elif (
         (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -31016,7 +31017,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_10"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -31024,26 +31025,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_11"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_1_12"
-      elif (last_candle["RSI_3"] > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_1_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_14"
-      elif (last_candle["RSI_3"] > 95.0) and (last_candle["RSI_14"] > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 95.0) and (last_candle["RSI_14"] > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -31051,7 +31052,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_16"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -31059,14 +31060,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_17"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_1_18"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] > 72.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -31076,21 +31077,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_19"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_20"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_21"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -31098,14 +31099,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_22"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] > 75.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -31113,7 +31114,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_24"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -31124,14 +31125,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_25"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -31139,14 +31140,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_27"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -31154,14 +31155,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_29"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_30"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -31169,14 +31170,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_31"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_32"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -31184,21 +31185,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_34"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_35"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -31206,7 +31207,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_36"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -31214,21 +31215,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_37"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_38"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_39"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -31239,7 +31240,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_40"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -31247,7 +31248,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_41"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -31258,7 +31259,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -31269,24 +31270,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_43"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
-      elif (last_candle["RSI_3"] > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_1_45"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_1_46"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -31294,7 +31295,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_47"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -31302,7 +31303,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_48"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -31313,21 +31314,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_50"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -31335,7 +31336,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -31347,7 +31348,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_53"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -31355,7 +31356,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_54"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -31363,7 +31364,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_55"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -31372,14 +31373,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 36.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -31387,7 +31388,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -31395,7 +31396,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_59"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -31403,14 +31404,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_61"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -31419,42 +31420,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_62"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_64"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_65"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_67"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -31462,35 +31463,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_1_69"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_70"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_71"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_72"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -31498,7 +31499,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_73"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -31506,7 +31507,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -31516,21 +31517,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_75"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -31538,14 +31539,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_78"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -31553,7 +31554,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_80"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -31561,7 +31562,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_81"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -31569,7 +31570,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_82"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -31577,14 +31578,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_83"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_84"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -31592,7 +31593,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_85"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -31600,7 +31601,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_86"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -31608,7 +31609,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_87"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -31616,14 +31617,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_88"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -31632,7 +31633,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_90"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -31644,7 +31645,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_91"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -31653,7 +31654,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_92"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -31667,7 +31668,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_93"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -31679,7 +31680,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_94"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -31688,7 +31689,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_95"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -31696,7 +31697,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_96"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -31704,7 +31705,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_97"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_15m"] > 72.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -31713,7 +31714,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_98"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -31723,14 +31724,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_99"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_14"] > 76.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_100"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -31738,7 +31739,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_101"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -31747,7 +31748,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_102"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -31755,7 +31756,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_103"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -31764,7 +31765,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_104"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -31772,7 +31773,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_105"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -31781,7 +31782,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_106"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -31789,14 +31790,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_107"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_108"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -31804,14 +31805,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_109"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -31821,7 +31822,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_111"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -31831,7 +31832,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -31840,7 +31841,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_113"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -31848,7 +31849,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_114"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -31856,28 +31857,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_115"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_116"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_117"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_118"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -31885,35 +31886,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_119"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_120"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_1_121"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_122"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -31922,7 +31923,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_124"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -31931,29 +31932,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_126"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_127"
-      elif (last_candle["RSI_3"] > 94.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 94.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_129"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -31967,7 +31968,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_131"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -31975,7 +31976,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_132"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -32038,7 +32039,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -32063,7 +32064,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_8"
       elif (
         (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -32077,7 +32078,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_10"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -32085,26 +32086,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_11"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_2_12"
-      elif (last_candle["RSI_3"] > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_2_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_14"
-      elif (last_candle["RSI_3"] > 92.0) and (last_candle["RSI_14"] > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["RSI_14"] > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -32112,7 +32113,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_16"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -32120,14 +32121,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_17"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_2_18"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] > 70.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -32137,21 +32138,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_19"
       elif (
-        (last_candle["RSI_3"] > 48.0)
+        (last_rsi_3 > 48.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_20"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_21"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -32159,14 +32160,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_22"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] > 70.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -32174,7 +32175,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_24"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -32185,14 +32186,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_25"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -32200,14 +32201,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_27"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -32215,14 +32216,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_29"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_30"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -32230,14 +32231,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_31"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_32"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -32245,21 +32246,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_34"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -7.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_35"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -32267,7 +32268,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_36"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -32275,21 +32276,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_37"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_38"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_39"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -32300,7 +32301,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_40"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -32308,7 +32309,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_41"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -32319,7 +32320,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -32330,24 +32331,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_43"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
-      elif (last_candle["RSI_3"] > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_2_45"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_2_46"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -32355,7 +32356,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_47"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -32363,7 +32364,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_48"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -32374,21 +32375,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_50"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -32396,7 +32397,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -32408,7 +32409,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_53"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -32416,7 +32417,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_54"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -32424,7 +32425,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_55"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -32433,14 +32434,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 38.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -32448,7 +32449,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -32456,7 +32457,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_59"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -32464,14 +32465,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_61"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -32480,42 +32481,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_62"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_64"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_65"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_67"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -32523,35 +32524,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_2_69"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_70"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_71"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_72"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -32559,7 +32560,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_73"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -32567,7 +32568,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -32577,21 +32578,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_75"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -32599,14 +32600,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_78"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -32614,7 +32615,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_80"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -32622,7 +32623,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_81"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -32630,7 +32631,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_82"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -32638,14 +32639,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_83"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_84"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -32653,7 +32654,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_85"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -32661,7 +32662,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_86"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -32669,7 +32670,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_87"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -32677,14 +32678,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_88"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -32693,7 +32694,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_90"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -32705,7 +32706,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_91"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -32714,7 +32715,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_92"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -32728,7 +32729,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_93"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -32740,7 +32741,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_94"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -32749,7 +32750,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_95"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -32757,7 +32758,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_96"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -32765,7 +32766,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_97"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -32774,7 +32775,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -32784,14 +32785,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_99"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14"] > 74.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_100"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -32799,7 +32800,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_101"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -32808,7 +32809,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_102"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -32816,7 +32817,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_103"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -32825,7 +32826,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -32833,7 +32834,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -32842,7 +32843,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -32850,14 +32851,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_107"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -32865,14 +32866,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_109"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
-        (last_candle["RSI_3"] > 48.0)
+        (last_rsi_3 > 48.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -32882,7 +32883,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_111"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -32892,7 +32893,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -32901,7 +32902,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_113"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -32909,7 +32910,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -32917,28 +32918,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_115"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_116"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_117"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_118"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -32946,35 +32947,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_119"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_120"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_2_121"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_122"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -32983,7 +32984,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_124"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -32992,29 +32993,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_126"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_127"
-      elif (last_candle["RSI_3"] > 92.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_129"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -33028,7 +33029,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_131"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -33036,7 +33037,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_132"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -33099,7 +33100,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -33124,7 +33125,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
         (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -33138,7 +33139,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_10"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -33146,26 +33147,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_11"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_3_12"
-      elif (last_candle["RSI_3"] > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_3_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_14"
-      elif (last_candle["RSI_3"] > 90.0) and (last_candle["RSI_14"] > 65.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["RSI_14"] > 65.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -33173,7 +33174,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -33181,14 +33182,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_17"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] > 68.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -33198,21 +33199,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_19"
       elif (
-        (last_candle["RSI_3"] > 46.0)
+        (last_rsi_3 > 46.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_20"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -33220,14 +33221,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_22"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] > 68.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -33235,7 +33236,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -33246,14 +33247,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_25"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -33261,14 +33262,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_27"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -33276,14 +33277,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_29"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -33291,14 +33292,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_31"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -33306,21 +33307,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_34"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -33328,7 +33329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -33336,21 +33337,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_37"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_38"
       elif (
-        (last_candle["RSI_3"] > 93.0)
+        (last_rsi_3 > 93.0)
         and (last_candle["WILLR_14"] > -7.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -33361,7 +33362,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_40"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -33369,7 +33370,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_41"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -33380,7 +33381,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -33391,24 +33392,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_43"
       elif (
-        (last_candle["RSI_3"] > 55.0)
+        (last_rsi_3 > 55.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_candle["RSI_3"] > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_3_45"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_3_46"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -33416,7 +33417,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_47"
       elif (
-        (last_candle["RSI_3"] > 55.0)
+        (last_rsi_3 > 55.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -33424,7 +33425,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -33435,21 +33436,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_50"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -33457,7 +33458,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -33469,7 +33470,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -33477,7 +33478,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -33485,7 +33486,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -33494,14 +33495,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 40.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -33509,7 +33510,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -33517,7 +33518,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_59"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -33525,14 +33526,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_61"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -33541,42 +33542,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_62"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_65"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -33584,35 +33585,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_3_69"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_70"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_71"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_72"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -33620,7 +33621,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_73"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -33628,7 +33629,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -33638,21 +33639,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_75"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -33660,14 +33661,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_78"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -33675,7 +33676,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -33683,7 +33684,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -33691,7 +33692,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -33699,14 +33700,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_83"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -33714,7 +33715,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -33722,7 +33723,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -33730,7 +33731,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_87"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -24.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -33738,14 +33739,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_88"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -33754,7 +33755,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_90"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -33766,7 +33767,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_91"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -33775,7 +33776,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_92"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -33789,7 +33790,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_93"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -33801,7 +33802,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_94"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -33810,7 +33811,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -33818,7 +33819,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -33826,7 +33827,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_97"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_15m"] > 68.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -33835,7 +33836,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -33845,14 +33846,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_99"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14"] > 72.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -33860,7 +33861,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_101"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -33869,7 +33870,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_102"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 60.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -33877,7 +33878,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_103"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -33886,7 +33887,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -33894,7 +33895,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -33903,7 +33904,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -33911,14 +33912,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_107"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -33926,14 +33927,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_109"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
-        (last_candle["RSI_3"] > 46.0)
+        (last_rsi_3 > 46.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -33943,7 +33944,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_111"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -33953,7 +33954,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -33962,7 +33963,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_113"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -33970,7 +33971,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_114"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -33978,28 +33979,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_115"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_116"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_117"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -34007,35 +34008,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_119"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_120"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_3_121"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_122"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -34044,7 +34045,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_124"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -34053,29 +34054,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_126"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_candle["RSI_3"] > 90.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -34089,7 +34090,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -34097,7 +34098,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -34160,7 +34161,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -34185,7 +34186,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_8"
       elif (
         (last_candle["WILLR_14"] > -7.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -34199,7 +34200,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_10"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -34207,26 +34208,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_11"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_4_12"
-      elif (last_candle["RSI_3"] > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_4_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_14"
-      elif (last_candle["RSI_3"] > 88.0) and (last_candle["RSI_14"] > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["RSI_14"] > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -34234,7 +34235,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_16"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -34242,14 +34243,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_17"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_4_18"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -34259,21 +34260,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_19"
       elif (
-        (last_candle["RSI_3"] > 44.0)
+        (last_rsi_3 > 44.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_20"
       elif (
-        (last_candle["RSI_3"] > 55.0)
+        (last_rsi_3 > 55.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_21"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -34281,14 +34282,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_22"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -34296,7 +34297,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_24"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -34307,14 +34308,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_25"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -34322,14 +34323,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_27"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -34337,14 +34338,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_29"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_30"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -34352,14 +34353,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_31"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_32"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -34367,21 +34368,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_34"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -9.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_35"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -34389,7 +34390,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_36"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -34397,21 +34398,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_37"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_38"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_39"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -34422,7 +34423,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_40"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -34430,7 +34431,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_41"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -34441,7 +34442,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -34452,24 +34453,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_43"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
-      elif (last_candle["RSI_3"] > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_4_45"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_4_46"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -34477,7 +34478,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_47"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -34485,7 +34486,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_48"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -34496,21 +34497,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_50"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -34518,7 +34519,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -34530,7 +34531,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_53"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -34538,7 +34539,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_54"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -34546,7 +34547,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_55"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -34555,14 +34556,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 42.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -34570,7 +34571,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -34578,7 +34579,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_59"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -34586,14 +34587,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_61"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -34602,42 +34603,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_62"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_64"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_65"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_67"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -34645,35 +34646,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
-        (last_candle["RSI_3"] > 93.0)
+        (last_rsi_3 > 93.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_4_69"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_70"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_71"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_72"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -34681,7 +34682,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_73"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -34689,7 +34690,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -34699,21 +34700,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_75"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_77"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -34721,14 +34722,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_78"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -34736,7 +34737,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_80"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -34744,7 +34745,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_81"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -34752,7 +34753,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_82"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -34760,14 +34761,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_83"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_84"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -34775,7 +34776,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_85"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -34783,7 +34784,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_86"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -34791,7 +34792,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_87"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -26.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -34799,14 +34800,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_88"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -34815,7 +34816,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_90"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -34827,7 +34828,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_91"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -34836,7 +34837,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_92"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -34850,7 +34851,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_93"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -34862,7 +34863,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_94"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -34871,7 +34872,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -34879,7 +34880,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_96"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -34887,7 +34888,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_97"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_15m"] > 66.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -34896,7 +34897,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_98"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -34906,14 +34907,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_99"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14"] > 70.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_100"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -34921,7 +34922,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_101"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -34930,7 +34931,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_102"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 62.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -34938,7 +34939,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_103"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -34947,7 +34948,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_104"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -34955,7 +34956,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_105"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -34964,7 +34965,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_106"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -34972,14 +34973,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_107"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_108"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -34987,14 +34988,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_109"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
-        (last_candle["RSI_3"] > 44.0)
+        (last_rsi_3 > 44.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -35004,7 +35005,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_111"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -40.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -35014,7 +35015,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -35023,7 +35024,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_113"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -35031,7 +35032,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_114"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -35039,28 +35040,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_115"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_116"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_117"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_118"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -35068,35 +35069,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_119"
       elif (
-        (last_candle["RSI_3"] > 48.0)
+        (last_rsi_3 > 48.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_120"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_4_121"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_122"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -35105,7 +35106,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_124"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -35114,29 +35115,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_126"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_127"
-      elif (last_candle["RSI_3"] > 88.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_129"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -35150,7 +35151,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_131"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -35158,7 +35159,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_132"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -35221,7 +35222,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -35246,7 +35247,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_8"
       elif (
         (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -35260,7 +35261,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_10"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -35268,26 +35269,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_11"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_5_12"
-      elif (last_candle["RSI_3"] > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 80.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_5_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_14"
-      elif (last_candle["RSI_3"] > 86.0) and (last_candle["RSI_14"] > 58.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 86.0) and (last_candle["RSI_14"] > 58.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -35295,7 +35296,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_16"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -35303,14 +35304,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_17"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -35320,21 +35321,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_19"
       elif (
-        (last_candle["RSI_3"] > 42.0)
+        (last_rsi_3 > 42.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_20"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -35342,14 +35343,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_22"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -35357,7 +35358,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -35368,14 +35369,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_25"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -35383,14 +35384,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_27"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -35398,14 +35399,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_29"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -35413,14 +35414,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_31"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -35428,21 +35429,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_34"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -35450,7 +35451,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -35458,21 +35459,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_37"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_38"
       elif (
-        (last_candle["RSI_3"] > 91.0)
+        (last_rsi_3 > 91.0)
         and (last_candle["WILLR_14"] > -9.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -35483,7 +35484,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_40"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -35491,7 +35492,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_41"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -35502,7 +35503,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -35513,24 +35514,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_43"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_candle["RSI_3"] > 86.0) and (last_candle["WILLR_14"] > -14.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 86.0) and (last_candle["WILLR_14"] > -14.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_5_45"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_5_46"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -35538,7 +35539,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_47"
       elif (
-        (last_candle["RSI_3"] > 45.0)
+        (last_rsi_3 > 45.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -35546,7 +35547,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -35557,21 +35558,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_50"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -35579,7 +35580,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -35591,7 +35592,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -35599,7 +35600,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -35607,7 +35608,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -35616,14 +35617,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 44.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -35631,7 +35632,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -35639,7 +35640,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_59"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -35647,14 +35648,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_61"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -35663,42 +35664,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_62"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_65"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -35706,35 +35707,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_70"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_71"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -35742,7 +35743,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_73"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -35750,7 +35751,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -35760,21 +35761,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_75"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -24.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -35782,14 +35783,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_78"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -35797,7 +35798,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -35805,7 +35806,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -35813,7 +35814,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_82"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -35821,14 +35822,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_83"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -35836,7 +35837,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -35844,7 +35845,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -35852,7 +35853,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_87"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -28.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -35860,14 +35861,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_88"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -35876,7 +35877,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_90"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -35888,7 +35889,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_91"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -35897,7 +35898,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_92"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -35911,7 +35912,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_93"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -35923,7 +35924,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_94"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -35932,7 +35933,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_95"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -35940,7 +35941,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -35948,7 +35949,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_97"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_15m"] > 64.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -35957,7 +35958,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_98"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 60.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -35967,14 +35968,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_99"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] > 68.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -24.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -35982,7 +35983,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_101"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -35991,7 +35992,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_102"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 64.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -35999,7 +36000,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -36008,7 +36009,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -36016,7 +36017,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -36025,7 +36026,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -36033,14 +36034,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_107"
       elif (
-        (last_candle["RSI_3"] > 48.0)
+        (last_rsi_3 > 48.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -36048,14 +36049,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_109"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
-        (last_candle["RSI_3"] > 42.0)
+        (last_rsi_3 > 42.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -36065,7 +36066,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_111"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -45.0)
         and (last_candle["RSI_14"] < 60.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -36075,7 +36076,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -36084,7 +36085,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_113"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -36092,7 +36093,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_114"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -36100,28 +36101,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_115"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_116"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_117"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -36129,35 +36130,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_119"
       elif (
-        (last_candle["RSI_3"] > 46.0)
+        (last_rsi_3 > 46.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_120"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_5_121"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_122"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -36166,7 +36167,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_124"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -36175,29 +36176,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_126"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_candle["RSI_3"] > 86.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 86.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -36211,7 +36212,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -36219,7 +36220,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -36282,7 +36283,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -36307,7 +36308,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_8"
       elif (
         (last_candle["WILLR_14"] > -7.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -36321,7 +36322,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_10"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -36329,26 +36330,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_11"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_6_12"
-      elif (last_candle["RSI_3"] > 85.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 85.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_6_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_14"
-      elif (last_candle["RSI_3"] > 88.0) and (last_candle["RSI_14"] > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["RSI_14"] > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -36356,7 +36357,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -36364,14 +36365,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_17"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] > 65.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -36381,21 +36382,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_19"
       elif (
-        (last_candle["RSI_3"] > 44.0)
+        (last_rsi_3 > 44.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_20"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -36403,14 +36404,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_22"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -36418,7 +36419,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -36429,14 +36430,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_25"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -36444,14 +36445,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_27"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -36459,14 +36460,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_29"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -36474,14 +36475,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_31"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -36489,21 +36490,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_34"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -9.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -36511,7 +36512,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -36519,21 +36520,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_37"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_38"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -36544,7 +36545,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_40"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -36552,7 +36553,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_41"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -36563,7 +36564,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -36574,24 +36575,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_43"
       elif (
-        (last_candle["RSI_3"] > 55.0)
+        (last_rsi_3 > 55.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_candle["RSI_3"] > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_6_45"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_6_46"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -36599,7 +36600,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_47"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -36607,7 +36608,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -36618,21 +36619,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_50"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -36640,7 +36641,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -36652,7 +36653,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -36660,7 +36661,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -36668,7 +36669,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -36677,14 +36678,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 42.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -36692,7 +36693,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -36700,7 +36701,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_59"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -36708,14 +36709,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_61"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -36724,42 +36725,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_62"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_65"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -36767,35 +36768,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
-        (last_candle["RSI_3"] > 93.0)
+        (last_rsi_3 > 93.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_70"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_71"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_72"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -36803,7 +36804,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_73"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -36811,7 +36812,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -36821,21 +36822,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_75"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -36843,14 +36844,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_78"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -36858,7 +36859,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -36866,7 +36867,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -36874,7 +36875,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_82"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -36882,14 +36883,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_83"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -36897,7 +36898,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -36905,7 +36906,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -36913,7 +36914,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_87"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -26.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -36921,14 +36922,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_88"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -36937,7 +36938,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_90"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -36949,7 +36950,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_91"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -36958,7 +36959,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_92"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -36972,7 +36973,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_93"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -36984,7 +36985,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_94"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -36993,7 +36994,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -37001,7 +37002,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -37009,7 +37010,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_97"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_15m"] > 66.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -37018,7 +37019,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_98"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -37028,14 +37029,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_99"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14"] > 70.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -37043,7 +37044,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_101"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -37052,7 +37053,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_102"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 62.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -37060,7 +37061,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_103"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -37069,7 +37070,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -37077,7 +37078,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -37086,7 +37087,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -37094,14 +37095,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_107"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -37109,14 +37110,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_109"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
-        (last_candle["RSI_3"] > 44.0)
+        (last_rsi_3 > 44.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -37126,7 +37127,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_111"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -40.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -37136,7 +37137,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -37145,7 +37146,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_113"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -37153,7 +37154,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_114"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -37161,28 +37162,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_115"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_116"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_117"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -37190,35 +37191,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_119"
       elif (
-        (last_candle["RSI_3"] > 48.0)
+        (last_rsi_3 > 48.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_120"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_6_121"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_122"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -37227,7 +37228,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_124"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -37236,29 +37237,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_126"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_candle["RSI_3"] > 88.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -37272,7 +37273,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -37280,7 +37281,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -37343,7 +37344,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -37368,7 +37369,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_8"
       elif (
         (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -37382,7 +37383,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_10"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -37390,26 +37391,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_11"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_7_12"
-      elif (last_candle["RSI_3"] > 90.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_7_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_14"
-      elif (last_candle["RSI_3"] > 90.0) and (last_candle["RSI_14"] > 62.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["RSI_14"] > 62.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -37417,7 +37418,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_16"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -37425,14 +37426,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_17"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] > 70.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_7_18"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] > 68.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -37442,21 +37443,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_19"
       elif (
-        (last_candle["RSI_3"] > 46.0)
+        (last_rsi_3 > 46.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_20"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_21"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -37464,14 +37465,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_22"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] > 68.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -37479,7 +37480,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_24"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -37490,14 +37491,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_25"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -37505,14 +37506,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_27"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -37520,14 +37521,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_29"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_30"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -37535,14 +37536,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_31"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_32"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -37550,21 +37551,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_34"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_35"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -37572,7 +37573,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_36"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -37580,21 +37581,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_37"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_38"
       elif (
-        (last_candle["RSI_3"] > 93.0)
+        (last_rsi_3 > 93.0)
         and (last_candle["WILLR_14"] > -7.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_39"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -37605,7 +37606,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_40"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -37613,7 +37614,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_41"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -37624,7 +37625,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -37635,24 +37636,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_43"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
-      elif (last_candle["RSI_3"] > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_7_45"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_7_46"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -37660,7 +37661,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_47"
       elif (
-        (last_candle["RSI_3"] > 55.0)
+        (last_rsi_3 > 55.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -37668,7 +37669,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_48"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -37679,21 +37680,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_50"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -37701,7 +37702,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -37713,7 +37714,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_53"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -37721,7 +37722,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_54"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -37729,7 +37730,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_55"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -37738,14 +37739,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 40.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -37753,7 +37754,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -37761,7 +37762,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_59"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -37769,14 +37770,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_61"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -37785,42 +37786,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_62"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_64"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_65"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_67"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -37828,35 +37829,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_7_69"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_70"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_71"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_72"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -37864,7 +37865,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_73"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -37872,7 +37873,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -37882,21 +37883,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_75"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -37904,14 +37905,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_78"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -37919,7 +37920,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_80"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -37927,7 +37928,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_81"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -37935,7 +37936,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_82"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -37943,14 +37944,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_83"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_84"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -37958,7 +37959,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_85"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -37966,7 +37967,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_86"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -37974,7 +37975,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_87"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -24.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -37982,14 +37983,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_88"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -37998,7 +37999,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_90"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -38010,7 +38011,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_91"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -38019,7 +38020,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_92"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -38033,7 +38034,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_93"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -38045,7 +38046,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_94"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -38054,7 +38055,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -38062,7 +38063,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_96"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -38070,7 +38071,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_97"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_15m"] > 68.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -38079,7 +38080,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -38089,14 +38090,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_99"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14"] > 72.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_100"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -38104,7 +38105,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_101"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -38113,7 +38114,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_102"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 60.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -38121,7 +38122,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_103"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -38130,7 +38131,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_104"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -38138,7 +38139,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_105"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -38147,7 +38148,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_106"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -38155,14 +38156,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_107"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_108"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -38170,14 +38171,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_109"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
-        (last_candle["RSI_3"] > 46.0)
+        (last_rsi_3 > 46.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -38187,7 +38188,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_111"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -38197,7 +38198,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -38206,7 +38207,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_113"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -38214,7 +38215,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_114"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -38222,28 +38223,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_115"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_116"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_117"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_118"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -38251,35 +38252,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_119"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_120"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_7_121"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_122"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -38288,7 +38289,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_124"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -38297,29 +38298,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_126"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_127"
-      elif (last_candle["RSI_3"] > 90.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_129"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -38333,7 +38334,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_131"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -38341,7 +38342,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_132"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -38404,7 +38405,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -38429,7 +38430,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_8"
       elif (
         (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -38443,7 +38444,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_10"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -38451,26 +38452,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_11"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_8_12"
-      elif (last_candle["RSI_3"] > 95.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 95.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_8_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_14"
-      elif (last_candle["RSI_3"] > 92.0) and (last_candle["RSI_14"] > 64.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["RSI_14"] > 64.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -38478,7 +38479,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_16"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -38486,14 +38487,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_17"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] > 72.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_8_18"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] > 70.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -38503,21 +38504,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_19"
       elif (
-        (last_candle["RSI_3"] > 48.0)
+        (last_rsi_3 > 48.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_20"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_21"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -38525,14 +38526,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_22"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] > 70.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -38540,7 +38541,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_24"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -38551,14 +38552,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_25"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -38566,14 +38567,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_27"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -38581,14 +38582,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_29"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_30"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -38596,14 +38597,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_31"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_32"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -38611,21 +38612,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_34"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -7.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_35"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -38633,7 +38634,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_36"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -38641,21 +38642,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_37"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_38"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_39"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -38666,7 +38667,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_40"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -38674,7 +38675,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_41"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -38685,7 +38686,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -38696,24 +38697,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_43"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
-      elif (last_candle["RSI_3"] > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_8_45"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_8_46"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -38721,7 +38722,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_47"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -38729,7 +38730,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_48"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -38740,21 +38741,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_50"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -38762,7 +38763,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -38774,7 +38775,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_53"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -38782,7 +38783,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_54"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -38790,7 +38791,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_55"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -38799,14 +38800,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 38.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -38814,7 +38815,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -38822,7 +38823,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_59"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -38830,14 +38831,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_60"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_61"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -38846,42 +38847,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_62"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_64"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_65"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_67"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -38889,35 +38890,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_8_69"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_70"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_71"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_72"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -38925,7 +38926,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_73"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -38933,7 +38934,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -38943,21 +38944,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_75"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -38965,14 +38966,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_78"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -38980,7 +38981,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_80"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -38988,7 +38989,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_81"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -38996,7 +38997,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_82"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -39004,14 +39005,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_83"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_84"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -39019,7 +39020,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_85"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -39027,7 +39028,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_86"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -39035,7 +39036,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_87"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -39043,14 +39044,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_88"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -39059,7 +39060,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_90"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -39071,7 +39072,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_91"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -39080,7 +39081,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_92"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -39094,7 +39095,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_93"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -39106,7 +39107,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_94"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -39115,7 +39116,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_95"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -39123,7 +39124,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_96"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -39131,7 +39132,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_97"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -39140,7 +39141,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -39150,14 +39151,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_99"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14"] > 74.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_100"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -39165,7 +39166,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_101"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -39174,7 +39175,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_102"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 58.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -39182,7 +39183,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_103"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -39191,7 +39192,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -39199,7 +39200,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -39208,7 +39209,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -39216,14 +39217,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_107"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -39231,14 +39232,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_109"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
-        (last_candle["RSI_3"] > 48.0)
+        (last_rsi_3 > 48.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -39248,7 +39249,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_111"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -39258,7 +39259,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -39267,7 +39268,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_113"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -39275,7 +39276,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -39283,28 +39284,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_115"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_116"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_117"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_118"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -39312,35 +39313,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_119"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_120"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_8_121"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_122"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -39349,7 +39350,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_124"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -39358,29 +39359,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_126"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_127"
-      elif (last_candle["RSI_3"] > 92.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_129"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -39394,7 +39395,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_131"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -39402,7 +39403,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_132"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -39465,7 +39466,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -39490,7 +39491,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_8"
       elif (
         (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -39504,7 +39505,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_10"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -39512,26 +39513,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_11"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_9_12"
-      elif (last_candle["RSI_3"] > 96.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_9_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_14"
-      elif (last_candle["RSI_3"] > 94.0) and (last_candle["RSI_14"] > 66.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 94.0) and (last_candle["RSI_14"] > 66.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -39539,7 +39540,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_16"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -39547,14 +39548,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_17"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14"] > 74.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_9_18"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14"] > 72.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -39564,21 +39565,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_19"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_20"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_21"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -39586,14 +39587,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_22"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_14"] > 72.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -39601,7 +39602,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_24"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -39612,14 +39613,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_25"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -39627,14 +39628,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_27"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -39642,14 +39643,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_29"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_30"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -39657,14 +39658,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_31"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_32"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -39672,21 +39673,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_34"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_35"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -39694,7 +39695,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_36"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -39702,21 +39703,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_37"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_38"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_39"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -39727,7 +39728,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_40"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -39735,7 +39736,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_41"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -39746,7 +39747,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_42"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -39757,24 +39758,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_43"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
-      elif (last_candle["RSI_3"] > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_9_45"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_9_46"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -39782,7 +39783,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_47"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -39790,7 +39791,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_48"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -39801,21 +39802,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_50"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -39823,7 +39824,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -39835,7 +39836,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_53"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -39843,7 +39844,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_54"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -39851,7 +39852,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_55"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -39860,14 +39861,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 36.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -39875,7 +39876,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -39883,7 +39884,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_59"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -39891,14 +39892,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_60"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_61"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -39907,42 +39908,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_62"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_64"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_65"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_67"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -39950,35 +39951,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_9_69"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_70"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_71"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_72"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -39986,7 +39987,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_73"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -39994,7 +39995,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -40004,21 +40005,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_75"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -40026,14 +40027,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_78"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -40041,7 +40042,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_80"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -40049,7 +40050,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_81"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -40057,7 +40058,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_82"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -40065,14 +40066,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_83"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_84"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -40080,7 +40081,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_85"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -40088,7 +40089,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_86"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -40096,7 +40097,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_87"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -40104,14 +40105,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_88"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -40120,7 +40121,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_90"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -40132,7 +40133,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_91"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -40141,7 +40142,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_92"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -40155,7 +40156,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_93"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -40167,7 +40168,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_94"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -40176,7 +40177,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_95"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -40184,7 +40185,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_96"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -40192,7 +40193,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_97"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_15m"] > 72.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -40201,7 +40202,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_98"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -40211,14 +40212,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_99"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_14"] > 76.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_100"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -40226,7 +40227,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_101"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -40235,7 +40236,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_102"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 56.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -40243,7 +40244,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_103"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -40252,7 +40253,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_104"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -40260,7 +40261,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_105"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -40269,7 +40270,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_106"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -40277,14 +40278,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_107"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_108"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -40292,14 +40293,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_109"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -40309,7 +40310,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_111"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -40319,7 +40320,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -40328,7 +40329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_113"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -40336,7 +40337,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_114"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -40344,28 +40345,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_115"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_116"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_117"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_118"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -40373,35 +40374,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_119"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_120"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_9_121"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_122"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -40410,7 +40411,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_124"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -40419,29 +40420,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_126"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_127"
-      elif (last_candle["RSI_3"] > 94.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 94.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_129"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -40455,7 +40456,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_131"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -40463,7 +40464,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_132"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -40526,7 +40527,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -40551,7 +40552,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_8"
       elif (
         (last_candle["WILLR_14"] > -3.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -40565,7 +40566,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_10"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -40573,26 +40574,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_11"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_10_12"
-      elif (last_candle["RSI_3"] > 96.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_10_13"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_14"
-      elif (last_candle["RSI_3"] > 96.0) and (last_candle["RSI_14"] > 68.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["RSI_14"] > 68.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -40600,7 +40601,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_16"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -40608,14 +40609,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_17"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14"] > 76.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_10_18"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14"] > 74.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -40625,21 +40626,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_19"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_20"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_21"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -40647,14 +40648,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_22"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_14"] > 74.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -40662,7 +40663,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_24"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -40673,14 +40674,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_25"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -40688,14 +40689,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_27"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -40703,14 +40704,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_29"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_30"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -40718,14 +40719,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_31"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_32"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -40733,21 +40734,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_34"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_35"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -40755,7 +40756,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_36"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -40763,21 +40764,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_37"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_38"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_39"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -40788,7 +40789,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_40"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -40796,7 +40797,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_41"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -40807,7 +40808,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_42"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -40818,24 +40819,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_43"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
-      elif (last_candle["RSI_3"] > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_10_45"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_10_46"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -40843,7 +40844,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_47"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -40851,7 +40852,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_48"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -40862,21 +40863,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_49"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_50"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -40884,7 +40885,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -40896,7 +40897,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_53"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -40904,7 +40905,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_54"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -40912,7 +40913,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_55"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -40921,14 +40922,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 34.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -40936,7 +40937,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_58"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -40944,7 +40945,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_59"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -40952,14 +40953,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_60"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_61"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -40968,42 +40969,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_62"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_64"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_65"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_67"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -41011,35 +41012,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_10_69"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_70"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_71"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_72"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -41047,7 +41048,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_73"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -41055,7 +41056,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -41065,21 +41066,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_75"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -41087,14 +41088,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_78"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -41102,7 +41103,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_80"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -41110,7 +41111,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_81"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -41118,7 +41119,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_82"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -41126,14 +41127,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_83"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_84"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -41141,7 +41142,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_85"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -41149,7 +41150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_86"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -41157,7 +41158,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_87"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -41165,14 +41166,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_88"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -41181,7 +41182,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_90"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -41193,7 +41194,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_91"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -41202,7 +41203,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_92"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -41216,7 +41217,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_93"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -41228,7 +41229,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_94"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -41237,7 +41238,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_95"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -41245,7 +41246,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_96"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -41253,7 +41254,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_97"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_15m"] > 74.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -41262,7 +41263,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_98"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -41272,14 +41273,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_99"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 78.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_100"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -41287,7 +41288,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_101"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -41296,7 +41297,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_102"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 54.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -41304,7 +41305,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_103"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -41313,7 +41314,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_104"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -41321,7 +41322,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_105"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -41330,7 +41331,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_106"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -41338,14 +41339,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_107"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_108"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -41353,14 +41354,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_109"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
-        (last_candle["RSI_3"] > 52.0)
+        (last_rsi_3 > 52.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -41370,7 +41371,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_111"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -41380,7 +41381,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -41389,7 +41390,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_113"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -41397,7 +41398,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_114"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -41405,28 +41406,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_115"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_116"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_117"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_118"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -41434,35 +41435,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_119"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_120"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_10_121"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_122"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -41471,7 +41472,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_124"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -41480,29 +41481,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_126"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_127"
-      elif (last_candle["RSI_3"] > 96.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_129"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -41516,7 +41517,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_131"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -41524,7 +41525,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_132"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -41587,7 +41588,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -41612,7 +41613,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_8"
       elif (
         (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3"] > 95.0)
+        and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -41626,7 +41627,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_10"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -41634,26 +41635,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_11"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_11_12"
-      elif (last_candle["RSI_3"] > 98.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 98.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_11_13"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_14"
-      elif (last_candle["RSI_3"] > 98.0) and (last_candle["RSI_14"] > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 98.0) and (last_candle["RSI_14"] > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -41661,7 +41662,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_16"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -41669,14 +41670,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_17"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14"] > 78.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_11_18"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14"] > 76.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -41686,21 +41687,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_19"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_20"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_21"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -41708,14 +41709,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_22"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_14"] > 76.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -41723,7 +41724,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_24"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -41734,14 +41735,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_25"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -41749,14 +41750,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_27"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -41764,14 +41765,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_29"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_30"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -41779,14 +41780,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_31"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_32"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -41794,21 +41795,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_34"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_35"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -41816,7 +41817,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_36"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -41824,21 +41825,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_37"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_38"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -3.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_39"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -41849,7 +41850,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_40"
       elif (
-        (last_candle["RSI_3"] > 97.0)
+        (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -41857,7 +41858,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_41"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -41868,7 +41869,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_42"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -41879,24 +41880,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_43"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
-      elif (last_candle["RSI_3"] > 98.0) and (last_candle["WILLR_14"] > -2.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 98.0) and (last_candle["WILLR_14"] > -2.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_11_45"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_11_46"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -41904,7 +41905,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_47"
       elif (
-        (last_candle["RSI_3"] > 75.0)
+        (last_rsi_3 > 75.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -41912,7 +41913,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_48"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -41923,21 +41924,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_49"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_50"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -41945,7 +41946,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -41957,7 +41958,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_53"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -41965,7 +41966,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_54"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -41973,7 +41974,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_55"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -41982,14 +41983,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 32.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -41997,7 +41998,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_58"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -42005,7 +42006,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_59"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -42013,14 +42014,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_60"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_61"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -42029,42 +42030,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_62"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_64"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_65"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_67"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -42072,35 +42073,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_11_69"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_70"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_71"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_72"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -42108,7 +42109,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_73"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -42116,7 +42117,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -42126,21 +42127,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_75"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -42148,14 +42149,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_78"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -42163,7 +42164,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_80"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -42171,7 +42172,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_81"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -42179,7 +42180,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_82"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -42187,14 +42188,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_83"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_84"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -42202,7 +42203,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_85"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -42210,7 +42211,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_86"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -42218,7 +42219,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_87"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -42226,14 +42227,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_88"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -42242,7 +42243,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_90"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -42254,7 +42255,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_91"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -42263,7 +42264,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_92"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -42277,7 +42278,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_93"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -42289,7 +42290,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_94"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -42298,7 +42299,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_95"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -42306,7 +42307,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_96"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -42314,7 +42315,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_97"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_15m"] > 76.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -42323,7 +42324,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_98"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -42333,14 +42334,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_99"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 80.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_100"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -42348,7 +42349,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_101"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -42357,7 +42358,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_102"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 52.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -42365,7 +42366,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_103"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -42374,7 +42375,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_104"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -42382,7 +42383,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_105"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -42391,7 +42392,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_106"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -42399,14 +42400,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_107"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_108"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -42414,14 +42415,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_109"
       elif (
-        (last_candle["RSI_3"] > 76.0)
+        (last_rsi_3 > 76.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
-        (last_candle["RSI_3"] > 54.0)
+        (last_rsi_3 > 54.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -42431,7 +42432,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_111"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -42441,7 +42442,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -42450,7 +42451,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_113"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -42458,7 +42459,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_114"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -42466,28 +42467,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_115"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_116"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_117"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_118"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -42495,35 +42496,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_119"
       elif (
-        (last_candle["RSI_3"] > 58.0)
+        (last_rsi_3 > 58.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_120"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_11_121"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_122"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -42532,7 +42533,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_124"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -42541,29 +42542,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_126"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_127"
-      elif (last_candle["RSI_3"] > 98.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 98.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_129"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -42577,7 +42578,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_131"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -42585,7 +42586,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_132"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
@@ -42648,7 +42649,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_5"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -42673,7 +42674,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_8"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3"] > 99.0)
+        and (last_rsi_3 > 99.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
@@ -42687,7 +42688,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_10"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
@@ -42695,26 +42696,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_11"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_12_12"
-      elif (last_candle["RSI_3"] > 99.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
+      elif (last_rsi_3 > 99.0) and (last_candle["RSI_3_4h"] < 5.0) and (last_candle["ROC_9_4h"] < -25.0):
         return True, f"exit_{mode_name}_d_12_13"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 5.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_14"
-      elif (last_candle["RSI_3"] > 99.0) and (last_candle["RSI_14"] > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 99.0) and (last_candle["RSI_14"] > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
@@ -42722,7 +42723,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_16"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -42730,14 +42731,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_17"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 80.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_12_18"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 78.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
@@ -42747,21 +42748,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_19"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_20"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_21"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -42769,14 +42770,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_22"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_14"] > 78.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -42784,7 +42785,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_24"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -15.0)
@@ -42795,14 +42796,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_25"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -42810,14 +42811,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_27"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -42825,14 +42826,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_29"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_30"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
@@ -42840,14 +42841,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_31"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_32"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
         and (last_candle["ROC_9_1h"] > 30.0)
@@ -42855,21 +42856,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_33"
       elif (
-        (last_candle["RSI_3"] > 65.0)
+        (last_rsi_3 > 65.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
         and (last_candle["ROC_9_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_34"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_35"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["ROC_9_4h"] < -25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -42877,7 +42878,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_36"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -42885,21 +42886,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_37"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_38"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_39"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
@@ -42910,7 +42911,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_40"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
@@ -42918,7 +42919,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_41"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
@@ -42929,7 +42930,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_42"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -42940,24 +42941,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_43"
       elif (
-        (last_candle["RSI_3"] > 85.0)
+        (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
-      elif (last_candle["RSI_3"] > 99.0) and (last_candle["WILLR_14"] > -1.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 99.0) and (last_candle["WILLR_14"] > -1.0) and (last_candle["RSI_3_1h"] < 10.0):
         return True, f"exit_{mode_name}_d_12_45"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
         return True, f"exit_{mode_name}_d_12_46"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -42965,7 +42966,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_47"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -42973,7 +42974,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_48"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["change_pct_1d"] < -5.0)
@@ -42984,21 +42985,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_49"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1d"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_50"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -43006,7 +43007,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_52"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 20.0)
@@ -43018,7 +43019,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_53"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
@@ -43026,7 +43027,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_54"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["ROC_9_4h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
@@ -43034,7 +43035,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_55"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -43043,14 +43044,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_56"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -43058,7 +43059,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_58"
       elif (
-        (last_candle["RSI_3"] > 95.0)
+        (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
@@ -43066,7 +43067,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_59"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -43074,14 +43075,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_60"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_61"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -43090,42 +43091,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_62"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_64"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_65"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_66"
       elif (
-        (last_candle["RSI_3"] > 50.0)
+        (last_rsi_3 > 50.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_67"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
@@ -43133,35 +43134,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["ROC_9_4h"] > 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["change_pct_4h"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_12_69"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_70"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_71"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_72"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -43169,7 +43170,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_73"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["RSI_3_1d"] < 25.0)
@@ -43177,7 +43178,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
@@ -43187,21 +43188,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_75"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -43209,14 +43210,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_78"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
@@ -43224,7 +43225,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_80"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -43232,7 +43233,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_81"
       elif (
-        (last_candle["RSI_3"] > 88.0)
+        (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 15.0)
@@ -43240,7 +43241,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_82"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -43248,14 +43249,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_83"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_84"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -43263,7 +43264,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_85"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14_4h"] > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
         and (last_candle["ROC_9_1h"] > 5.0)
@@ -43271,7 +43272,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_86"
       elif (
-        (last_candle["RSI_3"] > 72.0)
+        (last_rsi_3 > 72.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
@@ -43279,7 +43280,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_87"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -43287,14 +43288,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_88"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
       elif (
-        (last_candle["RSI_3"] > 98.0)
+        (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -43303,7 +43304,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_90"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
@@ -43315,7 +43316,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_91"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
@@ -43324,7 +43325,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_92"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
@@ -43338,7 +43339,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_93"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
@@ -43350,7 +43351,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_94"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -43359,7 +43360,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_95"
       elif (
-        (last_candle["RSI_3"] > 68.0)
+        (last_rsi_3 > 68.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
@@ -43367,7 +43368,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_96"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
@@ -43375,7 +43376,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_97"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_15m"] > 78.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -43384,7 +43385,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_98"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -43394,14 +43395,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_99"
       elif (
-        (last_candle["RSI_3"] > 99.0)
+        (last_rsi_3 > 99.0)
         and (last_candle["RSI_14"] > 82.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_100"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
@@ -43409,7 +43410,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_101"
       elif (
-        (last_candle["RSI_3"] > 74.0)
+        (last_rsi_3 > 74.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -43418,7 +43419,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_102"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 50.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -43426,7 +43427,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_103"
       elif (
-        (last_candle["RSI_3"] > 70.0)
+        (last_rsi_3 > 70.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -43435,7 +43436,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_104"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
@@ -43443,7 +43444,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_105"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -43452,7 +43453,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_106"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -43460,14 +43461,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_107"
       elif (
-        (last_candle["RSI_3"] > 62.0)
+        (last_rsi_3 > 62.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_108"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
@@ -43475,14 +43476,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_109"
       elif (
-        (last_candle["RSI_3"] > 78.0)
+        (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_4h"] < 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["ROC_9_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
-        (last_candle["RSI_3"] > 56.0)
+        (last_rsi_3 > 56.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
@@ -43492,7 +43493,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_111"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["RSI_3_1h"] < 35.0)
@@ -43502,7 +43503,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -43511,7 +43512,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_113"
       elif (
-        (last_candle["RSI_3"] > 90.0)
+        (last_rsi_3 > 90.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
@@ -43519,7 +43520,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_114"
       elif (
-        (last_candle["RSI_3"] > 84.0)
+        (last_rsi_3 > 84.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
@@ -43527,28 +43528,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_115"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_116"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_117"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_1h"] < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_118"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_1h"] < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
@@ -43556,35 +43557,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_119"
       elif (
-        (last_candle["RSI_3"] > 60.0)
+        (last_rsi_3 > 60.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["RSI_3_1h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_120"
       elif (
-        (last_candle["RSI_3"] > 66.0)
+        (last_rsi_3 > 66.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_12_121"
       elif (
-        (last_candle["RSI_3"] > 64.0)
+        (last_rsi_3 > 64.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_122"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
-        (last_candle["RSI_3"] > 94.0)
+        (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -43593,7 +43594,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_124"
       elif (
-        (last_candle["RSI_3"] > 82.0)
+        (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
@@ -43602,29 +43603,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_1h"] < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_126"
       elif (
-        (last_candle["RSI_3"] > 96.0)
+        (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_1h"] < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_127"
-      elif (last_candle["RSI_3"] > 99.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 99.0) and (last_candle["RSI_3_4h"] < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
       elif (
-        (last_candle["RSI_3"] > 92.0)
+        (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_129"
       elif (
-        (last_candle["RSI_3"] > 80.0)
+        (last_rsi_3 > 80.0)
         and (last_candle["RSI_14_1h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["CCI_20_change_pct_1h"] < -0.0)
@@ -43638,7 +43639,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_131"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_1h"] < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
@@ -43646,7 +43647,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_132"
       elif (
-        (last_candle["RSI_3"] > 86.0)
+        (last_rsi_3 > 86.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))


### PR DESCRIPTION
## Summary
- Reuses one `last_rsi_3` value in `long_exit_dec()` instead of reading `last_candle["RSI_3"]` throughout the dense long-exit decision ladder.
- Replaces 1,612 repeated direct candle-field reads with the local value.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same long-exit formulas, thresholds, condition order, candle selection, output signal names, and return behavior.
- The patch only reuses the same `last_candle["RSI_3"]` value already read from the same candle row inside the same `long_exit_dec()` call.
- A normalized AST check was used for the large diff: after removing the new local and replacing `last_rsi_3` back to `last_candle["RSI_3"]`, `long_exit_dec()` matches the base version.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact same-call candle-field reuse: the same row value is read once and reused by existing comparisons without changing thresholds, formulas, condition order, candle selection, or signal names.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- normalized AST equivalence check for `long_exit_dec()` after inverting the local-field substitution
