### PR TITLE
Reduce X7 grind-v2 adjust reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43822,6 +43822,8 @@ class NostalgiaForInfinityX7(IStrategy):
     dp = self.dp
     send_msg = self.dp.send_msg
     notification_msg = self.notification_msg
+    scale_stakes_for_min_stake = self.scale_stakes_for_min_stake
+    long_grind_exit_v2 = self.long_grind_exit_v2
     stake_currency = self.config["stake_currency"]
     trade_pair = trade.pair
     trade_amount = trade.amount
@@ -43895,7 +43897,7 @@ class NostalgiaForInfinityX7(IStrategy):
       return derisk_flag_timeout
 
     grind_1_max_sub_grinds = 0
-    grind_1_stakes = self.scale_stakes_for_min_stake(
+    grind_1_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_1_stakes_futures if is_futures else self.grinding_v2_grind_1_stakes_spot,
       slice_amount,
       min_stake,
@@ -43916,7 +43918,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_2_max_sub_grinds = 0
-    grind_2_stakes = self.scale_stakes_for_min_stake(
+    grind_2_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_2_stakes_futures if is_futures else self.grinding_v2_grind_2_stakes_spot,
       slice_amount,
       min_stake,
@@ -43937,7 +43939,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_3_max_sub_grinds = 0
-    grind_3_stakes = self.scale_stakes_for_min_stake(
+    grind_3_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_3_stakes_futures if is_futures else self.grinding_v2_grind_3_stakes_spot,
       slice_amount,
       min_stake,
@@ -43958,7 +43960,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_4_max_sub_grinds = 0
-    grind_4_stakes = self.scale_stakes_for_min_stake(
+    grind_4_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_4_stakes_futures if is_futures else self.grinding_v2_grind_4_stakes_spot,
       slice_amount,
       min_stake,
@@ -43979,7 +43981,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_5_max_sub_grinds = 0
-    grind_5_stakes = self.scale_stakes_for_min_stake(
+    grind_5_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_5_stakes_futures if is_futures else self.grinding_v2_grind_5_stakes_spot,
       slice_amount,
       min_stake,
@@ -44467,7 +44469,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -44554,7 +44556,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -44641,7 +44643,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -44675,7 +44677,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -44708,7 +44710,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -44722,7 +44724,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_1_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_1_current_open_rate) / grind_1_current_open_rate
-      if (grind_profit > (grind_1_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_1_profit_threshold + fee_open_rate + fee_close_rate)) and long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_1_total_amount * exit_rate / trade_leverage
@@ -44739,14 +44741,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_1_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_1_exit"
           for grind_entry_id in grind_1_buy_orders:
@@ -44789,14 +44791,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_1_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=grind_1_total_amount,
           )
         )
         log.info(
-          f"Grinding de-risk (grind_1_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding de-risk (grind_1_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_1_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "grind_1_derisk"
         for grind_entry_id in grind_1_buy_orders:
@@ -44831,7 +44833,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -44845,7 +44847,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_2_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_2_current_open_rate) / grind_2_current_open_rate
-      if (grind_profit > (grind_2_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_2_profit_threshold + fee_open_rate + fee_close_rate)) and long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_2_total_amount * exit_rate / trade_leverage
@@ -44862,14 +44864,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_2_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_2_exit"
           for grind_entry_id in grind_2_buy_orders:
@@ -44912,14 +44914,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_2_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=grind_2_total_amount,
           )
         )
         log.info(
-          f"Grinding de-risk (grind_2_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_2_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding de-risk (grind_2_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_2_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "grind_2_derisk"
         for grind_entry_id in grind_2_buy_orders:
@@ -44954,7 +44956,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -44968,7 +44970,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_3_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_3_current_open_rate) / grind_3_current_open_rate
-      if (grind_profit > (grind_3_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_3_profit_threshold + fee_open_rate + fee_close_rate)) and long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_3_total_amount * exit_rate / trade_leverage
@@ -44985,14 +44987,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_3_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_3_exit"
           for grind_entry_id in grind_3_buy_orders:
