### PR TITLE
Reuse X7 core long-exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -29562,10 +29562,13 @@ class NostalgiaForInfinityX7(IStrategy):
     buy_tag,
   ) -> tuple:
     last_rsi_3 = last_candle["RSI_3"]
+    last_roc_9_1d = last_candle["ROC_9_1d"]
+    last_rsi_3_1h = last_candle["RSI_3_1h"]
+    last_rsi_14 = last_candle["RSI_14"]
     if 0.01 > current_profit >= 0.001:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -29578,7 +29581,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -29600,7 +29603,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -29613,7 +29616,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_4"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -29621,16 +29624,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_7"
       elif (
@@ -29639,35 +29642,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
         (last_candle["WILLR_14"] > -1.0)
         and (last_rsi_3 > 99.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_10"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -29682,7 +29685,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_14"
-      elif (last_rsi_3 > 99.0) and (last_candle["RSI_14"] > 78.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
         (last_rsi_3 > 99.0)
@@ -29695,21 +29698,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_17"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] > 75.0)
+        and (last_rsi_14 > 75.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -29719,15 +29722,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_19"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_20"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_21"
@@ -29736,19 +29739,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -29774,45 +29777,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_27"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_29"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_31"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -29849,8 +29852,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -29872,7 +29875,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -29883,16 +29886,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -29901,8 +29904,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -29915,14 +29918,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_rsi_3 > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_0_45"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -29932,13 +29935,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_0_47"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -29963,24 +29966,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_50"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -29990,7 +29993,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -30000,31 +30003,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 34.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 34.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_58"
@@ -30032,13 +30035,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_59"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -30054,9 +30057,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_0_62"
@@ -30069,36 +30072,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
       elif (
-        (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 90.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_65"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -30112,31 +30112,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_69"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_70"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_71"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
@@ -30149,7 +30149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -30159,22 +30159,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_75"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -30182,22 +30182,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
         (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -30212,8 +30212,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_82"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -30228,7 +30228,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -30243,8 +30243,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -30259,24 +30259,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
       elif (
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_90"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -30287,16 +30287,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_91"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_92"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -30305,13 +30305,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_93"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -30323,7 +30323,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -30331,16 +30331,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -30348,7 +30348,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_15m"] > 74.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -30356,17 +30356,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -30374,32 +30374,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_101"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_102"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_103"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -30407,7 +30407,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -30415,8 +30415,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -30424,25 +30424,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_107"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
       elif (
@@ -30454,22 +30454,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
@@ -30478,20 +30478,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_113"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -30499,21 +30499,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_115"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_116"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_117"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -30521,28 +30521,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_119"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_120"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 95.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_0_121"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -30550,13 +30547,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -30566,7 +30563,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -30574,14 +30571,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_125"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_126"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -30591,7 +30588,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
@@ -30602,15 +30599,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_130"
       elif (
-        (last_candle["RSI_14"] < 36.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 36.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -30620,13 +30617,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_133"
     elif 0.02 > current_profit >= 0.01:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -30639,7 +30636,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -30661,7 +30658,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_3"
       elif (
         (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_14"] > 65.0)
+        and (last_rsi_14 > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -30674,7 +30671,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_4"
       elif (
         (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -30682,16 +30679,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
       elif (
@@ -30700,35 +30697,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_1_8"
       elif (
         (last_candle["WILLR_14"] > -2.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_9"
       elif (
         (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_10"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_1_11"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -30743,7 +30740,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_14"
-      elif (last_rsi_3 > 95.0) and (last_candle["RSI_14"] > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
         (last_rsi_3 > 95.0)
@@ -30756,21 +30753,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_17"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_1_18"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -30780,15 +30777,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_19"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_20"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_21"
@@ -30797,19 +30794,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] > 75.0)
+        and (last_rsi_14 > 75.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -30835,45 +30832,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_27"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_29"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_30"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_31"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -30910,8 +30907,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_36"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -30933,7 +30930,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -30944,16 +30941,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_41"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -30962,8 +30959,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -30976,14 +30973,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
-      elif (last_rsi_3 > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_1_45"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -30993,13 +30990,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_1_47"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -31024,24 +31021,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_50"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_1_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -31051,7 +31048,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_53"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -31061,31 +31058,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 36.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 36.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_58"
@@ -31093,13 +31090,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_59"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -31115,9 +31112,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_1_62"
@@ -31130,36 +31127,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_64"
       elif (
-        (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 68.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_65"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_67"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -31173,31 +31167,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_69"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_70"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_71"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_72"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_73"
       elif (
@@ -31210,7 +31204,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -31220,22 +31214,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_75"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -31243,22 +31237,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_80"
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -31273,8 +31267,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_82"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -31289,7 +31283,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -31304,8 +31298,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_86"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -31320,24 +31314,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_88"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_90"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -31348,16 +31342,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_91"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_92"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -31366,13 +31360,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_93"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -31384,7 +31378,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -31392,16 +31386,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_95"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_96"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -31409,7 +31403,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_15m"] > 72.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -31417,17 +31411,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_98"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_14"] > 76.0)
+        and (last_rsi_14 > 76.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -31435,32 +31429,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_101"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_102"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_103"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -31468,7 +31462,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_104"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -31476,8 +31470,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_105"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -31485,25 +31479,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_106"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_107"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_108"
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_109"
       elif (
@@ -31515,22 +31509,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_1_111"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
@@ -31539,20 +31533,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_1_113"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_114"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -31560,21 +31554,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_115"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_116"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_117"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -31582,28 +31576,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_119"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_120"
       elif (
-        (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_1_121"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -31611,13 +31602,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -31627,7 +31618,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -31635,14 +31626,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_125"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_126"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -31652,7 +31643,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_129"
       elif (
@@ -31663,15 +31654,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_130"
       elif (
-        (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_131"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -31681,13 +31672,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_133"
     elif 0.03 > current_profit >= 0.02:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -31700,7 +31691,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -31722,7 +31713,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_3"
       elif (
         (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_14"] > 65.0)
+        and (last_rsi_14 > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -31735,7 +31726,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_4"
       elif (
         (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -31743,16 +31734,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
       elif (
@@ -31761,35 +31752,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_2_8"
       elif (
         (last_candle["WILLR_14"] > -4.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_9"
       elif (
         (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_10"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_2_11"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -31804,7 +31795,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_14"
-      elif (last_rsi_3 > 92.0) and (last_candle["RSI_14"] > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_14 > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
         (last_rsi_3 > 70.0)
@@ -31817,21 +31808,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_17"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_2_18"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -31841,15 +31832,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_19"
       elif (
         (last_rsi_3 > 48.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_20"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_21"
@@ -31858,19 +31849,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -31896,45 +31887,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_27"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_29"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_30"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_31"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -31971,8 +31962,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_36"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -31994,7 +31985,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -32005,16 +31996,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_41"
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -32023,8 +32014,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -32037,14 +32028,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
-      elif (last_rsi_3 > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_2_45"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -32054,13 +32045,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_2_47"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -32085,24 +32076,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_50"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_2_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -32112,7 +32103,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_53"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -32122,31 +32113,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 38.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_58"
@@ -32154,13 +32145,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_59"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -32176,9 +32167,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_2_62"
@@ -32191,36 +32182,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_64"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 66.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_65"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_67"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -32234,31 +32222,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_69"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_70"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_71"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_72"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_73"
       elif (
@@ -32271,7 +32259,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -32281,22 +32269,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_75"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -18.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -32304,22 +32292,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_80"
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -32334,8 +32322,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_82"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -32350,7 +32338,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -32365,8 +32353,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_86"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -32381,24 +32369,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_88"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_90"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -32409,16 +32397,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_91"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_92"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -32427,13 +32415,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_93"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -32445,7 +32433,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -32453,16 +32441,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_95"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_96"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -32470,7 +32458,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -32478,17 +32466,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -32496,32 +32484,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -18.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_101"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_102"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_103"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -32529,7 +32517,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -32537,8 +32525,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -32546,25 +32534,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_107"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_109"
       elif (
@@ -32576,22 +32564,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
         (last_rsi_3 > 48.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_2_111"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
@@ -32600,20 +32588,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_2_113"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -32621,21 +32609,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_115"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_116"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_117"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -32643,28 +32631,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_119"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_120"
       elif (
-        (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_2_121"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -32672,13 +32657,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -32688,7 +32673,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -32696,14 +32681,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_125"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_126"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -32713,7 +32698,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_129"
       elif (
@@ -32724,15 +32709,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_130"
       elif (
-        (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_131"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -32742,13 +32727,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_133"
     elif 0.04 > current_profit >= 0.03:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -32761,7 +32746,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -32783,7 +32768,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
         (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_14"] > 65.0)
+        and (last_rsi_14 > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -32796,7 +32781,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_4"
       elif (
         (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -32804,16 +32789,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
@@ -32822,35 +32807,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
         (last_candle["WILLR_14"] > -6.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
         (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_10"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_3_11"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -32865,7 +32850,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_14"
-      elif (last_rsi_3 > 90.0) and (last_candle["RSI_14"] > 65.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14 > 65.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
         (last_rsi_3 > 70.0)
@@ -32878,21 +32863,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_17"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -32902,15 +32887,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_19"
       elif (
         (last_rsi_3 > 46.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_20"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_21"
@@ -32919,19 +32904,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -32957,45 +32942,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_27"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_29"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_31"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -33032,8 +33017,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -33055,7 +33040,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -33066,16 +33051,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_41"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -33084,8 +33069,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -33098,14 +33083,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_rsi_3 > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_3_45"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -33115,13 +33100,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_3_47"
       elif (
         (last_rsi_3 > 55.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -33146,24 +33131,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_50"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -33173,7 +33158,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -33183,31 +33168,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 40.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_58"
@@ -33215,13 +33200,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_59"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -33237,9 +33222,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_3_62"
@@ -33252,36 +33237,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 64.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_65"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -33295,31 +33277,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_69"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_70"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_71"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_72"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_73"
       elif (
@@ -33332,7 +33314,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -33342,22 +33324,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_75"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -33365,22 +33347,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -33395,8 +33377,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -33411,7 +33393,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -33426,8 +33408,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -33442,24 +33424,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_88"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_90"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -33470,16 +33452,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_91"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_92"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -33488,13 +33470,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_93"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -33506,7 +33488,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -33514,16 +33496,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -33531,7 +33513,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_15m"] > 68.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -33539,17 +33521,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -33557,32 +33539,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_101"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_102"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 60.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_103"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -33590,7 +33572,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -33598,8 +33580,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -33607,25 +33589,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_107"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
         (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
       elif (
@@ -33637,22 +33619,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 > 46.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_3_111"
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -35.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
@@ -33661,20 +33643,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_3_113"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_114"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -33682,21 +33664,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_115"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_116"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_117"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -33704,28 +33686,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_119"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_120"
       elif (
-        (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_3_121"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -33733,13 +33712,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -33749,7 +33728,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -33757,14 +33736,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_125"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_126"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -33774,7 +33753,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
@@ -33785,15 +33764,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_130"
       elif (
-        (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -33803,13 +33782,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_133"
     elif 0.05 > current_profit >= 0.04:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -33822,7 +33801,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -33844,7 +33823,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_3"
       elif (
         (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_14"] > 65.0)
+        and (last_rsi_14 > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -33857,7 +33836,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_4"
       elif (
         (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -33865,16 +33844,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
       elif (
@@ -33883,35 +33862,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_4_8"
       elif (
         (last_candle["WILLR_14"] > -7.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_9"
       elif (
         (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_10"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_4_11"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -33926,7 +33905,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_14"
-      elif (last_rsi_3 > 88.0) and (last_candle["RSI_14"] > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_14 > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
         (last_rsi_3 > 70.0)
@@ -33939,21 +33918,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_17"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_4_18"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -33963,15 +33942,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_19"
       elif (
         (last_rsi_3 > 44.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_20"
       elif (
         (last_rsi_3 > 55.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_21"
@@ -33980,19 +33959,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -34018,45 +33997,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_27"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_29"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_30"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_31"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -34093,8 +34072,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_36"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -34116,7 +34095,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -34127,16 +34106,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_41"
       elif (
         (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -34145,8 +34124,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -34159,14 +34138,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
-      elif (last_rsi_3 > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_4_45"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -34176,13 +34155,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_4_47"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -34207,24 +34186,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_50"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_4_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -34234,7 +34213,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_53"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -34244,31 +34223,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 42.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_58"
@@ -34276,13 +34255,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_59"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -34298,9 +34277,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_4_62"
@@ -34313,36 +34292,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_64"
       elif (
-        (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 62.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_65"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_67"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -34356,31 +34332,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_69"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_70"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_71"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_72"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_73"
       elif (
@@ -34393,7 +34369,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -34403,22 +34379,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_75"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 56.0)
+        and (last_rsi_14 < 56.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_77"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -22.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -34426,22 +34402,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_80"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -34456,8 +34432,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_82"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -34472,7 +34448,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -34487,8 +34463,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_86"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -34503,24 +34479,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_88"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_90"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -34531,16 +34507,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_91"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_92"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 56.0)
+        and (last_rsi_14 < 56.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -34549,13 +34525,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_93"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -34567,7 +34543,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -18.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -34575,16 +34551,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_96"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -34592,7 +34568,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_15m"] > 66.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -34600,17 +34576,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_98"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -34618,32 +34594,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -22.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_101"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_102"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 62.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 62.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_103"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -34651,7 +34627,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_104"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -34659,8 +34635,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_105"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -34668,25 +34644,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_106"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_107"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_108"
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_109"
       elif (
@@ -34698,22 +34674,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
         (last_rsi_3 > 44.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_4_111"
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -40.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
@@ -34722,20 +34698,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_4_113"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_114"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -34743,21 +34719,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_115"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_116"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_117"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -34765,28 +34741,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_119"
       elif (
         (last_rsi_3 > 48.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_120"
       elif (
-        (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_4_121"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -34794,13 +34767,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -34810,7 +34783,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -34818,14 +34791,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_125"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_126"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -34835,7 +34808,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_129"
       elif (
@@ -34846,15 +34819,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_130"
       elif (
-        (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_131"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -34864,13 +34837,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_133"
     elif 0.06 > current_profit >= 0.05:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -34883,7 +34856,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -34905,7 +34878,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
         (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_14"] > 65.0)
+        and (last_rsi_14 > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -34918,7 +34891,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_4"
       elif (
         (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -34926,16 +34899,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
@@ -34944,35 +34917,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_5_8"
       elif (
         (last_candle["WILLR_14"] > -8.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_9"
       elif (
         (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_10"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_5_11"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -34987,7 +34960,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_14"
-      elif (last_rsi_3 > 86.0) and (last_candle["RSI_14"] > 58.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_14 > 58.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
         (last_rsi_3 > 70.0)
@@ -35000,21 +34973,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -35.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_17"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -35024,15 +34997,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_19"
       elif (
         (last_rsi_3 > 42.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_20"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_21"
@@ -35041,19 +35014,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
       elif (
         (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -35079,45 +35052,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_27"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_29"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_31"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -35154,8 +35127,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -35177,7 +35150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_candle["WILLR_14"] > -35.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -35188,16 +35161,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_41"
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -35206,8 +35179,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -35220,14 +35193,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_rsi_3 > 86.0) and (last_candle["WILLR_14"] > -14.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 86.0) and (last_candle["WILLR_14"] > -14.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_5_45"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -35237,13 +35210,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_5_47"
       elif (
         (last_rsi_3 > 45.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -35268,24 +35241,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_50"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -35295,7 +35268,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -35305,31 +35278,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -22.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 44.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_58"
@@ -35337,13 +35310,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_59"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -35359,9 +35332,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_5_62"
@@ -35374,36 +35347,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
       elif (
-        (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_65"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -35417,31 +35387,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_69"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_70"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_71"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_73"
       elif (
@@ -35454,7 +35424,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -35464,22 +35434,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_75"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 58.0)
+        and (last_rsi_14 < 58.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -24.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -35487,22 +35457,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -18.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -35517,8 +35487,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_82"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -35533,7 +35503,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -35548,8 +35518,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -35564,24 +35534,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_88"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_90"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -35592,16 +35562,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_91"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_92"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 58.0)
+        and (last_rsi_14 < 58.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -35610,13 +35580,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_93"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -35628,7 +35598,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -35636,16 +35606,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_95"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -35653,7 +35623,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_15m"] > 64.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -35661,17 +35631,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_98"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 60.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 60.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -35679,32 +35649,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -24.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_101"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_102"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 64.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 64.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -35712,7 +35682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 56.0)
+        and (last_rsi_14 < 56.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -35720,8 +35690,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -35729,25 +35699,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_107"
       elif (
         (last_rsi_3 > 48.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
         (last_rsi_3 > 68.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
       elif (
@@ -35759,22 +35729,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 > 42.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_5_111"
       elif (
         (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -45.0)
-        and (last_candle["RSI_14"] < 60.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 60.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
@@ -35783,20 +35753,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_5_113"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_114"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 56.0)
+        and (last_rsi_14 < 56.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -35804,21 +35774,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_115"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_116"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_117"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -35826,28 +35796,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_119"
       elif (
         (last_rsi_3 > 46.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_120"
       elif (
-        (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 52.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_5_121"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -35855,13 +35822,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -35871,7 +35838,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 68.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -35879,14 +35846,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_125"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_126"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -35896,7 +35863,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
@@ -35907,15 +35874,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_130"
       elif (
-        (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -35925,13 +35892,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_133"
     elif 0.07 > current_profit >= 0.06:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -35944,7 +35911,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -35966,7 +35933,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
         (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -35979,7 +35946,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_4"
       elif (
         (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -35987,16 +35954,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
       elif (
@@ -36005,35 +35972,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_6_8"
       elif (
         (last_candle["WILLR_14"] > -7.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_9"
       elif (
         (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_10"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_6_11"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -36048,7 +36015,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_14"
-      elif (last_rsi_3 > 88.0) and (last_candle["RSI_14"] > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_14 > 60.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
         (last_rsi_3 > 75.0)
@@ -36061,21 +36028,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_17"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] > 65.0)
+        and (last_rsi_14 > 65.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -36085,15 +36052,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_19"
       elif (
         (last_rsi_3 > 44.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_20"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_21"
@@ -36102,19 +36069,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -36140,45 +36107,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_27"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_29"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_31"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -36215,8 +36182,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -36238,7 +36205,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -36249,16 +36216,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_41"
       elif (
         (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -36267,8 +36234,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -36281,14 +36248,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_rsi_3 > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 88.0) and (last_candle["WILLR_14"] > -12.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_6_45"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -36298,13 +36265,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_6_47"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -36329,24 +36296,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_50"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -36356,7 +36323,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -36366,31 +36333,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 42.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_58"
@@ -36398,13 +36365,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_59"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -36420,9 +36387,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_6_62"
@@ -36435,36 +36402,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
       elif (
-        (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 62.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_65"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -36478,31 +36442,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_69"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_70"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_71"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_72"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_73"
       elif (
@@ -36515,7 +36479,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -36525,22 +36489,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_75"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 56.0)
+        and (last_rsi_14 < 56.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -22.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -36548,22 +36512,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -36578,8 +36542,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_82"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -36594,7 +36558,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -36609,8 +36573,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -36625,24 +36589,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_88"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_90"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -36653,16 +36617,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_91"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_92"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 56.0)
+        and (last_rsi_14 < 56.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -36671,13 +36635,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_93"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -36689,7 +36653,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -18.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -36697,16 +36661,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -36714,7 +36678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_15m"] > 66.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -36722,17 +36686,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_98"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -36740,32 +36704,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -22.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_101"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_102"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 62.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 62.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_103"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -36773,7 +36737,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -36781,8 +36745,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -36790,25 +36754,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_107"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
       elif (
@@ -36820,22 +36784,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 > 44.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_6_111"
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -40.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
@@ -36844,20 +36808,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_6_113"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_114"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -36865,21 +36829,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_115"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_116"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_117"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -36887,28 +36851,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_119"
       elif (
         (last_rsi_3 > 48.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_120"
       elif (
-        (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_6_121"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -36916,13 +36877,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -36932,7 +36893,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -36940,14 +36901,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_125"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_126"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -36957,7 +36918,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
@@ -36968,15 +36929,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_130"
       elif (
-        (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -36986,13 +36947,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_133"
     elif 0.08 > current_profit >= 0.07:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -37005,7 +36966,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -37027,7 +36988,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_3"
       elif (
         (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -37040,7 +37001,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_4"
       elif (
         (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -37048,16 +37009,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
       elif (
@@ -37066,35 +37027,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_7_8"
       elif (
         (last_candle["WILLR_14"] > -6.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_9"
       elif (
         (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_10"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_7_11"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -37109,7 +37070,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_14"
-      elif (last_rsi_3 > 90.0) and (last_candle["RSI_14"] > 62.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14 > 62.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
         (last_rsi_3 > 80.0)
@@ -37122,21 +37083,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_17"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_7_18"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -37146,15 +37107,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_19"
       elif (
         (last_rsi_3 > 46.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_20"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_21"
@@ -37163,19 +37124,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -37201,45 +37162,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_27"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_29"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_30"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_31"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -37276,8 +37237,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_36"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -37299,7 +37260,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -37310,16 +37271,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_41"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -37328,8 +37289,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -37342,14 +37303,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
-      elif (last_rsi_3 > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 90.0) and (last_candle["WILLR_14"] > -10.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_7_45"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -37359,13 +37320,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_7_47"
       elif (
         (last_rsi_3 > 55.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -37390,24 +37351,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_50"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_7_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -37417,7 +37378,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_53"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -37427,31 +37388,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -18.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_55"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 40.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_58"
@@ -37459,13 +37420,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_59"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -37481,9 +37442,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_7_62"
@@ -37496,36 +37457,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_64"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 64.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_65"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_67"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -37539,31 +37497,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_69"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_70"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_71"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_72"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_73"
       elif (
@@ -37576,7 +37534,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -37586,22 +37544,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_75"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -37609,22 +37567,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_80"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -37639,8 +37597,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_82"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -37655,7 +37613,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -37670,8 +37628,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_86"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -37686,24 +37644,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_88"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_90"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -37714,16 +37672,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_91"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_92"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 54.0)
+        and (last_rsi_14 < 54.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -37732,13 +37690,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_93"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -37750,7 +37708,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -37758,16 +37716,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_96"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -37775,7 +37733,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_15m"] > 68.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -37783,17 +37741,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -37801,32 +37759,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_101"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_102"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 60.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_103"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -37834,7 +37792,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_104"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -37842,8 +37800,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_105"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -37851,25 +37809,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_106"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_107"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_108"
       elif (
         (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_109"
       elif (
@@ -37881,22 +37839,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
         (last_rsi_3 > 46.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_7_111"
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -35.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
@@ -37905,20 +37863,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_7_113"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_114"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -37926,21 +37884,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_115"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_116"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_117"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -37948,28 +37906,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_119"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_120"
       elif (
-        (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_7_121"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -37977,13 +37932,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -37993,7 +37948,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -38001,14 +37956,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_125"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_126"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -38018,7 +37973,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_129"
       elif (
@@ -38029,15 +37984,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_130"
       elif (
-        (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_131"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -38047,13 +38002,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_133"
     elif 0.09 > current_profit >= 0.08:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -38066,7 +38021,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -38088,7 +38043,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_3"
       elif (
         (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -38101,7 +38056,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_4"
       elif (
         (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -38109,16 +38064,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
       elif (
@@ -38127,35 +38082,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_8_8"
       elif (
         (last_candle["WILLR_14"] > -5.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_9"
       elif (
         (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_10"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_8_11"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -38170,7 +38125,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_14"
-      elif (last_rsi_3 > 92.0) and (last_candle["RSI_14"] > 64.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_14 > 64.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
         (last_rsi_3 > 85.0)
@@ -38183,21 +38138,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_17"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_8_18"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -38207,15 +38162,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_19"
       elif (
         (last_rsi_3 > 48.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_20"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_21"
@@ -38224,19 +38179,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -4.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -38262,45 +38217,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_27"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_29"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_30"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_31"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -38337,8 +38292,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_36"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -38360,7 +38315,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -38371,16 +38326,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_41"
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -38389,8 +38344,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -38403,14 +38358,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
-      elif (last_rsi_3 > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 92.0) and (last_candle["WILLR_14"] > -8.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_8_45"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -38420,13 +38375,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_8_47"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -38451,24 +38406,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_50"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_8_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -38478,7 +38433,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_53"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -38488,31 +38443,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -16.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_55"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 38.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_58"
@@ -38520,13 +38475,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_59"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -38542,9 +38497,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_8_62"
@@ -38557,36 +38512,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_64"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 66.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_65"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_67"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -38600,31 +38552,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_69"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_70"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_71"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_72"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_73"
       elif (
@@ -38637,7 +38589,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -38647,22 +38599,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_75"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -18.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -38670,22 +38622,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_80"
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -38700,8 +38652,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_82"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -38716,7 +38668,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -38731,8 +38683,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_86"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -38747,24 +38699,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_88"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_90"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -38775,16 +38727,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_91"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_92"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 52.0)
+        and (last_rsi_14 < 52.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -38793,13 +38745,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_93"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -38811,7 +38763,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -38819,16 +38771,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_95"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_96"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -38836,7 +38788,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -38844,17 +38796,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -38862,32 +38814,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -18.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_101"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_102"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 58.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 58.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_103"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -38895,7 +38847,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -38903,8 +38855,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -38912,25 +38864,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_107"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_109"
       elif (
@@ -38942,22 +38894,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
         (last_rsi_3 > 48.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_8_111"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -30.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
@@ -38966,20 +38918,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_8_113"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -38987,21 +38939,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_115"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_116"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_117"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -39009,28 +38961,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_119"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_120"
       elif (
-        (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_8_121"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -39038,13 +38987,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -39054,7 +39003,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -39062,14 +39011,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_125"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_126"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -39079,7 +39028,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_129"
       elif (
@@ -39090,15 +39039,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_130"
       elif (
-        (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_131"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -39108,13 +39057,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_133"
     elif 0.1 > current_profit >= 0.09:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -39127,7 +39076,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 68.0)
+        and (last_rsi_14 > 68.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -39149,7 +39098,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_3"
       elif (
         (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -39162,7 +39111,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_4"
       elif (
         (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -39170,16 +39119,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
       elif (
@@ -39188,35 +39137,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_9_8"
       elif (
         (last_candle["WILLR_14"] > -4.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_9"
       elif (
         (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_10"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_9_11"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -39231,7 +39180,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_14"
-      elif (last_rsi_3 > 94.0) and (last_candle["RSI_14"] > 66.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_14 > 66.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
         (last_rsi_3 > 90.0)
@@ -39244,21 +39193,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_17"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_9_18"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -39268,15 +39217,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_19"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_20"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_21"
@@ -39285,19 +39234,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14"] > 72.0)
+        and (last_rsi_14 > 72.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -39323,45 +39272,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_27"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_29"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_30"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_31"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -39398,8 +39347,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_36"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -39421,7 +39370,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -39432,16 +39381,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_41"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -39450,8 +39399,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -39464,14 +39413,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
-      elif (last_rsi_3 > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 94.0) and (last_candle["WILLR_14"] > -6.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_9_45"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -39481,13 +39430,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_9_47"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -39512,24 +39461,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_50"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_9_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -39539,7 +39488,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_53"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -39549,31 +39498,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -14.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_55"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 36.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 36.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_58"
@@ -39581,13 +39530,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_59"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -39603,9 +39552,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_9_62"
@@ -39618,36 +39567,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_64"
       elif (
-        (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 68.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_65"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_67"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -39661,31 +39607,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_69"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_70"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_71"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_72"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_73"
       elif (
@@ -39698,7 +39644,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -39708,22 +39654,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_75"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -39731,22 +39677,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_80"
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -39761,8 +39707,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_82"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -39777,7 +39723,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -39792,8 +39738,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_86"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -39808,24 +39754,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_88"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_90"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -39836,16 +39782,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_91"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_92"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -39854,13 +39800,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_93"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -39872,7 +39818,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -39880,16 +39826,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_95"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_96"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -39897,7 +39843,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_15m"] > 72.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -39905,17 +39851,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_98"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_14"] > 76.0)
+        and (last_rsi_14 > 76.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -39923,32 +39869,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -16.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_101"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_102"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 56.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 56.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_103"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -39956,7 +39902,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_104"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -39964,8 +39910,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_105"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -39973,25 +39919,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_106"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_107"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_108"
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_109"
       elif (
@@ -40003,22 +39949,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_9_111"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
@@ -40027,20 +39973,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_9_113"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_114"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -40048,21 +39994,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_115"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_116"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_117"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -40070,28 +40016,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_119"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_120"
       elif (
-        (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_9_121"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -40099,13 +40042,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -40115,7 +40058,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -40123,14 +40066,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_125"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_126"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -40140,7 +40083,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_129"
       elif (
@@ -40151,15 +40094,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_130"
       elif (
-        (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_131"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -40169,13 +40112,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_133"
     elif 0.12 > current_profit >= 0.1:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -40188,7 +40131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 70.0)
+        and (last_rsi_14 > 70.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -40210,7 +40153,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_3"
       elif (
         (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_14"] > 76.0)
+        and (last_rsi_14 > 76.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -40223,7 +40166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_4"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -40231,16 +40174,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
       elif (
@@ -40249,35 +40192,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_10_8"
       elif (
         (last_candle["WILLR_14"] > -3.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_9"
       elif (
         (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_10"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_10_11"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -40292,7 +40235,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_14"
-      elif (last_rsi_3 > 96.0) and (last_candle["RSI_14"] > 68.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 68.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
         (last_rsi_3 > 95.0)
@@ -40305,21 +40248,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_17"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14"] > 76.0)
+        and (last_rsi_14 > 76.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_10_18"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -40329,15 +40272,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_19"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_20"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_21"
@@ -40346,19 +40289,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -40384,45 +40327,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_27"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_29"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_30"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_31"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -40459,8 +40402,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_36"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -40482,7 +40425,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -40493,16 +40436,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_41"
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -40511,8 +40454,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_42"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -40525,14 +40468,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
-      elif (last_rsi_3 > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 96.0) and (last_candle["WILLR_14"] > -4.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_10_45"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -40542,13 +40485,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_10_47"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -40573,24 +40516,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_50"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_10_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -40600,7 +40543,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_53"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -40610,31 +40553,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -12.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_55"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 34.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 34.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_58"
@@ -40642,13 +40585,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_59"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -40664,9 +40607,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_10_62"
@@ -40679,36 +40622,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_64"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 70.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_65"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_67"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -40722,31 +40662,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_69"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_70"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_71"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_72"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_73"
       elif (
@@ -40759,7 +40699,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -40769,22 +40709,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_75"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -40792,22 +40732,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_80"
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -40822,8 +40762,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_82"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -40838,7 +40778,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -40853,8 +40793,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_86"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -40869,24 +40809,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_88"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
       elif (
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_90"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -40897,16 +40837,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_91"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_92"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -40915,13 +40855,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_93"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -40933,7 +40873,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -40941,16 +40881,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_95"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_96"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -40958,7 +40898,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_15m"] > 74.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -40966,17 +40906,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_98"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -40984,32 +40924,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -14.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_101"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_102"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 54.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 54.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_103"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -41017,7 +40957,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_104"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -41025,8 +40965,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_105"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -41034,25 +40974,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_106"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_107"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_108"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_109"
       elif (
@@ -41064,22 +41004,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
         (last_rsi_3 > 52.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_10_111"
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
@@ -41088,20 +41028,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_10_113"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_114"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -41109,21 +41049,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_115"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_116"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_117"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -41131,28 +41071,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_119"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_120"
       elif (
-        (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_10_121"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -41160,13 +41097,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -41176,7 +41113,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -41184,14 +41121,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_125"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_126"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -41201,7 +41138,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_129"
       elif (
@@ -41212,15 +41149,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_130"
       elif (
-        (last_candle["RSI_14"] < 36.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 36.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_131"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -41230,13 +41167,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_133"
     elif 0.2 > current_profit >= 0.12:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -41249,7 +41186,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 74.0)
+        and (last_rsi_14 > 74.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -41271,7 +41208,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_3"
       elif (
         (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -41284,7 +41221,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_4"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 76.0)
+        and (last_rsi_14 > 76.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -41292,16 +41229,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
       elif (
@@ -41310,35 +41247,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_11_8"
       elif (
         (last_candle["WILLR_14"] > -2.0)
         and (last_rsi_3 > 95.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_9"
       elif (
         (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_10"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_11_11"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -41353,7 +41290,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_14"
-      elif (last_rsi_3 > 98.0) and (last_candle["RSI_14"] > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 98.0) and (last_rsi_14 > 70.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
         (last_rsi_3 > 98.0)
@@ -41366,21 +41303,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_17"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_11_18"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14"] > 76.0)
+        and (last_rsi_14 > 76.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -41390,15 +41327,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_19"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_20"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_21"
@@ -41407,19 +41344,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14"] > 76.0)
+        and (last_rsi_14 > 76.0)
         and (last_candle["WILLR_14"] > -5.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -41445,45 +41382,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_27"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_29"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_30"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_31"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -41520,8 +41457,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_36"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -41543,7 +41480,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -5.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -41554,16 +41491,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 97.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_41"
       elif (
         (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -41572,8 +41509,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_42"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -41586,14 +41523,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
-      elif (last_rsi_3 > 98.0) and (last_candle["WILLR_14"] > -2.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 98.0) and (last_candle["WILLR_14"] > -2.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_11_45"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -41603,13 +41540,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_11_47"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -41634,24 +41571,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_50"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_11_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -41661,7 +41598,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_53"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -41671,31 +41608,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_55"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 32.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 32.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_58"
@@ -41703,13 +41640,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_59"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -41725,9 +41662,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_11_62"
@@ -41740,36 +41677,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_64"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 72.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_65"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_67"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -41783,31 +41717,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_69"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 36.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 36.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_70"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_71"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_72"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_73"
       elif (
@@ -41820,7 +41754,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -41830,22 +41764,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_75"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -41853,22 +41787,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_80"
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -41883,8 +41817,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_82"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -41899,7 +41833,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -41914,8 +41848,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_86"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -41930,24 +41864,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_88"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
       elif (
         (last_rsi_3 > 96.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_90"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -41958,16 +41892,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_91"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_92"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -41976,13 +41910,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_93"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -41994,7 +41928,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -8.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -42002,16 +41936,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_95"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_96"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -42019,7 +41953,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_candle["RSI_3_15m"] > 76.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -42027,17 +41961,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_98"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 80.0)
+        and (last_rsi_14 > 80.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -42045,32 +41979,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_candle["WILLR_14"] > -12.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_101"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_102"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 52.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 52.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_103"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -42078,7 +42012,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_104"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -42086,8 +42020,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_105"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -42095,25 +42029,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_106"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_107"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_108"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_109"
       elif (
@@ -42125,22 +42059,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_11_111"
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["WILLR_14"] > -15.0)
-        and (last_candle["RSI_14"] < 48.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 48.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
@@ -42149,20 +42083,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_11_113"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_114"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -42170,21 +42104,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_115"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_116"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_117"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -42192,28 +42126,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_119"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_120"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_11_121"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -42221,13 +42152,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -42237,7 +42168,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -42245,14 +42176,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_125"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_126"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -42262,7 +42193,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_129"
       elif (
@@ -42273,15 +42204,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_130"
       elif (
-        (last_candle["RSI_14"] < 34.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 34.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_131"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -42291,13 +42222,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_133"
     elif current_profit >= 0.2:
       if (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
         )
@@ -42310,7 +42241,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_1"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
@@ -42332,7 +42263,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_3"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 80.0)
+        and (last_rsi_14 > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
         and (
@@ -42345,7 +42276,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_4"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["ROC_9_1h"] < -5.0)
         and (last_candle["ROC_9_4h"] < -5.0)
       ):
@@ -42353,16 +42284,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_6"
       elif (
-        (last_candle["RSI_14"] < 50.0)
+        (last_rsi_14 < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_7"
       elif (
@@ -42371,35 +42302,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_12_8"
       elif (
         (last_candle["WILLR_14"] > -1.0)
         and (last_rsi_3 > 99.0)
         and (last_candle["change_pct_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_9"
       elif (
         (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["ROC_9_1h"] < -10.0)
         and (last_candle["ROC_9_4h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_10"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] < 45.0)
+        and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
         and (last_candle["ROC_9_1h"] < -10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_12_11"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_9_1h"] < -20.0)
         and (last_candle["ROC_9_4h"] < -20.0)
@@ -42414,7 +42345,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_14"
-      elif (last_rsi_3 > 99.0) and (last_candle["RSI_14"] > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 75.0) and (last_candle["ROC_9_4h"] < -30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
         (last_rsi_3 > 99.0)
@@ -42427,21 +42358,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_17"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 80.0)
+        and (last_rsi_14 > 80.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["ROC_2_1d"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_12_18"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -42451,15 +42382,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_19"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_20"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_21"
@@ -42468,19 +42399,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["change_pct_4h"] < -5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
       elif (
         (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_1d"] < 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_14"] > 78.0)
+        and (last_rsi_14 > 78.0)
         and (last_candle["WILLR_14"] > -1.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
@@ -42506,45 +42437,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_27"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["RSI_3_15m"] < 10.0)
         and (last_candle["ROC_9_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_29"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_30"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_31"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -42581,8 +42512,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_36"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_1d"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -42604,7 +42535,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 30.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -42615,16 +42546,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_41"
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 70.0)
@@ -42633,8 +42564,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_42"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -42647,14 +42578,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] > -2.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
-      elif (last_rsi_3 > 99.0) and (last_candle["WILLR_14"] > -1.0) and (last_candle["RSI_3_1h"] < 10.0):
+      elif (last_rsi_3 > 99.0) and (last_candle["WILLR_14"] > -1.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_12_45"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 10.0)
         and (last_candle["ROC_2_1d"] < -20.0)
       ):
@@ -42664,13 +42595,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (last_candle["change_pct_1d"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_12_47"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -42695,24 +42626,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_50"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["WILLR_14"] > -10.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_12_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 50.0)
+        and (last_rsi_14 < 50.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -42722,7 +42653,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_53"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["ROC_9_4h"] < -10.0)
         and (last_candle["change_pct_1d"] < -10.0)
@@ -42732,31 +42663,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_candle["WILLR_14"] > -8.0)
         and (last_candle["ROC_9_4h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_55"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_56"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (last_rsi_14 < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_58"
@@ -42764,13 +42695,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_candle["WILLR_14"] > -6.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_59"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["RSI_14_4h"] > 65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 50.0)
@@ -42786,9 +42717,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_candle["change_pct_1d"] < -5.0)
       ):
         return True, f"exit_{mode_name}_d_12_62"
@@ -42801,36 +42732,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_64"
       elif (
-        (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 36.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
-        and (last_candle["RSI_3_4h"] < 15.0)
+        (last_rsi_3 > 74.0) and (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_candle["RSI_3_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_65"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_67"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["ROC_2_4h"] < -30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
@@ -42844,31 +42772,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_69"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 34.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 34.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_70"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_71"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 36.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_14 < 36.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["AROONU_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_72"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 15.0)
         and (last_candle["ROC_9_4h"] < -20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_73"
       elif (
@@ -42881,7 +42809,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -42891,22 +42819,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_75"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["ROC_9_1h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 20.0)
         and (last_candle["RSI_3_1d"] < 20.0)
       ):
@@ -42914,22 +42842,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 30.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_80"
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -4.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
       ):
@@ -42944,8 +42872,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_82"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
       ):
@@ -42960,7 +42888,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 30.0)
+        and (last_rsi_3_1h < 30.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -42975,8 +42903,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_86"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
@@ -42991,24 +42919,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_88"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
       elif (
         (last_rsi_3 > 98.0)
         and (last_candle["WILLR_14"] > -25.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_90"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 25.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (
@@ -43019,16 +42947,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_91"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 25.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_92"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["RSI_3_15m"] < 50.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
@@ -43037,13 +42965,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 90.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_93"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 25.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 25.0)
         and (last_candle["RSI_3_4h"] < 45.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (
@@ -43055,7 +42983,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -6.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
         and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
@@ -43063,16 +42991,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_95"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 45.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 45.0)
         and (last_candle["RSI_3_1d"] < 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_96"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 40.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
       ):
@@ -43080,7 +43008,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_candle["RSI_3_15m"] > 78.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["RSI_3_1d"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -43088,17 +43016,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_98"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 65.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 65.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14"] > 82.0)
+        and (last_rsi_14 > 82.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["RSI_3_4h"] < 80.0)
       ):
@@ -43106,32 +43034,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 40.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_101"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_102"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 50.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 50.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_103"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -43139,7 +43067,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_104"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_3_15m"] < 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 90.0)
         and (last_candle["ROC_9_4h"] > 25.0)
@@ -43147,8 +43075,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_105"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["ROC_9_4h"] > 40.0)
@@ -43156,25 +43084,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_106"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 70.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_107"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_108"
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -2.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_109"
       elif (
@@ -43186,22 +43114,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_candle["RSI_14"] < 38.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_14 < 38.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["RSI_14_4h"] > 70.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_12_111"
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["WILLR_14"] > -10.0)
-        and (last_candle["RSI_14"] < 46.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_14 < 46.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["RSI_3_1d"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
@@ -43210,20 +43138,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] > 10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_12_113"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14"] < 44.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_14 < 44.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_114"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
@@ -43231,21 +43159,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_115"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["AROONU_14_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_116"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
+        and (last_rsi_3_1h < 50.0)
         and (last_candle["AROONU_14_1h"] > 80.0)
         and (last_candle["AROONU_14_4h"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_117"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["AROONU_14_4h"] > 40.0)
       ):
@@ -43253,28 +43181,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["WILLR_14"] > -20.0)
-        and (last_candle["RSI_3_1h"] < 60.0)
+        and (last_rsi_3_1h < 60.0)
         and (last_candle["RSI_3_4h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_119"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_candle["RSI_14"] < 42.0)
-        and (last_candle["RSI_3_1h"] < 40.0)
+        and (last_rsi_14 < 42.0)
+        and (last_rsi_3_1h < 40.0)
         and (last_candle["AROONU_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_120"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14"] < 40.0)
-        and (last_candle["RSI_3_1h"] < 50.0)
-        and (last_candle["RSI_14_4h"] > 85.0)
+        (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_12_121"
       elif (
         (last_rsi_3 > 64.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
       ):
@@ -43282,13 +43207,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_1d"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] > 80.0)
@@ -43298,7 +43223,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["WILLR_14"] > -1.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["RSI_3_1d"] < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
@@ -43306,14 +43231,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_125"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_1h"] < 15.0)
+        and (last_rsi_3_1h < 15.0)
         and (last_candle["RSI_3_4h"] < 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_126"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_1h"] < 10.0)
+        and (last_rsi_3_1h < 10.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["RSI_3_1d"] < 40.0)
       ):
@@ -43323,7 +43248,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_candle["RSI_3_4h"] < 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_129"
       elif (
@@ -43334,15 +43259,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_130"
       elif (
-        (last_candle["RSI_14"] < 32.0)
-        and (last_candle["RSI_3_1h"] < 20.0)
+        (last_rsi_14 < 32.0)
+        and (last_rsi_3_1h < 20.0)
         and (last_candle["RSI_3_4h"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_131"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_1h"] < 35.0)
+        and (last_rsi_3_1h < 35.0)
         and (last_candle["RSI_3_4h"] < 35.0)
         and (last_candle["AROONU_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 40.0)
@@ -43352,7 +43277,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
         and (last_candle["AROONU_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_133"
 


### PR DESCRIPTION
## Summary
- Reuses local values for `ROC_9_1d`, `RSI_3_1h`, and `RSI_14` in `long_exit_dec()`.
- Replaces 2,652 repeated direct candle-field reads with local value references.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same long-exit formulas, thresholds, condition order, candle selection, output signal names, and return behavior.
- The patch only reuses the same `last_candle[...]` values already read from the same candle row inside the same `long_exit_dec()` call.
- A normalized AST check was used for the large diff: after removing the new locals and replacing them back to their `last_candle[...]` reads, `long_exit_dec()` matches the base version.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact same-call candle-field reuse: the same row values are read once and reused by existing comparisons without changing thresholds, formulas, condition order, candle selection, or signal names.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- normalized AST equivalence check for `long_exit_dec()` after inverting the local-field substitutions
