### PR TITLE
Reuse X7 informative pair labels

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3207,7 +3207,8 @@ class NostalgiaForInfinityX7(IStrategy):
     assert self.dp, "DataProvider is required for multiple timeframes."
 
     # Get dataframe
-    informative_1d = self.dp.get_pair_dataframe(pair=metadata["pair"], timeframe=info_timeframe)
+    metadata_pair = metadata["pair"]
+    informative_1d = self.dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
 
     # Empty dataframe protection
     if informative_1d.empty:
@@ -3379,7 +3380,7 @@ class NostalgiaForInfinityX7(IStrategy):
         "low_min_30",
       ]
 
-      self.validate_indicators(df=informative_1d, columns=debug_cols, pair=metadata["pair"], timeframe=info_timeframe)
+      self.validate_indicators(df=informative_1d, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
 
     # =========================================================================
     # LOGGING
@@ -3387,7 +3388,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug("[%s] informative_1d_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
+    log.debug("[%s] informative_1d_indicators took: %.4f seconds.", metadata_pair, tok - tik)
 
     return informative_1d
 
@@ -3405,7 +3406,8 @@ class NostalgiaForInfinityX7(IStrategy):
     assert dp, "DataProvider is required for multiple timeframes."
 
     # Get dataframe
-    informative_4h = dp.get_pair_dataframe(pair=metadata["pair"], timeframe=info_timeframe)
+    metadata_pair = metadata["pair"]
+    informative_4h = dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
 
     # Empty dataframe protection
     if informative_4h.empty:
@@ -3626,14 +3628,14 @@ class NostalgiaForInfinityX7(IStrategy):
         "low_min_24",
       ]
 
-      validate_indicators(df=informative_4h, columns=debug_cols, pair=metadata["pair"], timeframe=info_timeframe)
+      validate_indicators(df=informative_4h, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
     # =========================================================================
     # LOGGING
     # =========================================================================
 
     tok = time.perf_counter()
 
-    log.debug("[%s] informative_4h_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
+    log.debug("[%s] informative_4h_indicators took: %.4f seconds.", metadata_pair, tok - tik)
 
     return informative_4h
 
@@ -3654,7 +3656,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # GET DATAFRAME
     # =========================================================================
 
-    informative_1h = dp.get_pair_dataframe(pair=metadata["pair"], timeframe=info_timeframe)
+    metadata_pair = metadata["pair"]
+    informative_1h = dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
 
     # Empty dataframe protection
     if informative_1h.empty:
@@ -3845,7 +3848,7 @@ class NostalgiaForInfinityX7(IStrategy):
         "low_min_24",
       ]
 
-      validate_indicators(df=informative_1h, columns=debug_cols, pair=metadata["pair"], timeframe=info_timeframe)
+      validate_indicators(df=informative_1h, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
 
     # =========================================================================
     # LOGGING
@@ -3853,7 +3856,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug("[%s] informative_1h_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
+    log.debug("[%s] informative_1h_indicators took: %.4f seconds.", metadata_pair, tok - tik)
 
     return informative_1h
 
@@ -3874,7 +3877,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # GET DATAFRAME
     # =========================================================================
 
-    informative_15m = dp.get_pair_dataframe(pair=metadata["pair"], timeframe=info_timeframe)
+    metadata_pair = metadata["pair"]
+    informative_15m = dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
 
     # Empty dataframe protection
     if informative_15m.empty:
@@ -4015,7 +4019,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # "bot_wick_pct",
       ]
 
-      validate_indicators(df=informative_15m, columns=debug_cols, pair=metadata["pair"], timeframe=info_timeframe)
+      validate_indicators(df=informative_15m, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
 
     # =========================================================================
     # LOGGING
@@ -4023,7 +4027,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug("[%s] informative_15m_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
+    log.debug("[%s] informative_15m_indicators took: %.4f seconds.", metadata_pair, tok - tik)
 
     return informative_15m
 
@@ -4031,6 +4035,7 @@ class NostalgiaForInfinityX7(IStrategy):
   # ---------------------------------------------------------------------------------------------
   def base_tf_5m_indicators(self, metadata: dict, df: DataFrame) -> DataFrame:
     tik = time.perf_counter()
+    metadata_pair = metadata["pair"]
 
     # =========================================================================
     # BASE DATA
@@ -4253,7 +4258,7 @@ class NostalgiaForInfinityX7(IStrategy):
         "num_empty_288",
       ]
 
-      self.validate_indicators(df=df, columns=debug_cols, pair=metadata["pair"], timeframe=self.timeframe)
+      self.validate_indicators(df=df, columns=debug_cols, pair=metadata_pair, timeframe=self.timeframe)
 
     # =========================================================================
     # GLOBAL PROTECTIONS
@@ -4271,7 +4276,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug("[%s] base_tf_5m_indicators took: %.4f seconds.", metadata["pair"], tok - tik)
+    log.debug("[%s] base_tf_5m_indicators took: %.4f seconds.", metadata_pair, tok - tik)
 
     return df
 
@@ -4293,6 +4298,7 @@ class NostalgiaForInfinityX7(IStrategy):
   # ---------------------------------------------------------------------------------------------
   def _btc_info_indicators(self, btc_info_pair: str, btc_info_timeframe: str, metadata: dict) -> DataFrame:
     tik = time.perf_counter()
+    metadata_pair = metadata["pair"]
 
     # -------------------------------------------------------------------------
     # LOAD DATA
@@ -4324,7 +4330,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     tok = time.perf_counter()
 
-    log.debug("[%s] btc_info_%s_indicators took: %.4f seconds.", metadata["pair"], btc_info_timeframe, tok - tik)
+    log.debug("[%s] btc_info_%s_indicators took: %.4f seconds.", metadata_pair, btc_info_timeframe, tok - tik)
 
     return df
 


### PR DESCRIPTION
## Summary
- Reuses a local `metadata_pair` value in the informative indicator helper functions.
- Applies the same pair label to dataframe loads, debug validation, and timing logs instead of repeatedly indexing `metadata["pair"]`.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same informative dataframe selection, indicator formulas, validation columns, logging text values, candle selection, thresholds, condition order, and return values.
- The patch only reuses the same metadata pair string already read inside each helper call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact metadata pair-label reuse in dataframe calls, validation calls, and logs; it does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