@@ -45035,14 +45037,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_3_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=grind_3_total_amount,
           )
         )
         log.info(
-          f"Grinding de-risk (grind_3_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_3_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding de-risk (grind_3_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_3_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "grind_3_derisk"
         for grind_entry_id in grind_3_buy_orders:
@@ -45104,7 +45106,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -45118,7 +45120,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_4_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_4_current_open_rate) / grind_4_current_open_rate
-      if (grind_profit > (grind_4_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_4_profit_threshold + fee_open_rate + fee_close_rate)) and long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_4_total_amount * exit_rate / trade_leverage
@@ -45135,14 +45137,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_4_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_4_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_4_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_4_exit"
           for grind_entry_id in grind_4_buy_orders:
@@ -45185,14 +45187,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_4_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=grind_4_total_amount,
           )
         )
         log.info(
-          f"Grinding de-risk (grind_4_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_4_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding de-risk (grind_4_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_4_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "grind_4_derisk"
         for grind_entry_id in grind_4_buy_orders:
@@ -45242,7 +45244,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -45256,7 +45258,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_5_sub_grind_count > 0:
       grind_profit = (exit_rate - grind_5_current_open_rate) / grind_5_current_open_rate
-      if (grind_profit > (grind_5_profit_threshold + fee_open_rate + fee_close_rate)) and self.long_grind_exit_v2(
+      if (grind_profit > (grind_5_profit_threshold + fee_open_rate + fee_close_rate)) and long_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_5_total_amount * exit_rate / trade_leverage
@@ -45273,14 +45275,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_5_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_5_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_5_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_5_exit"
           for grind_entry_id in grind_5_buy_orders:
@@ -45323,14 +45325,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_5_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=grind_5_total_amount,
           )
         )
         log.info(
-          f"Grinding de-risk (grind_5_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_5_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Grinding de-risk (grind_5_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_5_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "grind_5_derisk"
         for grind_entry_id in grind_5_buy_orders:
@@ -45376,7 +45378,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -45401,7 +45403,7 @@ class NostalgiaForInfinityX7(IStrategy):
           + fee_open_rate
           + fee_close_rate
         )
-      ) and self.long_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
+      ) and long_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
         sell_amount = buyback_1_total_amount * exit_rate / trade_leverage
         if ((current_stake_amount / trade_leverage) - sell_amount) < (min_stake * 1.55):
           sell_amount = (trade_amount * exit_rate / trade_leverage) - (min_stake * 1.55)
@@ -45416,14 +45418,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=buyback_1_total_amount,
             )
           )
           log.info(
-            f"Buyback exit (buyback_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Buyback exit (buyback_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "buyback_1_exit"
           for grind_entry_id in buyback_1_buy_orders:
@@ -45477,14 +45479,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=buyback_1_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=buyback_1_total_amount,
           )
         )
         log.info(
-          f"Buyback de-risk (buyback_1_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({buyback_1_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Buyback de-risk (buyback_1_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({buyback_1_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "buyback_1_derisk"
         for grind_entry_id in buyback_1_buy_orders:
@@ -45530,7 +45532,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -45555,7 +45557,7 @@ class NostalgiaForInfinityX7(IStrategy):
           + fee_open_rate
           + fee_close_rate
         )
-      ) and self.long_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
+      ) and long_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
         sell_amount = buyback_2_total_amount * exit_rate / trade_leverage
         if ((current_stake_amount / trade_leverage) - sell_amount) < (min_stake * 1.55):
           sell_amount = (trade_amount * exit_rate / trade_leverage) - (min_stake * 1.55)
