### PR TITLE
Reuse X7 wrapper enter-tag reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -2030,8 +2030,10 @@ class NostalgiaForInfinityX7(IStrategy):
     previous_candle_5 = df.iloc[-6]
 
     enter_tag = "empty"
-    if hasattr(trade, "enter_tag") and trade.enter_tag is not None:
-      enter_tag = trade.enter_tag
+    if hasattr(trade, "enter_tag"):
+      trade_enter_tag = trade.enter_tag
+      if trade_enter_tag is not None:
+        enter_tag = trade_enter_tag
     enter_tags = enter_tag.split()
 
     filled_orders, filled_entries, filled_exits = filled_order_snapshot(trade)
@@ -2745,8 +2747,10 @@ class NostalgiaForInfinityX7(IStrategy):
       return None
 
     enter_tag = "empty"
-    if hasattr(trade, "enter_tag") and trade.enter_tag is not None:
-      enter_tag = trade.enter_tag
+    if hasattr(trade, "enter_tag"):
+      trade_enter_tag = trade.enter_tag
+      if trade_enter_tag is not None:
+        enter_tag = trade_enter_tag
     enter_tags = enter_tag.split()
 
     is_backtest = self.is_backtest_mode()


### PR DESCRIPTION
## Summary
- Reuses a local `trade_enter_tag` value in the custom-exit and adjust-position wrappers.
- Avoids reading `trade.enter_tag` twice after the optional attribute check succeeds.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same `"empty"` fallback, same enter-tag splitting, same mode dispatch order, same order snapshots, same profit arithmetic, same candle selection, and same return values.
- The patch only reuses the already-read optional trade enter tag inside each wrapper call.
- No indicator, CMF/math, threshold, stake-sizing, or order-classification logic is changed.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact wrapper attribute reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
