### PR TITLE
Reuse X7 core short-exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -55759,10 +55759,13 @@ class NostalgiaForInfinityX7(IStrategy):
     buy_tag,
   ) -> tuple:
     last_rsi_3 = last_candle["RSI_3"]
+    last_roc_9_1d = last_candle["ROC_9_1d"]
+    last_rsi_3_1h = last_candle["RSI_3_1h"]
+    last_rsi_14 = last_candle["RSI_14"]
     if 0.01 > current_profit >= 0.001:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -55775,7 +55778,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
         (last_candle["WILLR_14"] <= -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -55797,7 +55800,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
         (last_candle["WILLR_14"] <= -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -55810,7 +55813,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_4"
       elif (
         (last_candle["WILLR_14"] <= -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -55818,16 +55821,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_7"
       elif (
@@ -55836,35 +55839,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
         (last_candle["WILLR_14"] < -99.0)
         and (last_rsi_3 < 1.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_10"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -55879,7 +55882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_14"
-      elif (last_rsi_3 < 1.0) and (last_candle["RSI_14"] < 22.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
         (last_rsi_3 < 1.0)
@@ -55892,21 +55895,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_0_17"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] < 25.0)
+        and (last_rsi_14 < 25.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -55916,15 +55919,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_19"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_20"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_21"
@@ -55933,19 +55936,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -55971,45 +55974,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_27"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_29"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_31"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -56046,8 +56049,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -56069,7 +56072,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -56080,16 +56083,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -56098,8 +56101,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -56112,14 +56115,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_0_45"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -56129,13 +56132,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_0_47"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -56160,24 +56163,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_50"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -56187,7 +56190,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -56197,31 +56200,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 66.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 66.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_58"
@@ -56229,13 +56232,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_59"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -56251,9 +56254,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_62"
@@ -56266,36 +56269,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_0_65"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -56309,31 +56309,28 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_69"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_70"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_71"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
@@ -56346,7 +56343,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -56356,22 +56353,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_75"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -56379,22 +56376,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -56409,8 +56406,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_82"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -56425,7 +56422,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -56440,8 +56437,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -56456,24 +56453,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_90"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -56484,16 +56481,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_91"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_92"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -56502,13 +56499,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_93"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -56520,7 +56517,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -56528,16 +56525,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -56545,7 +56542,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_15m"] < 26.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -56553,17 +56550,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -56571,32 +56568,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_101"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_102"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_103"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -56604,7 +56601,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -56612,8 +56609,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -56621,25 +56618,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_107"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
       elif (
@@ -56651,22 +56648,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
@@ -56675,20 +56672,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_113"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -56696,21 +56693,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_115"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_116"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_117"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -56718,28 +56715,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_119"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        (last_rsi_3 < 5.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 60.0) and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_120"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 5.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_121"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -56747,13 +56738,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -56763,7 +56754,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -56771,14 +56762,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_125"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_126"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -56788,7 +56779,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
@@ -56799,15 +56790,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_130"
       elif (
-        (last_candle["RSI_14"] > 64.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 64.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -56817,13 +56808,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_133"
     elif 0.02 > current_profit >= 0.01:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -56836,7 +56827,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -56858,7 +56849,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_3"
       elif (
         (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_14"] < 35.0)
+        and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -56871,7 +56862,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_4"
       elif (
         (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -56879,16 +56870,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
       elif (
@@ -56897,35 +56888,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_1_8"
       elif (
         (last_candle["WILLR_14"] < -98.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_9"
       elif (
         (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_1_10"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_1_11"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -56940,7 +56931,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_14"
-      elif (last_rsi_3 < 5.0) and (last_candle["RSI_14"] < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
         (last_rsi_3 < 5.0)
@@ -56953,21 +56944,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_1_17"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_18"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -56977,15 +56968,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_19"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_20"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_21"
@@ -56994,19 +56985,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] < 25.0)
+        and (last_rsi_14 < 25.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -57032,45 +57023,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_27"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_29"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_30"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_31"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -57107,8 +57098,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_36"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -57130,7 +57121,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -57141,16 +57132,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_41"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -57159,8 +57150,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -57173,14 +57164,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
-      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_1_45"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -57190,13 +57181,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_1_47"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -57221,24 +57212,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_50"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_1_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -57248,7 +57239,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_53"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -57258,31 +57249,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 64.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 64.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_58"
@@ -57290,13 +57281,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_59"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -57312,9 +57303,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_62"
@@ -57327,36 +57318,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_64"
       elif (
-        (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_1_65"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_67"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -57370,31 +57358,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_69"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_70"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_71"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_72"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_73"
       elif (
@@ -57407,7 +57395,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -57417,22 +57405,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_75"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -57440,22 +57428,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_80"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -57470,8 +57458,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_82"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -57486,7 +57474,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -57501,8 +57489,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_86"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -57517,24 +57505,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_88"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_90"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -57545,16 +57533,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_91"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_92"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -57563,13 +57551,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_93"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -57581,7 +57569,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -57589,16 +57577,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_95"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_96"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -57606,7 +57594,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_15m"] < 28.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -57614,17 +57602,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_98"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_14"] < 24.0)
+        and (last_rsi_14 < 24.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -57632,32 +57620,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_101"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_102"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_103"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -57665,7 +57653,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_104"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -57673,8 +57661,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_105"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -57682,25 +57670,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_106"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_107"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_108"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_109"
       elif (
@@ -57712,22 +57700,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_1_111"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
@@ -57736,20 +57724,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_113"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_114"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -57757,21 +57745,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_115"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_116"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_117"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -57779,28 +57767,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_119"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_120"
       elif (
-        (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_121"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -57808,13 +57793,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -57824,7 +57809,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -57832,14 +57817,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_125"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_126"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -57849,7 +57834,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_129"
       elif (
@@ -57860,15 +57845,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_130"
       elif (
-        (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_131"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -57878,13 +57863,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_133"
     elif 0.03 > current_profit >= 0.02:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -57897,7 +57882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -57919,7 +57904,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_3"
       elif (
         (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_14"] < 35.0)
+        and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -57932,7 +57917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_4"
       elif (
         (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -57940,16 +57925,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
       elif (
@@ -57958,35 +57943,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_2_8"
       elif (
         (last_candle["WILLR_14"] < -96.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_9"
       elif (
         (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_2_10"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_2_11"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -58001,7 +57986,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_14"
-      elif (last_rsi_3 < 8.0) and (last_candle["RSI_14"] < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
         (last_rsi_3 < 30.0)
@@ -58014,21 +57999,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_2_17"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_18"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -58038,15 +58023,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_19"
       elif (
         (last_rsi_3 < 52.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_20"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_21"
@@ -58055,19 +58040,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -58093,45 +58078,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_27"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_29"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_30"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_31"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -58168,8 +58153,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_36"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -58191,7 +58176,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -58202,16 +58187,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_41"
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -58220,8 +58205,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -58234,14 +58219,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
-      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_2_45"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -58251,13 +58236,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_2_47"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -58282,24 +58267,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_50"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_2_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -58309,7 +58294,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_53"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -58319,31 +58304,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 62.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_58"
@@ -58351,13 +58336,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_59"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -58373,9 +58358,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_62"
@@ -58388,36 +58373,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_64"
       elif (
-        (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_2_65"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_67"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -58431,31 +58413,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_69"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_70"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_71"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_72"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_73"
       elif (
@@ -58468,7 +58450,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -58478,22 +58460,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_75"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -58501,22 +58483,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_80"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -58531,8 +58513,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_82"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -58547,7 +58529,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -58562,8 +58544,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_86"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -58578,24 +58560,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_88"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_90"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -58606,16 +58588,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_91"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_92"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -58624,13 +58606,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_93"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -58642,7 +58624,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -58650,16 +58632,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_95"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_96"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -58667,7 +58649,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -58675,17 +58657,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -58693,32 +58675,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_101"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_102"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_103"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -58726,7 +58708,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -58734,8 +58716,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -58743,25 +58725,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_107"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_109"
       elif (
@@ -58773,22 +58755,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
         (last_rsi_3 < 52.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_2_111"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
@@ -58797,20 +58779,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_113"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -58818,21 +58800,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_115"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_116"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_117"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -58840,28 +58822,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_119"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_120"
       elif (
-        (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_121"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -58869,13 +58848,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -58885,7 +58864,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -58893,14 +58872,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_125"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_126"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -58910,7 +58889,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_129"
       elif (
@@ -58921,15 +58900,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_130"
       elif (
-        (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_131"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -58939,13 +58918,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_133"
     elif 0.04 > current_profit >= 0.03:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -58958,7 +58937,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -58980,7 +58959,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
         (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_14"] < 35.0)
+        and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -58993,7 +58972,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_4"
       elif (
         (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -59001,16 +58980,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
@@ -59019,35 +58998,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
         (last_candle["WILLR_14"] < -94.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
         (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_3_10"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_3_11"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -59062,7 +59041,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_14"
-      elif (last_rsi_3 < 10.0) and (last_candle["RSI_14"] < 35.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 35.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
         (last_rsi_3 < 30.0)
@@ -59075,21 +59054,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_3_17"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -59099,15 +59078,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_19"
       elif (
         (last_rsi_3 < 54.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_20"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_21"
@@ -59116,19 +59095,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -59154,45 +59133,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_27"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_29"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_31"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -59229,8 +59208,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -59252,7 +59231,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -59263,16 +59242,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_41"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -59281,8 +59260,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -59295,14 +59274,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_3_45"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -59312,13 +59291,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_3_47"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -59343,24 +59322,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_50"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -59370,7 +59349,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -59380,31 +59359,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 60.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_58"
@@ -59412,13 +59391,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_59"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -59434,9 +59413,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_62"
@@ -59449,36 +59428,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
       elif (
-        (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_3_65"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -59492,31 +59468,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_69"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_70"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_71"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_72"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_73"
       elif (
@@ -59529,7 +59505,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -59539,22 +59515,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_75"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -59562,22 +59538,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -59592,8 +59568,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -59608,7 +59584,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -59623,8 +59599,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -59639,24 +59615,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_88"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_90"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -59667,16 +59643,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_91"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_92"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -59685,13 +59661,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_93"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -59703,7 +59679,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -59711,16 +59687,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -59728,7 +59704,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_15m"] < 32.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -59736,17 +59712,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -59754,32 +59730,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_101"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_102"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 40.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_103"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -59787,7 +59763,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -59795,8 +59771,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -59804,25 +59780,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_107"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
       elif (
@@ -59834,22 +59810,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 < 54.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_3_111"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
@@ -59858,20 +59834,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_113"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_114"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -59879,21 +59855,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_115"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_116"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_117"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -59901,28 +59877,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_119"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_120"
       elif (
-        (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_121"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -59930,13 +59903,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -59946,7 +59919,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -59954,14 +59927,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_125"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_126"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -59971,7 +59944,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
@@ -59982,15 +59955,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_130"
       elif (
-        (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -60000,13 +59973,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_133"
     elif 0.05 > current_profit >= 0.04:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -60019,7 +59992,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -60041,7 +60014,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_3"
       elif (
         (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_14"] < 35.0)
+        and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -60054,7 +60027,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_4"
       elif (
         (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -60062,16 +60035,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
       elif (
@@ -60080,35 +60053,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_4_8"
       elif (
         (last_candle["WILLR_14"] < -93.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_9"
       elif (
         (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_4_10"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_4_11"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -60123,7 +60096,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_14"
-      elif (last_rsi_3 < 12.0) and (last_candle["RSI_14"] < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
         (last_rsi_3 < 30.0)
@@ -60136,21 +60109,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_4_17"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_18"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -60160,15 +60133,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_19"
       elif (
         (last_rsi_3 < 56.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_20"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_21"
@@ -60177,19 +60150,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -60215,45 +60188,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_27"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_29"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_30"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_31"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -60290,8 +60263,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_36"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -60313,7 +60286,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -60324,16 +60297,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_41"
       elif (
         (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -60342,8 +60315,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -60356,14 +60329,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
-      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_4_45"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -60373,13 +60346,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_4_47"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -60404,24 +60377,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_50"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_4_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -60431,7 +60404,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_53"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -60441,31 +60414,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 58.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_58"
@@ -60473,13 +60446,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_59"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -60495,9 +60468,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_62"
@@ -60510,36 +60483,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_64"
       elif (
-        (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_4_65"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_67"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -60553,31 +60523,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_69"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_70"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_71"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_72"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_73"
       elif (
@@ -60590,7 +60560,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -60600,22 +60570,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_75"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 44.0)
+        and (last_rsi_14 > 44.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_77"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -78.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -60623,22 +60593,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_80"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -60653,8 +60623,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_82"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -60669,7 +60639,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -60684,8 +60654,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_86"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -60700,24 +60670,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_88"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_90"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -60728,16 +60698,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_91"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_92"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 44.0)
+        and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -60746,13 +60716,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_93"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -60764,7 +60734,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -60772,16 +60742,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_96"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -60789,7 +60759,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_15m"] < 34.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -60797,17 +60767,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_98"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -60815,32 +60785,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -78.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_101"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_102"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 38.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 38.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_103"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -60848,7 +60818,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_104"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -60856,8 +60826,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_105"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -60865,25 +60835,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_106"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_107"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_108"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_109"
       elif (
@@ -60895,22 +60865,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
         (last_rsi_3 < 56.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_4_111"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -60.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
@@ -60919,20 +60889,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_113"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_114"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -60940,21 +60910,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_115"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_116"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_117"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -60962,28 +60932,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_119"
       elif (
         (last_rsi_3 < 52.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_120"
       elif (
-        (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_121"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -60991,13 +60958,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -61007,7 +60974,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -61015,14 +60982,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_125"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_126"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -61032,7 +60999,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_129"
       elif (
@@ -61043,15 +61010,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_130"
       elif (
-        (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_131"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -61061,13 +61028,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_133"
     elif 0.06 > current_profit >= 0.05:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -61080,7 +61047,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -61102,7 +61069,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
         (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_14"] < 35.0)
+        and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -61115,7 +61082,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_4"
       elif (
         (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -61123,16 +61090,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
@@ -61141,35 +61108,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_5_8"
       elif (
         (last_candle["WILLR_14"] < -92.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_9"
       elif (
         (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_5_10"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_5_11"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -61184,7 +61151,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_14"
-      elif (last_rsi_3 < 14.0) and (last_candle["RSI_14"] > 58.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_14 > 58.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
         (last_rsi_3 < 30.0)
@@ -61197,21 +61164,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_5_17"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -61221,15 +61188,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_19"
       elif (
         (last_rsi_3 < 58.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_20"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_21"
@@ -61238,19 +61205,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
       elif (
         (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -61276,45 +61243,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_27"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_29"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_31"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -61351,8 +61318,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -61374,7 +61341,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -61385,16 +61352,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_41"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -61403,8 +61370,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -61417,14 +61384,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_rsi_3 < 14.0) and (last_candle["WILLR_14"] < -86.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 14.0) and (last_candle["WILLR_14"] < -86.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_5_45"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -61434,13 +61401,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_5_47"
       elif (
         (last_rsi_3 < 55.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -61465,24 +61432,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_50"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] < 48.0)
+        and (last_rsi_14 < 48.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -61492,7 +61459,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -61502,31 +61469,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -78.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 56.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_58"
@@ -61534,13 +61501,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_59"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -61556,9 +61523,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_62"
@@ -61571,36 +61538,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
       elif (
-        (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_5_65"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -61614,31 +61578,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_69"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_70"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_71"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_73"
       elif (
@@ -61651,7 +61615,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -61661,22 +61625,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_75"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 42.0)
+        and (last_rsi_14 > 42.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -76.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -61684,22 +61648,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -61714,8 +61678,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_82"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -61730,7 +61694,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -61745,8 +61709,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -61761,24 +61725,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_88"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_90"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -61789,16 +61753,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_91"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_92"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 42.0)
+        and (last_rsi_14 > 42.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -61807,13 +61771,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_93"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -61825,7 +61789,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -61833,16 +61797,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_95"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -61850,7 +61814,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_15m"] < 36.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -61858,17 +61822,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_98"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 40.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 40.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -61876,32 +61840,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -76.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_101"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_102"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 36.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 36.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -61909,7 +61873,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 44.0)
+        and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -61917,8 +61881,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -61926,25 +61890,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_107"
       elif (
         (last_rsi_3 < 52.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
         (last_rsi_3 < 32.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
       elif (
@@ -61956,22 +61920,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 < 58.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_5_111"
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -55.0)
-        and (last_candle["RSI_14"] > 40.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 40.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
@@ -61980,20 +61944,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_113"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_114"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 44.0)
+        and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -62001,21 +61965,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_115"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_116"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_117"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -62023,28 +61987,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_119"
       elif (
         (last_rsi_3 < 54.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_120"
       elif (
-        (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 48.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_121"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -62052,13 +62013,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -62068,7 +62029,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 32.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -62076,14 +62037,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_125"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_126"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -62093,7 +62054,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
@@ -62104,15 +62065,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_130"
       elif (
-        (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -62122,13 +62083,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_133"
     elif 0.07 > current_profit >= 0.06:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -62141,7 +62102,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -62163,7 +62124,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
         (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -62176,7 +62137,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_4"
       elif (
         (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -62184,16 +62145,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
       elif (
@@ -62202,35 +62163,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_6_8"
       elif (
         (last_candle["WILLR_14"] < -93.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_9"
       elif (
         (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_6_10"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_6_11"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -62245,7 +62206,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_14"
-      elif (last_rsi_3 < 12.0) and (last_candle["RSI_14"] < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
         (last_rsi_3 < 25.0)
@@ -62258,21 +62219,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_6_17"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] < 35.0)
+        and (last_rsi_14 < 35.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -62282,15 +62243,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_19"
       elif (
         (last_rsi_3 < 56.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_20"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_21"
@@ -62299,19 +62260,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -62337,45 +62298,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_27"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_29"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_31"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -62412,8 +62373,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -62435,7 +62396,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -62446,16 +62407,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_41"
       elif (
         (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -62464,8 +62425,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -62478,14 +62439,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_6_45"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -62495,13 +62456,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_6_47"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -62526,24 +62487,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_50"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] < 46.0)
+        and (last_rsi_14 < 46.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -62553,7 +62514,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -62563,31 +62524,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 58.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_58"
@@ -62595,13 +62556,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_59"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -62617,9 +62578,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_62"
@@ -62632,36 +62593,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
       elif (
-        (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_6_65"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -62675,31 +62633,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_69"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_70"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_71"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_72"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_73"
       elif (
@@ -62712,7 +62670,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -62722,22 +62680,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_75"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 44.0)
+        and (last_rsi_14 > 44.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -78.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -62745,22 +62703,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -62775,8 +62733,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_82"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -62791,7 +62749,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -62806,8 +62764,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -62822,24 +62780,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_88"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_90"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -62850,16 +62808,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_91"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_92"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 44.0)
+        and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -62868,13 +62826,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_93"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -62886,7 +62844,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -62894,16 +62852,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -62911,7 +62869,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_15m"] < 34.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -62919,17 +62877,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_98"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -62937,32 +62895,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -78.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_101"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_102"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 38.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 38.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_103"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -62970,7 +62928,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -62978,8 +62936,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -62987,25 +62945,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_107"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
       elif (
@@ -63017,22 +62975,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 < 56.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_6_111"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -60.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
@@ -63041,20 +62999,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_113"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_114"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -63062,21 +63020,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_115"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_116"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_117"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -63084,28 +63042,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_119"
       elif (
         (last_rsi_3 < 52.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_120"
       elif (
-        (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_121"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -63113,13 +63068,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -63129,7 +63084,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -63137,14 +63092,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_125"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_126"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -63154,7 +63109,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
@@ -63165,15 +63120,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_130"
       elif (
-        (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -63183,13 +63138,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_133"
     elif 0.08 > current_profit >= 0.07:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -63202,7 +63157,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -63224,7 +63179,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_3"
       elif (
         (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -63237,7 +63192,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_4"
       elif (
         (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -63245,16 +63200,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
       elif (
@@ -63263,35 +63218,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_7_8"
       elif (
         (last_candle["WILLR_14"] < -94.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_9"
       elif (
         (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_7_10"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_7_11"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -63306,7 +63261,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_14"
-      elif (last_rsi_3 < 10.0) and (last_candle["RSI_14"] < 38.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 38.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
         (last_rsi_3 < 20.0)
@@ -63319,21 +63274,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_7_17"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_18"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -63343,15 +63298,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_19"
       elif (
         (last_rsi_3 < 54.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_20"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_21"
@@ -63360,19 +63315,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -63398,45 +63353,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_27"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_29"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_30"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_31"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -63473,8 +63428,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_36"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -63496,7 +63451,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -63507,16 +63462,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_41"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -65.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -63525,8 +63480,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -63539,14 +63494,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
-      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_7_45"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -63556,13 +63511,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_7_47"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -63587,24 +63542,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_50"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] < 44.0)
+        and (last_rsi_14 < 44.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_7_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -63614,7 +63569,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_53"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -63624,31 +63579,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -82.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_55"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 60.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_58"
@@ -63656,13 +63611,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_59"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -63678,9 +63633,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_62"
@@ -63693,36 +63648,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_64"
       elif (
-        (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_7_65"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_67"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -63736,31 +63688,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_69"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_70"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_71"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_72"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_73"
       elif (
@@ -63773,7 +63725,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -63783,22 +63735,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_75"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -63806,22 +63758,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_80"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -63836,8 +63788,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_82"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -63852,7 +63804,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -63867,8 +63819,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_86"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -63883,24 +63835,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_88"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_90"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -63911,16 +63863,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_91"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_92"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 46.0)
+        and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -63929,13 +63881,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_93"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -63947,7 +63899,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -63955,16 +63907,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_96"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -63972,7 +63924,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_15m"] < 32.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -63980,17 +63932,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -63998,32 +63950,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_101"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_102"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 40.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_103"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -64031,7 +63983,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_104"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -64039,8 +63991,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_105"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -64048,25 +64000,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_106"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_107"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_108"
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_109"
       elif (
@@ -64078,22 +64030,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
         (last_rsi_3 < 54.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_7_111"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
@@ -64102,20 +64054,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_113"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_114"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -64123,21 +64075,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_115"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_116"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_117"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -64145,28 +64097,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_119"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_120"
       elif (
-        (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_121"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -64174,13 +64123,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -64190,7 +64139,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -64198,14 +64147,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_125"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_126"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -64215,7 +64164,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_129"
       elif (
@@ -64226,15 +64175,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_130"
       elif (
-        (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_131"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -64244,13 +64193,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_133"
     elif 0.09 > current_profit >= 0.08:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -64263,7 +64212,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -64285,7 +64234,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_3"
       elif (
         (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -64298,7 +64247,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_4"
       elif (
         (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -64306,16 +64255,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
       elif (
@@ -64324,35 +64273,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_8_8"
       elif (
         (last_candle["WILLR_14"] < -95.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_9"
       elif (
         (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_8_10"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_8_11"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -64367,7 +64316,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_14"
-      elif (last_rsi_3 < 8.0) and (last_candle["RSI_14"] < 36.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 36.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
         (last_rsi_3 < 15.0)
@@ -64380,21 +64329,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_8_17"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_18"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -64404,15 +64353,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_19"
       elif (
         (last_rsi_3 < 52.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_20"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_21"
@@ -64421,19 +64370,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -96.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -64459,45 +64408,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_27"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_29"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_30"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_31"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -64534,8 +64483,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_36"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -64557,7 +64506,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -64568,16 +64517,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_41"
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -64586,8 +64535,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -64600,14 +64549,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
-      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_8_45"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -64617,13 +64566,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_8_47"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -64648,24 +64597,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_50"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] < 42.0)
+        and (last_rsi_14 < 42.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_8_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -64675,7 +64624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_53"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -64685,31 +64634,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -84.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_55"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 62.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_58"
@@ -64717,13 +64666,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_59"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -64739,9 +64688,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_62"
@@ -64754,36 +64703,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_64"
       elif (
-        (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_8_65"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_67"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -64797,31 +64743,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_69"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_70"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_71"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_72"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_73"
       elif (
@@ -64834,7 +64780,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -64844,22 +64790,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_75"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -64867,22 +64813,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_80"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -64897,8 +64843,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_82"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -64913,7 +64859,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -64928,8 +64874,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_86"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -64944,24 +64890,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_88"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_90"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -64972,16 +64918,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_91"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_92"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 48.0)
+        and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -64990,13 +64936,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_93"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -65008,7 +64954,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -65016,16 +64962,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_95"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_96"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -65033,7 +64979,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -65041,17 +64987,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -65059,32 +65005,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_101"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_102"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 42.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 42.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_103"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -65092,7 +65038,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -65100,8 +65046,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -65109,25 +65055,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_107"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_109"
       elif (
@@ -65139,22 +65085,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
         (last_rsi_3 < 52.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_8_111"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
@@ -65163,20 +65109,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_113"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -65184,21 +65130,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_115"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_116"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_117"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -65206,28 +65152,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_119"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_120"
       elif (
-        (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_121"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -65235,13 +65178,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -65251,7 +65194,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -65259,14 +65202,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_125"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_126"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -65276,7 +65219,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_129"
       elif (
@@ -65287,15 +65230,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_130"
       elif (
-        (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_131"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -65305,13 +65248,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_133"
     elif 0.1 > current_profit >= 0.09:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -65324,7 +65267,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 32.0)
+        and (last_rsi_14 < 32.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -65346,7 +65289,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_3"
       elif (
         (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -65359,7 +65302,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_4"
       elif (
         (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -65367,16 +65310,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
       elif (
@@ -65385,35 +65328,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_9_8"
       elif (
         (last_candle["WILLR_14"] < -96.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_9"
       elif (
         (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_9_10"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_9_11"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -65428,7 +65371,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_14"
-      elif (last_rsi_3 < 6.0) and (last_candle["RSI_14"] < 34.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 34.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
         (last_rsi_3 < 10.0)
@@ -65441,21 +65384,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_9_17"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_18"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -65465,15 +65408,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_19"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_20"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_21"
@@ -65482,19 +65425,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14"] < 28.0)
+        and (last_rsi_14 < 28.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -65520,45 +65463,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_27"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_29"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_30"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_31"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -65595,8 +65538,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_36"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -65618,7 +65561,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -65629,16 +65572,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_41"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -65647,8 +65590,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -65661,14 +65604,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
-      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_9_45"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -65678,13 +65621,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_9_47"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -65709,24 +65652,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_50"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] < 40.0)
+        and (last_rsi_14 < 40.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_9_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -65736,7 +65679,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_53"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -65746,31 +65689,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -86.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_55"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 64.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 64.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_58"
@@ -65778,13 +65721,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_59"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -65800,9 +65743,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_62"
@@ -65815,36 +65758,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_64"
       elif (
-        (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_9_65"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_67"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -65858,31 +65798,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_69"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_70"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_71"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_72"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_73"
       elif (
@@ -65895,7 +65835,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -65905,22 +65845,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_75"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -65928,22 +65868,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_80"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -65958,8 +65898,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_82"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -65974,7 +65914,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -65989,8 +65929,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_86"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -66005,24 +65945,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_88"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_90"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -66033,16 +65973,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_91"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_92"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -66051,13 +65991,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_93"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -66069,7 +66009,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -66077,16 +66017,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_95"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_96"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -66094,7 +66034,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_15m"] < 28.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -66102,17 +66042,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_98"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_14"] < 24.0)
+        and (last_rsi_14 < 24.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -66120,32 +66060,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_101"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_102"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 44.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 44.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_103"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -66153,7 +66093,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_104"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -66161,8 +66101,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_105"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -66170,25 +66110,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_106"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_107"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_108"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_109"
       elif (
@@ -66200,22 +66140,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_9_111"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
@@ -66224,20 +66164,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_113"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_114"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -66245,21 +66185,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_115"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_116"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_117"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -66267,28 +66207,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_119"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_120"
       elif (
-        (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_121"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -66296,13 +66233,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -66312,7 +66249,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -66320,14 +66257,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_125"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_126"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -66337,7 +66274,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_129"
       elif (
@@ -66348,15 +66285,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_130"
       elif (
-        (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_131"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -66366,13 +66303,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_133"
     elif 0.12 > current_profit >= 0.1:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -66385,7 +66322,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 30.0)
+        and (last_rsi_14 < 30.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -66407,7 +66344,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_3"
       elif (
         (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_14"] < 24.0)
+        and (last_rsi_14 < 24.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -66420,7 +66357,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_4"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -66428,16 +66365,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
       elif (
@@ -66446,35 +66383,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_10_8"
       elif (
         (last_candle["WILLR_14"] < -97.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_9"
       elif (
         (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_10_10"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_10_11"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -66489,7 +66426,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_14"
-      elif (last_rsi_3 < 4.0) and (last_candle["RSI_14"] < 32.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 32.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
         (last_rsi_3 < 5.0)
@@ -66502,21 +66439,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_10_17"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14"] < 24.0)
+        and (last_rsi_14 < 24.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_18"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -66526,15 +66463,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_19"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_20"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_21"
@@ -66543,19 +66480,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -66581,45 +66518,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_27"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_29"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_30"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_31"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -66656,8 +66593,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_36"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -66679,7 +66616,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -66690,16 +66627,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_41"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -66708,8 +66645,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_42"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -66722,14 +66659,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
-      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_10_45"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -66739,13 +66676,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_10_47"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -66770,24 +66707,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_50"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] < 38.0)
+        and (last_rsi_14 < 38.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_10_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -66797,7 +66734,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_53"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -66807,31 +66744,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -88.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_55"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 66.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 66.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_58"
@@ -66839,13 +66776,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_59"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -66861,9 +66798,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_62"
@@ -66876,36 +66813,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_64"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 30.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_10_65"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_67"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -66919,31 +66853,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_69"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_70"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_71"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_72"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_73"
       elif (
@@ -66956,7 +66890,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -66966,22 +66900,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_75"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -66989,22 +66923,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_80"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -67019,8 +66953,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_82"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -67035,7 +66969,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -67050,8 +66984,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_86"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -67066,24 +67000,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_88"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_90"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -67094,16 +67028,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_91"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_92"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 52.0)
+        and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -67112,13 +67046,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_93"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -67130,7 +67064,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -67138,16 +67072,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_95"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_96"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -67155,7 +67089,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_15m"] < 26.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -67163,17 +67097,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_98"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -67181,32 +67115,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_101"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_102"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 46.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 46.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_103"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -67214,7 +67148,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_104"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -67222,8 +67156,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_105"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -67231,25 +67165,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_106"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_107"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_108"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_109"
       elif (
@@ -67261,22 +67195,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
         (last_rsi_3 < 48.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_10_111"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
@@ -67285,20 +67219,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_113"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_114"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -67306,21 +67240,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_115"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_116"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_117"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -67328,28 +67262,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_119"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_120"
       elif (
-        (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_121"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -67357,13 +67288,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -67373,7 +67304,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -67381,14 +67312,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_125"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_126"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -67398,7 +67329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_129"
       elif (
@@ -67409,15 +67340,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_130"
       elif (
-        (last_candle["RSI_14"] > 64.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 64.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_131"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -67427,13 +67358,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_133"
     elif 0.2 > current_profit >= 0.12:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -67446,7 +67377,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 26.0)
+        and (last_rsi_14 < 26.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -67468,7 +67399,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_3"
       elif (
         (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -67481,7 +67412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_4"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 24.0)
+        and (last_rsi_14 < 24.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -67489,16 +67420,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
       elif (
@@ -67507,35 +67438,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_11_8"
       elif (
         (last_candle["WILLR_14"] < -98.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_9"
       elif (
         (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_11_10"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_11_11"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -67550,7 +67481,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_14"
-      elif (last_rsi_3 < 2.0) and (last_candle["RSI_14"] < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
         (last_rsi_3 < 2.0)
@@ -67563,21 +67494,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_11_17"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_18"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14"] < 24.0)
+        and (last_rsi_14 < 24.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -67587,15 +67518,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_19"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_20"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_21"
@@ -67604,19 +67535,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14"] < 24.0)
+        and (last_rsi_14 < 24.0)
         and (last_candle["WILLR_14"] < -95.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -67642,45 +67573,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_27"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_29"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_30"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_31"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -67717,8 +67648,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_36"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -67740,7 +67671,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -67751,16 +67682,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 3.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_41"
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -67769,8 +67700,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_42"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -67783,14 +67714,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
-      elif (last_rsi_3 < 2.0) and (last_candle["WILLR_14"] < -98.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 2.0) and (last_candle["WILLR_14"] < -98.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_11_45"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -67800,13 +67731,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_11_47"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -67831,24 +67762,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_50"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] < 36.0)
+        and (last_rsi_14 < 36.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_11_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -67858,7 +67789,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_53"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -67868,31 +67799,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_55"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 68.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 68.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_58"
@@ -67900,13 +67831,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_59"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -67922,9 +67853,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_62"
@@ -67937,36 +67868,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_64"
       elif (
-        (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 28.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_11_65"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_67"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -67980,31 +67908,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_69"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 64.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 64.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_70"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_71"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_72"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_73"
       elif (
@@ -68017,7 +67945,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -68027,22 +67955,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_75"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -68050,22 +67978,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_80"
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -68080,8 +68008,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_82"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -68096,7 +68024,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -68111,8 +68039,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_86"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -68127,24 +68055,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_88"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_90"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -68155,16 +68083,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_91"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_92"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 54.0)
+        and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -68173,13 +68101,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_93"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -68191,7 +68119,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -68199,16 +68127,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_95"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_96"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -68216,7 +68144,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_15m"] < 24.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -68224,17 +68152,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_98"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 20.0)
+        and (last_rsi_14 < 20.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -68242,32 +68170,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_101"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_102"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 48.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 48.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_103"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -68275,7 +68203,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_104"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -68283,8 +68211,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_105"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -68292,25 +68220,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_106"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_107"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_108"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_109"
       elif (
@@ -68322,22 +68250,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
         (last_rsi_3 < 46.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_11_111"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_14"] > 52.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 52.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
@@ -68346,20 +68274,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_113"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_114"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -68367,21 +68295,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_115"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_116"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_117"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -68389,28 +68317,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_119"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_120"
       elif (
-        (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_121"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -68418,13 +68343,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -68434,7 +68359,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -68442,14 +68367,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_125"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_126"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -68459,7 +68384,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_129"
       elif (
@@ -68470,15 +68395,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_130"
       elif (
-        (last_candle["RSI_14"] > 66.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 66.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_131"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -68488,13 +68413,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_133"
     elif current_profit >= 0.2:
       if (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -68507,7 +68432,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_1"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -68529,7 +68454,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_3"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 20.0)
+        and (last_rsi_14 < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
         and (
@@ -68542,7 +68467,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_4"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["ROC_9_1h"] > 5.0)
         and (last_candle["ROC_9_4h"] > 5.0)
       ):
@@ -68550,16 +68475,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_6"
       elif (
-        (last_candle["RSI_14"] > 50.0)
+        (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_7"
       elif (
@@ -68568,35 +68493,35 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_12_8"
       elif (
         (last_candle["WILLR_14"] < -99.0)
         and (last_rsi_3 < 1.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_9"
       elif (
         (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
         and (last_candle["ROC_9_4h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_12_10"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] > 55.0)
+        and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_12_11"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
         and (last_candle["ROC_9_4h"] > 20.0)
@@ -68611,7 +68536,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_14"
-      elif (last_rsi_3 < 1.0) and (last_candle["RSI_14"] < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
         (last_rsi_3 < 1.0)
@@ -68624,21 +68549,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -30.0)
       ):
         return True, f"exit_{mode_name}_d_12_17"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 20.0)
+        and (last_rsi_14 < 20.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_18"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -68648,15 +68573,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_19"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_20"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_21"
@@ -68665,19 +68590,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
       elif (
         (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_14"] < 22.0)
+        and (last_rsi_14 < 22.0)
         and (last_candle["WILLR_14"] < -99.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
@@ -68703,45 +68628,45 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_27"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 90.0)
         and (last_candle["ROC_9_4h"] < -50.0)
       ):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_29"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_30"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_31"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -68778,8 +68703,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_36"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] < 80.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -68801,7 +68726,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -68812,16 +68737,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_41"
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
@@ -68830,8 +68755,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_42"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -68844,14 +68769,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["WILLR_14"] < -98.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
-      elif (last_rsi_3 < 1.0) and (last_candle["WILLR_14"] < -99.0) and (last_candle["RSI_3_1h"] > 90.0):
+      elif (last_rsi_3 < 1.0) and (last_candle["WILLR_14"] < -99.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_12_45"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 90.0)
         and (last_candle["ROC_2_1d"] > 20.0)
       ):
@@ -68861,13 +68786,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 5.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_12_47"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -68892,24 +68817,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_50"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] < 34.0)
+        and (last_rsi_14 < 34.0)
         and (last_candle["WILLR_14"] < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_12_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 50.0)
+        and (last_rsi_14 > 50.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -68919,7 +68844,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_53"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 60.0)
+        and (last_rsi_14 > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["ROC_9_4h"] > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
@@ -68929,31 +68854,31 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_candle["WILLR_14"] < -92.0)
         and (last_candle["ROC_9_4h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_55"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_56"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 30.0))
+        and (last_rsi_14 > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_58"
@@ -68961,13 +68886,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_candle["WILLR_14"] < -94.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 15.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_59"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["RSI_14_4h"] < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
@@ -68983,9 +68908,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_62"
@@ -68998,36 +68923,33 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_64"
       elif (
-        (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 64.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
+        (last_rsi_3 < 26.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
       ):
         return True, f"exit_{mode_name}_d_12_65"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["RSI_14"] > 64.0)
+        and (last_rsi_14 > 64.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_67"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
@@ -69041,31 +68963,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_69"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 66.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 66.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_70"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_71"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 64.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_14 > 64.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_72"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 85.0)
         and (last_candle["ROC_9_4h"] > 20.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_73"
       elif (
@@ -69078,7 +69000,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
@@ -69088,22 +69010,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_75"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["ROC_9_1h"] < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
@@ -69111,22 +69033,22 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 70.0)
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_80"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
@@ -69141,8 +69063,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_82"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
       ):
@@ -69157,7 +69079,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 70.0)
+        and (last_rsi_3_1h > 70.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -69172,8 +69094,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_86"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
@@ -69188,24 +69110,24 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_88"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 66.0)
+        and (last_rsi_14 > 66.0)
         and (last_candle["ROC_9_1h"] > 5.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_90"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (
@@ -69216,16 +69138,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_91"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_92"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 56.0)
+        and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
@@ -69234,13 +69156,13 @@ class NostalgiaForInfinityX7(IStrategy):
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
         )
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_93"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 75.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 75.0)
         and (last_candle["RSI_3_4h"] > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (
@@ -69252,7 +69174,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
@@ -69260,16 +69182,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_95"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 55.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_96"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 60.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
       ):
@@ -69277,7 +69199,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_15m"] < 22.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -69285,17 +69207,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_98"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 35.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 35.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14"] < 18.0)
+        and (last_rsi_14 < 18.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_candle["RSI_3_4h"] > 20.0)
       ):
@@ -69303,32 +69225,32 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_101"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -40.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_102"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 50.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 50.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_103"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -69336,7 +69258,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_104"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_15m"] > 45.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
         and (last_candle["ROC_9_4h"] < -25.0)
@@ -69344,8 +69266,8 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_105"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["ROC_9_4h"] < -40.0)
@@ -69353,25 +69275,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_106"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_107"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_108"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_3_4h"] > 80.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -50.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_109"
       elif (
@@ -69383,22 +69305,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
         (last_rsi_3 < 44.0)
-        and (last_candle["RSI_14"] > 62.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_14 > 62.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -20.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_12_111"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_14"] > 54.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_14 > 54.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -30.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
@@ -69407,20 +69329,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_3_1d"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
         and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] > 10.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_113"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14"] > 56.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_14 > 56.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_114"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_14"] > 58.0)
+        and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_15m"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
@@ -69428,21 +69350,21 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_115"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_116"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
+        and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
         and (last_candle["AROONU_14_4h"] < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_117"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
@@ -69450,28 +69372,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_1h"] > 40.0)
+        and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_3_4h"] > 40.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_119"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["RSI_14"] > 58.0)
-        and (last_candle["RSI_3_1h"] > 60.0)
+        and (last_rsi_14 > 58.0)
+        and (last_rsi_3_1h > 60.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_120"
       elif (
-        (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14"] > 60.0)
-        and (last_candle["RSI_3_1h"] > 50.0)
-        and (last_candle["RSI_14_4h"] < 15.0)
+        (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_121"
       elif (
         (last_rsi_3 < 36.0)
-        and (last_candle["RSI_14"] > 62.0)
+        and (last_rsi_14 > 62.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
       ):
@@ -69479,13 +69398,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (
           isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
           and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
@@ -69495,7 +69414,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
@@ -69503,14 +69422,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_125"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_1h"] > 85.0)
+        and (last_rsi_3_1h > 85.0)
         and (last_candle["RSI_3_4h"] > 60.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_126"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_1h"] > 90.0)
+        and (last_rsi_3_1h > 90.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["RSI_3_1d"] > 60.0)
       ):
@@ -69520,7 +69439,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_4h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -80.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_129"
       elif (
@@ -69531,15 +69450,15 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_130"
       elif (
-        (last_candle["RSI_14"] > 68.0)
-        and (last_candle["RSI_3_1h"] > 80.0)
+        (last_rsi_14 > 68.0)
+        and (last_rsi_3_1h > 80.0)
         and (last_candle["RSI_3_4h"] > 70.0)
         and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_131"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_1h"] > 65.0)
+        and (last_rsi_3_1h > 65.0)
         and (last_candle["RSI_3_4h"] > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
@@ -69549,7 +69468,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (isinstance(last_candle["ROC_9_1d"], np.float64) and (last_candle["ROC_9_1d"] < -25.0))
+        and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_133"
 


### PR DESCRIPTION
## Summary
- Reuses local values for `ROC_9_1d`, `RSI_3_1h`, and `RSI_14` in `short_exit_dec()`.
- Replaces 2,652 repeated direct candle-field reads with local value references.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same short-exit formulas, thresholds, condition order, candle selection, output signal names, and return behavior.
- The patch only reuses the same `last_candle[...]` values already read from the same candle row inside the same `short_exit_dec()` call.
- A normalized AST check was used for the large diff: after removing the new locals and replacing them back to their `last_candle[...]` reads, `short_exit_dec()` matches the base version.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact same-call candle-field reuse: the same row values are read once and reused by existing comparisons without changing thresholds, formulas, condition order, candle selection, or signal names.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- normalized AST equivalence check for `short_exit_dec()` after inverting the local-field substitutions