@@ -45570,14 +45572,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=buyback_2_total_amount,
             )
           )
           log.info(
-            f"Buyback exit (buyback_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Buyback exit (buyback_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "buyback_2_exit"
           for grind_entry_id in buyback_2_buy_orders:
@@ -45631,14 +45633,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=buyback_2_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=buyback_2_total_amount,
           )
         )
         log.info(
-          f"Buyback de-risk (buyback_2_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({buyback_2_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Buyback de-risk (buyback_2_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({buyback_2_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "buyback_2_derisk"
         for grind_entry_id in buyback_2_buy_orders:
@@ -45684,7 +45686,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -45709,7 +45711,7 @@ class NostalgiaForInfinityX7(IStrategy):
           + fee_open_rate
           + fee_close_rate
         )
-      ) and self.long_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
+      ) and long_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
         sell_amount = buyback_3_total_amount * exit_rate / trade_leverage
         if ((current_stake_amount / trade_leverage) - sell_amount) < (min_stake * 1.55):
           sell_amount = (trade_amount * exit_rate / trade_leverage) - (min_stake * 1.55)
@@ -45724,14 +45726,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=buyback_3_total_amount,
             )
           )
           log.info(
-            f"Buyback exit (buyback_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Buyback exit (buyback_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "buyback_3_exit"
           for grind_entry_id in buyback_3_buy_orders:
@@ -45785,14 +45787,14 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=buyback_3_current_grind_stake_profit,
             grind_profit_pct=grind_profit,
             coin_amount=buyback_3_total_amount,
           )
         )
         log.info(
-          f"Buyback de-risk (buyback_3_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({buyback_3_current_grind_stake_profit} {self.config['stake_currency']})"
+          f"Buyback de-risk (buyback_3_derisk) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({buyback_3_current_grind_stake_profit} {stake_currency})"
         )
         order_tag = "buyback_3_derisk"
         for grind_entry_id in buyback_3_buy_orders:
@@ -70015,6 +70017,8 @@ class NostalgiaForInfinityX7(IStrategy):
     dp = self.dp
     send_msg = self.dp.send_msg
     notification_msg = self.notification_msg
+    scale_stakes_for_min_stake = self.scale_stakes_for_min_stake
+    short_grind_exit_v2 = self.short_grind_exit_v2
     stake_currency = self.config["stake_currency"]
     trade_pair = trade.pair
     trade_amount = trade.amount
@@ -70088,7 +70092,7 @@ class NostalgiaForInfinityX7(IStrategy):
       return derisk_flag_timeout
 
     grind_1_max_sub_grinds = 0
