### PR TITLE
Reuse X7 short-exit RSI-3 field

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -56051,6 +56051,7 @@ class NostalgiaForInfinityX7(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
+    last_rsi_3 = last_candle["RSI_3"]
     if 0.01 > current_profit >= 0.001:
       if (
         (last_candle["WILLR_14"] < -99.0)
@@ -56108,7 +56109,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -56133,7 +56134,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3"] < 1.0)
+        and (last_rsi_3 < 1.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -56147,7 +56148,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_10"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -56155,26 +56156,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_12"
-      elif (last_candle["RSI_3"] < 1.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 1.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_0_13"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_14"
-      elif (last_candle["RSI_3"] < 1.0) and (last_candle["RSI_14"] < 22.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 1.0) and (last_candle["RSI_14"] < 22.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -56182,7 +56183,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -56190,14 +56191,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_17"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] < 25.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 22.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -56207,21 +56208,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_19"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_20"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_21"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -56229,14 +56230,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_22"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 22.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -56244,7 +56245,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -56255,14 +56256,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_25"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -56270,14 +56271,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_27"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -56285,14 +56286,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_29"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -56300,14 +56301,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_31"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -56315,21 +56316,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_0_34"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -56337,7 +56338,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -56345,21 +56346,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_37"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_38"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -56370,7 +56371,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_40"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -56378,7 +56379,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -56389,7 +56390,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -56400,24 +56401,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_43"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_candle["RSI_3"] < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_0_45"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_46"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -56425,7 +56426,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_47"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -56433,7 +56434,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -56444,21 +56445,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_50"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -56466,7 +56467,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -56478,7 +56479,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -56486,7 +56487,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -56494,7 +56495,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -56503,14 +56504,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 66.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -56518,7 +56519,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -56526,7 +56527,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_59"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -56534,14 +56535,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_60"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_61"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -56550,42 +56551,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_62"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_0_65"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -56593,35 +56594,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_70"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_71"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -56629,7 +56630,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -56637,7 +56638,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -56647,21 +56648,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_75"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -56669,14 +56670,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_78"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -56684,7 +56685,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -56692,7 +56693,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -56700,7 +56701,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_82"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -56708,14 +56709,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_83"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -56723,7 +56724,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -56731,7 +56732,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -56739,7 +56740,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -56747,14 +56748,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -56763,7 +56764,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_90"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -56775,7 +56776,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_91"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -56784,7 +56785,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_92"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -56798,7 +56799,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_93"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -56810,7 +56811,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_94"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -56819,7 +56820,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -56827,7 +56828,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -56835,7 +56836,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_97"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_15m"] < 26.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -56844,7 +56845,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -56854,14 +56855,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_99"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 22.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -56869,7 +56870,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_101"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -56878,7 +56879,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_102"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -56886,7 +56887,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_103"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -56895,7 +56896,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -56903,7 +56904,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -56912,7 +56913,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -56920,14 +56921,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_107"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -56935,14 +56936,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_109"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -56952,7 +56953,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -56962,7 +56963,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -56971,7 +56972,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_113"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -56979,7 +56980,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -56987,28 +56988,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_115"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_116"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_117"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -57016,35 +57017,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_119"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_120"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_121"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_122"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -57053,7 +57054,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_124"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -57062,29 +57063,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_126"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_candle["RSI_3"] < 4.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -57098,7 +57099,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -57106,7 +57107,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -57169,7 +57170,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -57194,7 +57195,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_8"
       elif (
         (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -57208,7 +57209,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_10"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -57216,26 +57217,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_11"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_12"
-      elif (last_candle["RSI_3"] < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_1_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_14"
-      elif (last_candle["RSI_3"] < 5.0) and (last_candle["RSI_14"] < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 5.0) and (last_candle["RSI_14"] < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -57243,7 +57244,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_16"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -57251,14 +57252,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_17"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_18"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] < 28.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -57268,21 +57269,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_19"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_20"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_21"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -57290,14 +57291,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_22"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] < 25.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -57305,7 +57306,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_24"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -57316,14 +57317,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_25"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -57331,14 +57332,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_27"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -57346,14 +57347,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_29"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_30"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -57361,14 +57362,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_31"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_32"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -57376,21 +57377,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_1_34"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_35"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -57398,7 +57399,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_36"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -57406,21 +57407,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_37"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_38"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_39"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -57431,7 +57432,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_40"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -57439,7 +57440,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_41"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -57450,7 +57451,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -57461,24 +57462,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_43"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
-      elif (last_candle["RSI_3"] < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_1_45"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_46"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -57486,7 +57487,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_47"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -57494,7 +57495,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_48"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -57505,21 +57506,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_50"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -57527,7 +57528,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -57539,7 +57540,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_53"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -57547,7 +57548,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_54"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -57555,7 +57556,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_55"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -57564,14 +57565,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 64.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -57579,7 +57580,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -57587,7 +57588,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_59"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -57595,14 +57596,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_61"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -57611,42 +57612,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_62"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_64"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_1_65"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_67"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -57654,35 +57655,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_69"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_70"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_71"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_72"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -57690,7 +57691,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_73"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -57698,7 +57699,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -57708,21 +57709,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_75"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -57730,14 +57731,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_78"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -57745,7 +57746,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_80"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -57753,7 +57754,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_81"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -57761,7 +57762,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_82"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -57769,14 +57770,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_83"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_84"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -57784,7 +57785,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_85"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -57792,7 +57793,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_86"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -57800,7 +57801,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_87"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -57808,14 +57809,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_88"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -57824,7 +57825,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_90"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -57836,7 +57837,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_91"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -57845,7 +57846,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_92"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -57859,7 +57860,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_93"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -57871,7 +57872,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_94"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -57880,7 +57881,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_95"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -57888,7 +57889,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_96"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -57896,7 +57897,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_97"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_15m"] < 28.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -57905,7 +57906,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_98"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -57915,14 +57916,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_99"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_14"] < 24.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_100"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -57930,7 +57931,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_101"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -57939,7 +57940,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_102"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -57947,7 +57948,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_103"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -57956,7 +57957,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_104"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -57964,7 +57965,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_105"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -57973,7 +57974,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_106"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -57981,14 +57982,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_107"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_108"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -57996,14 +57997,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_109"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -58013,7 +58014,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_111"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -58023,7 +58024,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -58032,7 +58033,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_113"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -58040,7 +58041,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_114"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -58048,28 +58049,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_115"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_116"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_117"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_118"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -58077,35 +58078,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_119"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_120"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_121"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_122"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -58114,7 +58115,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_124"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -58123,29 +58124,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_126"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_127"
-      elif (last_candle["RSI_3"] < 6.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_129"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -58159,7 +58160,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_131"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -58167,7 +58168,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_132"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -58230,7 +58231,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -58255,7 +58256,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_8"
       elif (
         (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -58269,7 +58270,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_10"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -58277,26 +58278,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_11"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_12"
-      elif (last_candle["RSI_3"] < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_2_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_14"
-      elif (last_candle["RSI_3"] < 8.0) and (last_candle["RSI_14"] < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["RSI_14"] < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -58304,7 +58305,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_16"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -58312,14 +58313,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_17"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_18"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] < 30.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -58329,21 +58330,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_19"
       elif (
-        (last_candle["RSI_3"] < 52.0)
+        (last_rsi_3 < 52.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_20"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_21"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -58351,14 +58352,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_22"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] < 30.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -58366,7 +58367,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_24"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -58377,14 +58378,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_25"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -58392,14 +58393,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_27"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -58407,14 +58408,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_29"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_30"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -58422,14 +58423,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_31"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_32"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -58437,21 +58438,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_2_34"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -93.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_35"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -58459,7 +58460,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_36"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -58467,21 +58468,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_37"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_38"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_39"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -58492,7 +58493,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_40"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -58500,7 +58501,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_41"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -58511,7 +58512,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -58522,24 +58523,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_43"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
-      elif (last_candle["RSI_3"] < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_2_45"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_46"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -58547,7 +58548,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_47"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -58555,7 +58556,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_48"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -58566,21 +58567,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_50"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -58588,7 +58589,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -58600,7 +58601,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_53"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -58608,7 +58609,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_54"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -58616,7 +58617,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_55"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -58625,14 +58626,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 62.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -58640,7 +58641,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -58648,7 +58649,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_59"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -58656,14 +58657,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_61"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -58672,42 +58673,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_62"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_64"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_2_65"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_67"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -58715,35 +58716,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_69"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_70"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_71"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_72"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -58751,7 +58752,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_73"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -58759,7 +58760,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -58769,21 +58770,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_75"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -58791,14 +58792,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_78"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -58806,7 +58807,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_80"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -58814,7 +58815,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_81"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -58822,7 +58823,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_82"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -58830,14 +58831,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_83"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_84"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -58845,7 +58846,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_85"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -58853,7 +58854,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_86"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -58861,7 +58862,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_87"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -58869,14 +58870,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_88"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -58885,7 +58886,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_90"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -58897,7 +58898,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_91"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -58906,7 +58907,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_92"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -58920,7 +58921,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_93"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -58932,7 +58933,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_94"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -58941,7 +58942,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_95"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -58949,7 +58950,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_96"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -58957,7 +58958,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_97"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -58966,7 +58967,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -58976,14 +58977,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_99"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14"] < 26.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_100"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -58991,7 +58992,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_101"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -59000,7 +59001,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_102"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -59008,7 +59009,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_103"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -59017,7 +59018,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -59025,7 +59026,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -59034,7 +59035,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -59042,14 +59043,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_107"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -59057,14 +59058,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_109"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
-        (last_candle["RSI_3"] < 52.0)
+        (last_rsi_3 < 52.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -59074,7 +59075,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_111"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -59084,7 +59085,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -59093,7 +59094,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_113"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -59101,7 +59102,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -59109,28 +59110,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_115"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_116"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_117"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_118"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -59138,35 +59139,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_119"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_120"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_121"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_122"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -59175,7 +59176,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_124"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -59184,29 +59185,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_126"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_127"
-      elif (last_candle["RSI_3"] < 8.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_129"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -59220,7 +59221,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_131"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -59228,7 +59229,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_132"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -59291,7 +59292,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -59316,7 +59317,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
         (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -59330,7 +59331,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_10"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -59338,26 +59339,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_11"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_12"
-      elif (last_candle["RSI_3"] < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_3_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_14"
-      elif (last_candle["RSI_3"] < 10.0) and (last_candle["RSI_14"] < 35.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["RSI_14"] < 35.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -59365,7 +59366,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -59373,14 +59374,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_17"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] < 32.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -59390,21 +59391,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_19"
       elif (
-        (last_candle["RSI_3"] < 54.0)
+        (last_rsi_3 < 54.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_20"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -59412,14 +59413,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_22"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] < 32.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -59427,7 +59428,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -59438,14 +59439,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_25"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -59453,14 +59454,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_27"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -59468,14 +59469,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_29"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -59483,14 +59484,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_31"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -59498,21 +59499,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_3_34"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -59520,7 +59521,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -59528,21 +59529,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_37"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_38"
       elif (
-        (last_candle["RSI_3"] < 7.0)
+        (last_rsi_3 < 7.0)
         and (last_candle["WILLR_14"] < -93.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -59553,7 +59554,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_40"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -59561,7 +59562,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_41"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -59572,7 +59573,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -59583,24 +59584,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_43"
       elif (
-        (last_candle["RSI_3"] < 45.0)
+        (last_rsi_3 < 45.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_candle["RSI_3"] < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_3_45"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_46"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -59608,7 +59609,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_47"
       elif (
-        (last_candle["RSI_3"] < 45.0)
+        (last_rsi_3 < 45.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -59616,7 +59617,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -59627,21 +59628,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_50"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -59649,7 +59650,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -59661,7 +59662,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -59669,7 +59670,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -59677,7 +59678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -59686,14 +59687,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 60.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -59701,7 +59702,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -59709,7 +59710,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_59"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -59717,14 +59718,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_61"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -59733,42 +59734,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_62"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_3_65"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -59776,35 +59777,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_69"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_70"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_71"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_72"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -59812,7 +59813,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_73"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -59820,7 +59821,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -59830,21 +59831,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_75"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -59852,14 +59853,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_78"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -59867,7 +59868,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -59875,7 +59876,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -59883,7 +59884,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -59891,14 +59892,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_83"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -59906,7 +59907,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -59914,7 +59915,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -59922,7 +59923,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_87"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -76.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -59930,14 +59931,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_88"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -59946,7 +59947,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_90"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -59958,7 +59959,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_91"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -59967,7 +59968,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_92"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -59981,7 +59982,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_93"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -59993,7 +59994,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_94"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -60002,7 +60003,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -60010,7 +60011,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -60018,7 +60019,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_97"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_15m"] < 32.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -60027,7 +60028,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -60037,14 +60038,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_99"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14"] < 28.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -60052,7 +60053,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_101"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -60061,7 +60062,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_102"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 40.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -60069,7 +60070,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_103"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -60078,7 +60079,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -60086,7 +60087,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -60095,7 +60096,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -60103,14 +60104,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_107"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -60118,14 +60119,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_109"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
-        (last_candle["RSI_3"] < 54.0)
+        (last_rsi_3 < 54.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -60135,7 +60136,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_111"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -60145,7 +60146,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -60154,7 +60155,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_113"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -60162,7 +60163,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_114"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -60170,28 +60171,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_115"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_116"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_117"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -60199,35 +60200,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_119"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_120"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_121"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_122"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -60236,7 +60237,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_124"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -60245,29 +60246,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_126"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_candle["RSI_3"] < 10.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -60281,7 +60282,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -60289,7 +60290,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -60352,7 +60353,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -60377,7 +60378,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_8"
       elif (
         (last_candle["WILLR_14"] < -93.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -60391,7 +60392,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_10"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -60399,26 +60400,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_11"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_12"
-      elif (last_candle["RSI_3"] < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_4_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_14"
-      elif (last_candle["RSI_3"] < 12.0) and (last_candle["RSI_14"] < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["RSI_14"] < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -60426,7 +60427,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_16"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -60434,14 +60435,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_17"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_18"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -60451,21 +60452,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_19"
       elif (
-        (last_candle["RSI_3"] < 56.0)
+        (last_rsi_3 < 56.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_20"
       elif (
-        (last_candle["RSI_3"] < 45.0)
+        (last_rsi_3 < 45.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_21"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -60473,14 +60474,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_22"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -60488,7 +60489,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_24"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -60499,14 +60500,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_25"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -60514,14 +60515,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_27"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -60529,14 +60530,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_29"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_30"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -60544,14 +60545,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_31"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_32"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -60559,21 +60560,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_4_34"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -91.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_35"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -60581,7 +60582,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_36"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -60589,21 +60590,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_37"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_38"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_39"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -60614,7 +60615,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_40"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -60622,7 +60623,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_41"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -60633,7 +60634,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -60644,24 +60645,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_43"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
-      elif (last_candle["RSI_3"] < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_4_45"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_46"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -60669,7 +60670,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_47"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -60677,7 +60678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_48"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -60688,21 +60689,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_50"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -60710,7 +60711,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -60722,7 +60723,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_53"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -60730,7 +60731,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_54"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -60738,7 +60739,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_55"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -60747,14 +60748,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 58.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -60762,7 +60763,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -60770,7 +60771,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_59"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -60778,14 +60779,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_61"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -60794,42 +60795,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_62"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_64"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_4_65"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_67"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -60837,35 +60838,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
-        (last_candle["RSI_3"] < 7.0)
+        (last_rsi_3 < 7.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_69"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_70"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_71"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_72"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -60873,7 +60874,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_73"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -60881,7 +60882,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -60891,21 +60892,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_75"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_77"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -60913,14 +60914,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_78"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -60928,7 +60929,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_80"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -60936,7 +60937,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_81"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -60944,7 +60945,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_82"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -60952,14 +60953,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_83"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_84"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -60967,7 +60968,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_85"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -60975,7 +60976,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_86"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -60983,7 +60984,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_87"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -74.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -60991,14 +60992,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_88"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -61007,7 +61008,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_90"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -61019,7 +61020,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_91"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -61028,7 +61029,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_92"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -61042,7 +61043,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_93"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -61054,7 +61055,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_94"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -61063,7 +61064,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -61071,7 +61072,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_96"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -61079,7 +61080,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_97"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_15m"] < 34.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -61088,7 +61089,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_98"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -61098,14 +61099,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_99"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14"] < 30.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_100"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -61113,7 +61114,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_101"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -61122,7 +61123,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_102"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 38.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -61130,7 +61131,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_103"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -61139,7 +61140,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_104"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -61147,7 +61148,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_105"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -61156,7 +61157,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_106"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -61164,14 +61165,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_107"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_108"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -61179,14 +61180,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_109"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
-        (last_candle["RSI_3"] < 56.0)
+        (last_rsi_3 < 56.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -61196,7 +61197,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_111"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -60.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -61206,7 +61207,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -61215,7 +61216,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_113"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -61223,7 +61224,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_114"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -61231,28 +61232,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_115"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_116"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_117"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_118"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -61260,35 +61261,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_119"
       elif (
-        (last_candle["RSI_3"] < 52.0)
+        (last_rsi_3 < 52.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_120"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_121"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_122"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -61297,7 +61298,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_124"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -61306,29 +61307,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_126"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_127"
-      elif (last_candle["RSI_3"] < 12.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_129"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -61342,7 +61343,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_131"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -61350,7 +61351,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_132"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -61413,7 +61414,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -61438,7 +61439,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_8"
       elif (
         (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -61452,7 +61453,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_10"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -61460,26 +61461,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_11"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_12"
-      elif (last_candle["RSI_3"] < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_5_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_14"
-      elif (last_candle["RSI_3"] < 14.0) and (last_candle["RSI_14"] > 58.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 14.0) and (last_candle["RSI_14"] > 58.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -61487,7 +61488,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_16"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -61495,14 +61496,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_17"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -61512,21 +61513,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_19"
       elif (
-        (last_candle["RSI_3"] < 58.0)
+        (last_rsi_3 < 58.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_20"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -61534,14 +61535,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_22"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -61549,7 +61550,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -61560,14 +61561,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_25"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -61575,14 +61576,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_27"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -61590,14 +61591,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_29"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -61605,14 +61606,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_31"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -61620,21 +61621,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_5_34"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -61642,7 +61643,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -61650,21 +61651,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_37"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_38"
       elif (
-        (last_candle["RSI_3"] < 9.0)
+        (last_rsi_3 < 9.0)
         and (last_candle["WILLR_14"] < -91.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -61675,7 +61676,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_40"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -61683,7 +61684,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_41"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -61694,7 +61695,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -61705,24 +61706,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_43"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_candle["RSI_3"] < 14.0) and (last_candle["WILLR_14"] < -86.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 14.0) and (last_candle["WILLR_14"] < -86.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_5_45"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_46"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -61730,7 +61731,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_47"
       elif (
-        (last_candle["RSI_3"] < 55.0)
+        (last_rsi_3 < 55.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -61738,7 +61739,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -61749,21 +61750,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_50"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] < 48.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -61771,7 +61772,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -61783,7 +61784,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -61791,7 +61792,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -61799,7 +61800,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -61808,14 +61809,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 56.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -61823,7 +61824,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -61831,7 +61832,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_59"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -61839,14 +61840,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_61"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -61855,42 +61856,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_62"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_5_65"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -61898,35 +61899,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_70"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_71"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -61934,7 +61935,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_73"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -61942,7 +61943,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -61952,21 +61953,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_75"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -76.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -61974,14 +61975,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_78"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -61989,7 +61990,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -61997,7 +61998,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -62005,7 +62006,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_82"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -62013,14 +62014,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_83"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -62028,7 +62029,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -62036,7 +62037,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -62044,7 +62045,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_87"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -72.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -62052,14 +62053,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_88"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -62068,7 +62069,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_90"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -62080,7 +62081,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_91"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -62089,7 +62090,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_92"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -62103,7 +62104,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_93"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -62115,7 +62116,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_94"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -62124,7 +62125,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_95"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -62132,7 +62133,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -62140,7 +62141,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_97"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_15m"] < 36.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -62149,7 +62150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_98"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 40.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -62159,14 +62160,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_99"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] < 32.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -76.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -62174,7 +62175,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_101"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -62183,7 +62184,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_102"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 36.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -62191,7 +62192,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -62200,7 +62201,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -62208,7 +62209,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -62217,7 +62218,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -62225,14 +62226,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_107"
       elif (
-        (last_candle["RSI_3"] < 52.0)
+        (last_rsi_3 < 52.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -62240,14 +62241,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_109"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
-        (last_candle["RSI_3"] < 58.0)
+        (last_rsi_3 < 58.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -62257,7 +62258,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_111"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -55.0)
         and (last_candle["RSI_14"] > 40.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -62267,7 +62268,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -62276,7 +62277,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_113"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -62284,7 +62285,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_114"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -62292,28 +62293,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_115"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_116"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_117"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -62321,35 +62322,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_119"
       elif (
-        (last_candle["RSI_3"] < 54.0)
+        (last_rsi_3 < 54.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_120"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_121"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_122"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -62358,7 +62359,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_124"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -62367,29 +62368,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_126"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_candle["RSI_3"] < 14.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 14.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -62403,7 +62404,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -62411,7 +62412,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -62474,7 +62475,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -62499,7 +62500,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_8"
       elif (
         (last_candle["WILLR_14"] < -93.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -62513,7 +62514,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_10"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -62521,26 +62522,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_11"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_12"
-      elif (last_candle["RSI_3"] < 15.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 15.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_6_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_14"
-      elif (last_candle["RSI_3"] < 12.0) and (last_candle["RSI_14"] < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["RSI_14"] < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -62548,7 +62549,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -62556,14 +62557,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_17"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] < 35.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -62573,21 +62574,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_19"
       elif (
-        (last_candle["RSI_3"] < 56.0)
+        (last_rsi_3 < 56.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_20"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -62595,14 +62596,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_22"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -62610,7 +62611,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -62621,14 +62622,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_25"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -62636,14 +62637,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_27"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -62651,14 +62652,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_29"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -62666,14 +62667,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_31"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -62681,21 +62682,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_6_34"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -91.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -62703,7 +62704,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -62711,21 +62712,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_37"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_38"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -62736,7 +62737,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_40"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -62744,7 +62745,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_41"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -62755,7 +62756,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -62766,24 +62767,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_43"
       elif (
-        (last_candle["RSI_3"] < 45.0)
+        (last_rsi_3 < 45.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_candle["RSI_3"] < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_6_45"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_46"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -62791,7 +62792,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_47"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -62799,7 +62800,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -62810,21 +62811,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_50"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] < 46.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -62832,7 +62833,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -62844,7 +62845,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -62852,7 +62853,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -62860,7 +62861,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -62869,14 +62870,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 58.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -62884,7 +62885,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -62892,7 +62893,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_59"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -62900,14 +62901,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_61"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -62916,42 +62917,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_62"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_6_65"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -62959,35 +62960,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
-        (last_candle["RSI_3"] < 7.0)
+        (last_rsi_3 < 7.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_70"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_71"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_72"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -62995,7 +62996,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_73"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -63003,7 +63004,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -63013,21 +63014,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_75"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -63035,14 +63036,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_78"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -63050,7 +63051,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -63058,7 +63059,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -63066,7 +63067,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_82"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -63074,14 +63075,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_83"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -63089,7 +63090,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -63097,7 +63098,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -63105,7 +63106,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_87"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -74.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -63113,14 +63114,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_88"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -63129,7 +63130,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_90"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -63141,7 +63142,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_91"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -63150,7 +63151,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_92"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -63164,7 +63165,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_93"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -63176,7 +63177,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_94"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -63185,7 +63186,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -63193,7 +63194,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -63201,7 +63202,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_97"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_15m"] < 34.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -63210,7 +63211,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_98"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -63220,14 +63221,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_99"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14"] < 30.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -63235,7 +63236,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_101"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -63244,7 +63245,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_102"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 38.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -63252,7 +63253,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_103"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -63261,7 +63262,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -63269,7 +63270,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -63278,7 +63279,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -63286,14 +63287,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_107"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -63301,14 +63302,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_109"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
-        (last_candle["RSI_3"] < 56.0)
+        (last_rsi_3 < 56.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -63318,7 +63319,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_111"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -60.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -63328,7 +63329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -63337,7 +63338,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_113"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -63345,7 +63346,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_114"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -63353,28 +63354,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_115"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_116"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_117"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -63382,35 +63383,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_119"
       elif (
-        (last_candle["RSI_3"] < 52.0)
+        (last_rsi_3 < 52.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_120"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_121"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_122"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -63419,7 +63420,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_124"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -63428,29 +63429,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_126"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_candle["RSI_3"] < 12.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -63464,7 +63465,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -63472,7 +63473,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -63535,7 +63536,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -63560,7 +63561,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_8"
       elif (
         (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -63574,7 +63575,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_10"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -63582,26 +63583,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_11"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_12"
-      elif (last_candle["RSI_3"] < 10.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_7_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_14"
-      elif (last_candle["RSI_3"] < 10.0) and (last_candle["RSI_14"] < 38.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["RSI_14"] < 38.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -63609,7 +63610,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_16"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -63617,14 +63618,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_17"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] < 30.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_18"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] < 32.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -63634,21 +63635,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_19"
       elif (
-        (last_candle["RSI_3"] < 54.0)
+        (last_rsi_3 < 54.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_20"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_21"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -63656,14 +63657,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_22"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] < 32.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -63671,7 +63672,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_24"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -63682,14 +63683,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_25"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -63697,14 +63698,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_27"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -63712,14 +63713,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_29"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_30"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -63727,14 +63728,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_31"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_32"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -63742,21 +63743,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_7_34"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_35"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -63764,7 +63765,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_36"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -63772,21 +63773,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_37"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_38"
       elif (
-        (last_candle["RSI_3"] < 7.0)
+        (last_rsi_3 < 7.0)
         and (last_candle["WILLR_14"] < -93.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_39"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -63797,7 +63798,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_40"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -63805,7 +63806,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_41"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -63816,7 +63817,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -63827,24 +63828,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_43"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
-      elif (last_candle["RSI_3"] < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_7_45"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_46"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -63852,7 +63853,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_47"
       elif (
-        (last_candle["RSI_3"] < 45.0)
+        (last_rsi_3 < 45.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -63860,7 +63861,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_48"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -63871,21 +63872,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_50"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] < 44.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -63893,7 +63894,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -63905,7 +63906,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_53"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -63913,7 +63914,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_54"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -63921,7 +63922,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_55"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -63930,14 +63931,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 60.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -63945,7 +63946,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -63953,7 +63954,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_59"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -63961,14 +63962,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_61"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -63977,42 +63978,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_62"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_64"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_7_65"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_67"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -64020,35 +64021,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_69"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_70"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_71"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_72"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -64056,7 +64057,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_73"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -64064,7 +64065,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -64074,21 +64075,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_75"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -64096,14 +64097,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_78"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -64111,7 +64112,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_80"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -64119,7 +64120,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_81"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -64127,7 +64128,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_82"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -64135,14 +64136,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_83"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_84"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -64150,7 +64151,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_85"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -64158,7 +64159,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_86"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -64166,7 +64167,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_87"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -76.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -64174,14 +64175,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_88"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -64190,7 +64191,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_90"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -64202,7 +64203,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_91"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -64211,7 +64212,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_92"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -64225,7 +64226,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_93"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -64237,7 +64238,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_94"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -64246,7 +64247,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -64254,7 +64255,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_96"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -64262,7 +64263,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_97"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_15m"] < 32.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -64271,7 +64272,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -64281,14 +64282,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_99"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14"] < 28.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_100"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -64296,7 +64297,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_101"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -64305,7 +64306,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_102"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 40.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -64313,7 +64314,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_103"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -64322,7 +64323,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_104"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -64330,7 +64331,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_105"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -64339,7 +64340,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_106"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -64347,14 +64348,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_107"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_108"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -64362,14 +64363,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_109"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
-        (last_candle["RSI_3"] < 54.0)
+        (last_rsi_3 < 54.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -64379,7 +64380,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_111"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -64389,7 +64390,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -64398,7 +64399,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_113"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -64406,7 +64407,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_114"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -64414,28 +64415,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_115"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_116"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_117"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_118"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -64443,35 +64444,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_119"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_120"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_121"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_122"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -64480,7 +64481,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_124"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -64489,29 +64490,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_126"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_127"
-      elif (last_candle["RSI_3"] < 10.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_129"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -64525,7 +64526,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_131"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -64533,7 +64534,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_132"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -64596,7 +64597,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -64621,7 +64622,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_8"
       elif (
         (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -64635,7 +64636,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_10"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -64643,26 +64644,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_11"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_12"
-      elif (last_candle["RSI_3"] < 5.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 5.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_8_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_14"
-      elif (last_candle["RSI_3"] < 8.0) and (last_candle["RSI_14"] < 36.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["RSI_14"] < 36.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -64670,7 +64671,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_16"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -64678,14 +64679,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_17"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] < 28.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_18"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] < 30.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -64695,21 +64696,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_19"
       elif (
-        (last_candle["RSI_3"] < 52.0)
+        (last_rsi_3 < 52.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_20"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_21"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -64717,14 +64718,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_22"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] < 30.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -64732,7 +64733,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_24"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -64743,14 +64744,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_25"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -64758,14 +64759,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_27"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -64773,14 +64774,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_29"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_30"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -64788,14 +64789,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_31"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_32"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -64803,21 +64804,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_8_34"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -93.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_35"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -64825,7 +64826,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_36"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -64833,21 +64834,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_37"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_38"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_39"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -64858,7 +64859,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_40"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -64866,7 +64867,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_41"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -64877,7 +64878,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -64888,24 +64889,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_43"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
-      elif (last_candle["RSI_3"] < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_8_45"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_46"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -64913,7 +64914,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_47"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -64921,7 +64922,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_48"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -64932,21 +64933,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_50"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] < 42.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -64954,7 +64955,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -64966,7 +64967,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_53"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -64974,7 +64975,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_54"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -64982,7 +64983,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_55"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -64991,14 +64992,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 62.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -65006,7 +65007,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -65014,7 +65015,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_59"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -65022,14 +65023,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_60"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_61"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -65038,42 +65039,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_62"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_64"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_8_65"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_67"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -65081,35 +65082,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_69"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_70"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_71"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_72"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -65117,7 +65118,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_73"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -65125,7 +65126,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -65135,21 +65136,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_75"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -65157,14 +65158,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_78"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -65172,7 +65173,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_80"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -65180,7 +65181,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_81"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -65188,7 +65189,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_82"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -65196,14 +65197,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_83"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_84"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -65211,7 +65212,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_85"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -65219,7 +65220,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_86"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -65227,7 +65228,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_87"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -65235,14 +65236,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_88"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -65251,7 +65252,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_90"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -65263,7 +65264,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_91"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -65272,7 +65273,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_92"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -65286,7 +65287,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_93"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -65298,7 +65299,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_94"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -65307,7 +65308,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_95"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -65315,7 +65316,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_96"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -65323,7 +65324,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_97"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -65332,7 +65333,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -65342,14 +65343,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_99"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14"] < 26.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_100"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -65357,7 +65358,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_101"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -65366,7 +65367,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_102"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 42.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -65374,7 +65375,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_103"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -65383,7 +65384,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -65391,7 +65392,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -65400,7 +65401,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -65408,14 +65409,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_107"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -65423,14 +65424,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_109"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
-        (last_candle["RSI_3"] < 52.0)
+        (last_rsi_3 < 52.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -65440,7 +65441,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_111"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -65450,7 +65451,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -65459,7 +65460,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_113"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -65467,7 +65468,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -65475,28 +65476,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_115"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_116"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_117"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_118"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -65504,35 +65505,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_119"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_120"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_121"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_122"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -65541,7 +65542,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_124"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -65550,29 +65551,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_126"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_127"
-      elif (last_candle["RSI_3"] < 8.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_129"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -65586,7 +65587,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_131"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -65594,7 +65595,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_132"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -65657,7 +65658,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -65682,7 +65683,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_8"
       elif (
         (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -65696,7 +65697,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_10"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -65704,26 +65705,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_11"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_12"
-      elif (last_candle["RSI_3"] < 4.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_9_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_14"
-      elif (last_candle["RSI_3"] < 6.0) and (last_candle["RSI_14"] < 34.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 6.0) and (last_candle["RSI_14"] < 34.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -65731,7 +65732,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_16"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -65739,14 +65740,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_17"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14"] < 26.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_18"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14"] < 28.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -65756,21 +65757,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_19"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_20"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_21"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -65778,14 +65779,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_22"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_14"] < 28.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -65793,7 +65794,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_24"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -65804,14 +65805,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_25"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -65819,14 +65820,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_27"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -65834,14 +65835,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_29"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_30"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -65849,14 +65850,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_31"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_32"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -65864,21 +65865,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_9_34"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_35"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -65886,7 +65887,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_36"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -65894,21 +65895,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_37"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_38"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_39"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -65919,7 +65920,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_40"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -65927,7 +65928,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_41"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -65938,7 +65939,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_42"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -65949,24 +65950,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_43"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
-      elif (last_candle["RSI_3"] < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_9_45"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_46"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -65974,7 +65975,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_47"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -65982,7 +65983,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_48"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -65993,21 +65994,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_50"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] < 40.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -66015,7 +66016,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -66027,7 +66028,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_53"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -66035,7 +66036,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_54"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -66043,7 +66044,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_55"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -66052,14 +66053,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 64.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -66067,7 +66068,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -66075,7 +66076,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_59"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -66083,14 +66084,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_60"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_61"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -66099,42 +66100,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_62"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_64"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_9_65"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_67"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -66142,35 +66143,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_69"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_70"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_71"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_72"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -66178,7 +66179,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_73"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -66186,7 +66187,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -66196,21 +66197,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_75"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -66218,14 +66219,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_78"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -66233,7 +66234,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_80"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -66241,7 +66242,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_81"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -66249,7 +66250,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_82"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -66257,14 +66258,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_83"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_84"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -66272,7 +66273,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_85"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -66280,7 +66281,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_86"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -66288,7 +66289,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_87"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -66296,14 +66297,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_88"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -66312,7 +66313,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_90"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -66324,7 +66325,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_91"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -66333,7 +66334,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_92"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -66347,7 +66348,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_93"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -66359,7 +66360,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_94"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -66368,7 +66369,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_95"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -66376,7 +66377,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_96"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -66384,7 +66385,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_97"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_15m"] < 28.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -66393,7 +66394,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_98"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -66403,14 +66404,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_99"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_14"] < 24.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_100"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -66418,7 +66419,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_101"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -66427,7 +66428,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_102"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 44.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -66435,7 +66436,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_103"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -66444,7 +66445,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_104"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -66452,7 +66453,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_105"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -66461,7 +66462,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_106"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -66469,14 +66470,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_107"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_108"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -66484,14 +66485,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_109"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -66501,7 +66502,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_111"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -66511,7 +66512,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -66520,7 +66521,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_113"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -66528,7 +66529,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_114"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -66536,28 +66537,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_115"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_116"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_117"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_118"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -66565,35 +66566,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_119"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_120"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_121"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_122"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -66602,7 +66603,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_124"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -66611,29 +66612,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_126"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_127"
-      elif (last_candle["RSI_3"] < 6.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_129"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -66647,7 +66648,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_131"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -66655,7 +66656,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_132"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -66718,7 +66719,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -66743,7 +66744,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_8"
       elif (
         (last_candle["WILLR_14"] < -97.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -66757,7 +66758,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_10"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -66765,26 +66766,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_11"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_12"
-      elif (last_candle["RSI_3"] < 4.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_10_13"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_14"
-      elif (last_candle["RSI_3"] < 4.0) and (last_candle["RSI_14"] < 32.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["RSI_14"] < 32.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -66792,7 +66793,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_16"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -66800,14 +66801,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_17"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14"] < 24.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_18"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14"] < 26.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -66817,21 +66818,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_19"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_20"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_21"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -66839,14 +66840,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_22"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_14"] < 26.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -66854,7 +66855,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_24"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -66865,14 +66866,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_25"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -66880,14 +66881,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_27"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -66895,14 +66896,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_29"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_30"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -66910,14 +66911,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_31"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_32"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -66925,21 +66926,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_10_34"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_35"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -66947,7 +66948,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_36"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -66955,21 +66956,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_37"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_38"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_39"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -66980,7 +66981,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_40"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -66988,7 +66989,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_41"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -66999,7 +67000,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_42"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -67010,24 +67011,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_43"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
-      elif (last_candle["RSI_3"] < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_10_45"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_46"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -67035,7 +67036,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_47"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -67043,7 +67044,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_48"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -67054,21 +67055,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_49"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_50"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] < 38.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -67076,7 +67077,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -67088,7 +67089,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_53"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -67096,7 +67097,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_54"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -67104,7 +67105,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_55"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -67113,14 +67114,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 66.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -67128,7 +67129,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_58"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -67136,7 +67137,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_59"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -67144,14 +67145,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_60"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_61"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -67160,42 +67161,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_62"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_64"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_10_65"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_67"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -67203,35 +67204,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_69"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_70"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_71"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_72"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -67239,7 +67240,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_73"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -67247,7 +67248,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -67257,21 +67258,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_75"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -67279,14 +67280,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_78"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -67294,7 +67295,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_80"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -67302,7 +67303,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_81"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -67310,7 +67311,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_82"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -67318,14 +67319,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_83"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_84"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -67333,7 +67334,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_85"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -67341,7 +67342,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_86"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -67349,7 +67350,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_87"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -67357,14 +67358,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_88"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -67373,7 +67374,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_90"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -67385,7 +67386,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_91"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -67394,7 +67395,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_92"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -67408,7 +67409,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_93"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -67420,7 +67421,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_94"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -67429,7 +67430,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_95"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -67437,7 +67438,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_96"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -67445,7 +67446,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_97"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_15m"] < 26.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -67454,7 +67455,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_98"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -67464,14 +67465,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_99"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 22.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_100"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -67479,7 +67480,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_101"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -67488,7 +67489,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_102"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 46.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -67496,7 +67497,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_103"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -67505,7 +67506,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_104"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -67513,7 +67514,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_105"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -67522,7 +67523,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_106"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -67530,14 +67531,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_107"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_108"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -67545,14 +67546,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_109"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
-        (last_candle["RSI_3"] < 48.0)
+        (last_rsi_3 < 48.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -67562,7 +67563,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_111"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -67572,7 +67573,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -67581,7 +67582,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_113"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -67589,7 +67590,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_114"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -67597,28 +67598,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_115"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_116"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_117"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_118"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -67626,35 +67627,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_119"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_120"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_121"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_122"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -67663,7 +67664,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_124"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -67672,29 +67673,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_126"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_127"
-      elif (last_candle["RSI_3"] < 4.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_129"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -67708,7 +67709,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_131"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -67716,7 +67717,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_132"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -67779,7 +67780,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -67804,7 +67805,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_8"
       elif (
         (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3"] < 5.0)
+        and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -67818,7 +67819,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_10"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -67826,26 +67827,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_11"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_12"
-      elif (last_candle["RSI_3"] < 2.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 2.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_11_13"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_14"
-      elif (last_candle["RSI_3"] < 2.0) and (last_candle["RSI_14"] < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 2.0) and (last_candle["RSI_14"] < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -67853,7 +67854,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_16"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -67861,14 +67862,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_17"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14"] < 22.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_18"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14"] < 24.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -67878,21 +67879,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_19"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_20"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_21"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -67900,14 +67901,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_22"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_14"] < 24.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -67915,7 +67916,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_24"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -67926,14 +67927,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_25"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -67941,14 +67942,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_27"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -67956,14 +67957,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_29"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_30"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -67971,14 +67972,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_31"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_32"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -67986,21 +67987,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_11_34"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_35"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -68008,7 +68009,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_36"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -68016,21 +68017,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_37"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_38"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -97.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_39"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -68041,7 +68042,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_40"
       elif (
-        (last_candle["RSI_3"] < 3.0)
+        (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -68049,7 +68050,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_41"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -68060,7 +68061,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_42"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -68071,24 +68072,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_43"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
-      elif (last_candle["RSI_3"] < 2.0) and (last_candle["WILLR_14"] < -98.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 2.0) and (last_candle["WILLR_14"] < -98.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_11_45"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_46"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -68096,7 +68097,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_47"
       elif (
-        (last_candle["RSI_3"] < 25.0)
+        (last_rsi_3 < 25.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -68104,7 +68105,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_48"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -68115,21 +68116,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_49"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_50"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] < 36.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -68137,7 +68138,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -68149,7 +68150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_53"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -68157,7 +68158,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_54"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -68165,7 +68166,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_55"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -68174,14 +68175,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 68.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -68189,7 +68190,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_58"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -68197,7 +68198,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_59"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -68205,14 +68206,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_60"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_61"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -68221,42 +68222,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_62"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_64"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_11_65"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_67"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -68264,35 +68265,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_69"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_70"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_71"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_72"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -68300,7 +68301,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_73"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -68308,7 +68309,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -68318,21 +68319,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_75"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -68340,14 +68341,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_78"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -68355,7 +68356,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_80"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -68363,7 +68364,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_81"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -68371,7 +68372,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_82"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -68379,14 +68380,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_83"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_84"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -68394,7 +68395,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_85"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -68402,7 +68403,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_86"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -68410,7 +68411,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_87"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -68418,14 +68419,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_88"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -68434,7 +68435,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_90"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -68446,7 +68447,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_91"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -68455,7 +68456,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_92"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -68469,7 +68470,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_93"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -68481,7 +68482,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_94"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -68490,7 +68491,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_95"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -68498,7 +68499,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_96"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -68506,7 +68507,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_97"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_15m"] < 24.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -68515,7 +68516,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_98"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -68525,14 +68526,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_99"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 20.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_100"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -68540,7 +68541,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_101"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -68549,7 +68550,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_102"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 48.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -68557,7 +68558,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_103"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -68566,7 +68567,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_104"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -68574,7 +68575,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_105"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -68583,7 +68584,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_106"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -68591,14 +68592,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_107"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_108"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -68606,14 +68607,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_109"
       elif (
-        (last_candle["RSI_3"] < 24.0)
+        (last_rsi_3 < 24.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
-        (last_candle["RSI_3"] < 46.0)
+        (last_rsi_3 < 46.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -68623,7 +68624,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_111"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_14"] > 52.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -68633,7 +68634,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -68642,7 +68643,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_113"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -68650,7 +68651,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_114"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -68658,28 +68659,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_115"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_116"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_117"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_118"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -68687,35 +68688,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_119"
       elif (
-        (last_candle["RSI_3"] < 42.0)
+        (last_rsi_3 < 42.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_120"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_121"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_122"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -68724,7 +68725,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_124"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -68733,29 +68734,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_126"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_127"
-      elif (last_candle["RSI_3"] < 2.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 2.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_129"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -68769,7 +68770,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_131"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -68777,7 +68778,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_132"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
@@ -68840,7 +68841,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_5"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -68865,7 +68866,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_8"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3"] < 1.0)
+        and (last_rsi_3 < 1.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
@@ -68879,7 +68880,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_10"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
@@ -68887,26 +68888,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_11"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_12"
-      elif (last_candle["RSI_3"] < 1.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 1.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
         return True, f"exit_{mode_name}_d_12_13"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_14"
-      elif (last_candle["RSI_3"] < 1.0) and (last_candle["RSI_14"] < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 1.0) and (last_candle["RSI_14"] < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
@@ -68914,7 +68915,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_16"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -68922,14 +68923,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_17"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 20.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_18"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 22.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
@@ -68939,21 +68940,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_19"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_20"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_21"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -68961,14 +68962,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_22"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_14"] < 22.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -68976,7 +68977,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_24"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 15.0)
@@ -68987,14 +68988,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_25"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -69002,14 +69003,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_27"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -69017,14 +69018,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_29"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_30"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
@@ -69032,14 +69033,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_31"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_32"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
@@ -69047,21 +69048,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_33"
       elif (
-        (last_candle["RSI_3"] < 35.0)
+        (last_rsi_3 < 35.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
         and (last_candle["ROC_9_1h"] < -40.0)
       ):
         return True, f"exit_{mode_name}_d_12_34"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_35"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["ROC_9_4h"] > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -69069,7 +69070,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_36"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
@@ -69077,21 +69078,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_37"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_38"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_39"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
@@ -69102,7 +69103,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_40"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
@@ -69110,7 +69111,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_41"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
@@ -69121,7 +69122,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_42"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -69132,24 +69133,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_43"
       elif (
-        (last_candle["RSI_3"] < 15.0)
+        (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
-      elif (last_candle["RSI_3"] < 1.0) and (last_candle["WILLR_14"] < -99.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 1.0) and (last_candle["WILLR_14"] < -99.0) and (last_candle["RSI_3_1h"] > 90.0):
         return True, f"exit_{mode_name}_d_12_45"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_46"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -69157,7 +69158,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_47"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -69165,7 +69166,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_48"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
@@ -69176,21 +69177,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_49"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_50"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] < 34.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -69198,7 +69199,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_52"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 80.0)
@@ -69210,7 +69211,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_53"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
@@ -69218,7 +69219,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_54"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["ROC_9_4h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
@@ -69226,7 +69227,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_55"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -69235,14 +69236,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_56"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -69250,7 +69251,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_58"
       elif (
-        (last_candle["RSI_3"] < 5.0)
+        (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
@@ -69258,7 +69259,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_59"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -69266,14 +69267,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_60"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_61"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -69282,42 +69283,42 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_62"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_3_1d"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_64"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_12_65"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_66"
       elif (
-        (last_candle["RSI_3"] < 50.0)
+        (last_rsi_3 < 50.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_67"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
@@ -69325,35 +69326,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["ROC_9_4h"] < -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_69"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_70"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_71"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 64.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_72"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -69361,7 +69362,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_73"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
@@ -69369,7 +69370,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
@@ -69379,21 +69380,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_75"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -69401,14 +69402,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_78"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
@@ -69416,7 +69417,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_80"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -69424,7 +69425,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_81"
       elif (
-        (last_candle["RSI_3"] < 12.0)
+        (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
@@ -69432,7 +69433,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_82"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -69440,14 +69441,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_83"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_84"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -69455,7 +69456,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_85"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
@@ -69463,7 +69464,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_86"
       elif (
-        (last_candle["RSI_3"] < 28.0)
+        (last_rsi_3 < 28.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
@@ -69471,7 +69472,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_87"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -69479,14 +69480,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_88"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 66.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
       elif (
-        (last_candle["RSI_3"] < 2.0)
+        (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -69495,7 +69496,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_90"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
@@ -69507,7 +69508,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_91"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
@@ -69516,7 +69517,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_92"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
@@ -69530,7 +69531,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_93"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
@@ -69542,7 +69543,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_94"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -69551,7 +69552,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_95"
       elif (
-        (last_candle["RSI_3"] < 32.0)
+        (last_rsi_3 < 32.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
@@ -69559,7 +69560,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_96"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
@@ -69567,7 +69568,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_97"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_15m"] < 22.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -69576,7 +69577,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_98"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -69586,14 +69587,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_99"
       elif (
-        (last_candle["RSI_3"] < 1.0)
+        (last_rsi_3 < 1.0)
         and (last_candle["RSI_14"] < 18.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_100"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
@@ -69601,7 +69602,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_101"
       elif (
-        (last_candle["RSI_3"] < 26.0)
+        (last_rsi_3 < 26.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -69610,7 +69611,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_102"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 50.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -69618,7 +69619,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_103"
       elif (
-        (last_candle["RSI_3"] < 30.0)
+        (last_rsi_3 < 30.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -69627,7 +69628,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_104"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
@@ -69635,7 +69636,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_105"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -69644,7 +69645,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_106"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -69652,14 +69653,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_107"
       elif (
-        (last_candle["RSI_3"] < 38.0)
+        (last_rsi_3 < 38.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_108"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
@@ -69667,14 +69668,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_109"
       elif (
-        (last_candle["RSI_3"] < 22.0)
+        (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_4h"] > 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["ROC_9_4h"] < -25.0)
       ):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
-        (last_candle["RSI_3"] < 44.0)
+        (last_rsi_3 < 44.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
@@ -69684,7 +69685,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_111"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_14"] > 54.0)
         and (last_candle["RSI_3_1h"] > 65.0)
@@ -69694,7 +69695,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -69703,7 +69704,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_113"
       elif (
-        (last_candle["RSI_3"] < 10.0)
+        (last_rsi_3 < 10.0)
         and (last_candle["RSI_14"] > 56.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
@@ -69711,7 +69712,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_114"
       elif (
-        (last_candle["RSI_3"] < 16.0)
+        (last_rsi_3 < 16.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
@@ -69719,28 +69720,28 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_115"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_116"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_117"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_1h"] > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_118"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_1h"] > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
@@ -69748,35 +69749,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_119"
       elif (
-        (last_candle["RSI_3"] < 40.0)
+        (last_rsi_3 < 40.0)
         and (last_candle["RSI_14"] > 58.0)
         and (last_candle["RSI_3_1h"] > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_120"
       elif (
-        (last_candle["RSI_3"] < 34.0)
+        (last_rsi_3 < 34.0)
         and (last_candle["RSI_14"] > 60.0)
         and (last_candle["RSI_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_121"
       elif (
-        (last_candle["RSI_3"] < 36.0)
+        (last_rsi_3 < 36.0)
         and (last_candle["RSI_14"] > 62.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_122"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
-        (last_candle["RSI_3"] < 6.0)
+        (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -69785,7 +69786,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_124"
       elif (
-        (last_candle["RSI_3"] < 18.0)
+        (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
@@ -69794,29 +69795,29 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_1h"] > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_126"
       elif (
-        (last_candle["RSI_3"] < 4.0)
+        (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_1h"] > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_127"
-      elif (last_candle["RSI_3"] < 1.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 1.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
       elif (
-        (last_candle["RSI_3"] < 8.0)
+        (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_129"
       elif (
-        (last_candle["RSI_3"] < 20.0)
+        (last_rsi_3 < 20.0)
         and (last_candle["RSI_14_1h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
@@ -69830,7 +69831,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_131"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_1h"] > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
@@ -69838,7 +69839,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_132"
       elif (
-        (last_candle["RSI_3"] < 14.0)
+        (last_rsi_3 < 14.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))


### PR DESCRIPTION
## Summary
- Reuses one `last_rsi_3` value in `short_exit_dec()` instead of reading `last_candle["RSI_3"]` throughout the dense short-exit decision ladder.
- Replaces 1,612 repeated direct candle-field reads with the local value.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same short-exit formulas, thresholds, condition order, candle selection, output signal names, and return behavior.
- The patch only reuses the same `last_candle["RSI_3"]` value already read from the same candle row inside the same `short_exit_dec()` call.
- A normalized AST check was used for the large diff: after removing the new local and replacing `last_rsi_3` back to `last_candle["RSI_3"]`, `short_exit_dec()` matches the base version.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact same-call candle-field reuse: the same row value is read once and reused by existing comparisons without changing thresholds, formulas, condition order, candle selection, or signal names.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- normalized AST equivalence check for `short_exit_dec()` after inverting the local-field substitution