-    grind_1_stakes = self.scale_stakes_for_min_stake(
+    grind_1_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_1_stakes_futures if is_futures else self.grinding_v2_grind_1_stakes_spot,
       slice_amount,
       min_stake,
@@ -70109,7 +70113,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_2_max_sub_grinds = 0
-    grind_2_stakes = self.scale_stakes_for_min_stake(
+    grind_2_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_2_stakes_futures if is_futures else self.grinding_v2_grind_2_stakes_spot,
       slice_amount,
       min_stake,
@@ -70130,7 +70134,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_3_max_sub_grinds = 0
-    grind_3_stakes = self.scale_stakes_for_min_stake(
+    grind_3_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_3_stakes_futures if is_futures else self.grinding_v2_grind_3_stakes_spot,
       slice_amount,
       min_stake,
@@ -70151,7 +70155,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_4_max_sub_grinds = 0
-    grind_4_stakes = self.scale_stakes_for_min_stake(
+    grind_4_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_4_stakes_futures if is_futures else self.grinding_v2_grind_4_stakes_spot,
       slice_amount,
       min_stake,
@@ -70172,7 +70176,7 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     grind_5_max_sub_grinds = 0
-    grind_5_stakes = self.scale_stakes_for_min_stake(
+    grind_5_stakes = scale_stakes_for_min_stake(
       self.grinding_v2_grind_5_stakes_futures if is_futures else self.grinding_v2_grind_5_stakes_spot,
       slice_amount,
       min_stake,
@@ -70660,7 +70664,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -70747,7 +70751,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -70834,7 +70838,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -70868,7 +70872,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
           )
         )
         log.info(
@@ -70901,7 +70905,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -70915,7 +70919,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_1_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_1_current_open_rate) / grind_1_current_open_rate
-      if (grind_profit > (grind_1_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_1_profit_threshold + fee_open_rate + fee_close_rate)) and short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_1_total_amount * exit_rate / trade_leverage
@@ -70932,14 +70936,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_1_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_1_exit"
           for grind_entry_id in grind_1_buy_orders:
@@ -70982,7 +70986,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_1_total_amount,
@@ -71024,7 +71028,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -71038,7 +71042,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_2_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_2_current_open_rate) / grind_2_current_open_rate
-      if (grind_profit > (grind_2_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_2_profit_threshold + fee_open_rate + fee_close_rate)) and short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_2_total_amount * exit_rate / trade_leverage
@@ -71055,14 +71059,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_2_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_2_exit"
           for grind_entry_id in grind_2_buy_orders:
@@ -71105,7 +71109,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_2_total_amount,
@@ -71147,7 +71151,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -71161,7 +71165,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_3_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_3_current_open_rate) / grind_3_current_open_rate
-      if (grind_profit > (grind_3_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_3_profit_threshold + fee_open_rate + fee_close_rate)) and short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_3_total_amount * exit_rate / trade_leverage
@@ -71178,14 +71182,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_3_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_3_exit"
           for grind_entry_id in grind_3_buy_orders:
@@ -71228,7 +71232,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_3_total_amount,
@@ -71285,7 +71289,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -71299,7 +71303,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_4_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_4_current_open_rate) / grind_4_current_open_rate
-      if (grind_profit > (grind_4_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_4_profit_threshold + fee_open_rate + fee_close_rate)) and short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_4_total_amount * exit_rate / trade_leverage
@@ -71316,14 +71320,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_4_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_4_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_4_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_4_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_4_exit"
           for grind_entry_id in grind_4_buy_orders:
@@ -71366,7 +71370,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_4_total_amount,
@@ -71423,7 +71427,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -71437,7 +71441,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     if grind_5_sub_grind_count > 0:
       grind_profit = -(exit_rate - grind_5_current_open_rate) / grind_5_current_open_rate
-      if (grind_profit > (grind_5_profit_threshold + fee_open_rate + fee_close_rate)) and self.short_grind_exit_v2(
+      if (grind_profit > (grind_5_profit_threshold + fee_open_rate + fee_close_rate)) and short_grind_exit_v2(
         last_candle, previous_candle, slice_profit, True
       ):
         sell_amount = grind_5_total_amount * exit_rate / trade_leverage
@@ -71454,14 +71458,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=grind_5_total_amount,
             )
           )
           log.info(
-            f"Grinding exit (grind_5_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Grinding exit (grind_5_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {grind_5_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "grind_5_exit"
           for grind_entry_id in grind_5_buy_orders:
@@ -71504,7 +71508,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             grind_profit_stake=grind_profit * sell_amount * trade_leverage,
             grind_profit_pct=grind_profit,
             coin_amount=grind_5_total_amount,
@@ -71557,7 +71561,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -71582,7 +71586,7 @@ class NostalgiaForInfinityX7(IStrategy):
           + fee_open_rate
           + fee_close_rate
         )
-      ) and self.short_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
+      ) and short_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
         sell_amount = buyback_1_total_amount * exit_rate / trade_leverage
         if ((current_stake_amount / trade_leverage) - sell_amount) < (min_stake * 1.55):
           sell_amount = (trade_amount * exit_rate / trade_leverage) - (min_stake * 1.55)
@@ -71597,14 +71601,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=buyback_1_total_amount,
             )
           )
           log.info(
-            f"Buyback exit (buyback_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Buyback exit (buyback_1_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_1_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "buyback_1_exit"
           for grind_entry_id in buyback_1_buy_orders:
@@ -71658,7 +71662,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             coin_amount=buyback_1_total_amount,
           )
         )
@@ -71709,7 +71713,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -71734,7 +71738,7 @@ class NostalgiaForInfinityX7(IStrategy):
           + fee_open_rate
           + fee_close_rate
         )
-      ) and self.short_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
+      ) and short_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
         sell_amount = buyback_2_total_amount * exit_rate / trade_leverage
         if ((current_stake_amount / trade_leverage) - sell_amount) < (min_stake * 1.55):
           sell_amount = (trade_amount * exit_rate / trade_leverage) - (min_stake * 1.55)
@@ -71749,14 +71753,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=buyback_2_total_amount,
             )
           )
           log.info(
-            f"Buyback exit (buyback_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Buyback exit (buyback_2_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_2_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "buyback_2_exit"
           for grind_entry_id in buyback_2_buy_orders:
@@ -71810,7 +71814,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             coin_amount=buyback_2_total_amount,
           )
         )
@@ -71861,7 +71865,7 @@ class NostalgiaForInfinityX7(IStrategy):
           stake_amount=buy_amount,
           profit_stake=profit_stake,
           profit_ratio=profit_ratio,
-          stake_currency=self.config["stake_currency"],
+          stake_currency=stake_currency,
         )
       )
       log.info(
@@ -71886,7 +71890,7 @@ class NostalgiaForInfinityX7(IStrategy):
           + fee_open_rate
           + fee_close_rate
         )
-      ) and self.short_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
+      ) and short_grind_exit_v2(last_candle, previous_candle, slice_profit, True):
         sell_amount = buyback_3_total_amount * exit_rate / trade_leverage
         if ((current_stake_amount / trade_leverage) - sell_amount) < (min_stake * 1.55):
           sell_amount = (trade_amount * exit_rate / trade_leverage) - (min_stake * 1.55)
@@ -71901,14 +71905,14 @@ class NostalgiaForInfinityX7(IStrategy):
               stake_amount=sell_amount,
               profit_stake=profit_stake,
               profit_ratio=profit_ratio,
-              stake_currency=self.config["stake_currency"],
+              stake_currency=stake_currency,
               grind_profit_stake=grind_profit * sell_amount * trade_leverage,
               grind_profit_pct=grind_profit,
               coin_amount=buyback_3_total_amount,
             )
           )
           log.info(
-            f"Buyback exit (buyback_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {self.config['stake_currency']})"
+            f"Buyback exit (buyback_3_exit) [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Coin amount: {buyback_3_total_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}% | Grind profit: {(grind_profit * 100.0):.2f}% ({grind_profit * sell_amount * trade_leverage} {stake_currency})"
           )
           order_tag = "buyback_3_exit"
           for grind_entry_id in buyback_3_buy_orders:
@@ -71962,7 +71966,7 @@ class NostalgiaForInfinityX7(IStrategy):
             stake_amount=sell_amount,
             profit_stake=profit_stake,
             profit_ratio=profit_ratio,
-            stake_currency=self.config["stake_currency"],
+            stake_currency=stake_currency,
             coin_amount=buyback_3_total_amount,
           )
         )


### PR DESCRIPTION
## Summary
- Reuses the existing `stake_currency` local inside long/short grind-v2 adjust paths instead of repeatedly reading `self.config[...]` for notifications/logging.
- Reuses local `scale_stakes_for_min_stake` and v2 grind-exit helper references across the repeated v2 grind ladders.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same v2 grind stake arrays, thresholds, leverage, min-stake scaling inputs, exit-helper calls, order classification, profit arithmetic, return values, and notification behavior.
- The patch only reuses values already read inside the same adjust call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is local object reuse inside the same v2 adjust calls and does not change formulas, thresholds, order classification, candle selection, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
