### PR TITLE
Reuse X7 profit-target order reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1195,6 +1195,7 @@ class NostalgiaForInfinityX7(IStrategy):
     long_scalp_mode_tags = self.long_scalp_mode_tags
     long_scalp_rebuy_grind_mode_tags = self.long_scalp_rebuy_grind_mode_tags
     trade_leverage = trade.leverage
+    select_filled_orders = trade.select_filled_orders
 
     is_backtest = self.is_backtest_mode()
     is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
@@ -1204,9 +1205,10 @@ class NostalgiaForInfinityX7(IStrategy):
       f"exit_{mode_name}_stoploss",
       f"exit_{mode_name}_stoploss_u_e",
     ]:
-      filled_entries = trade.select_filled_orders(trade.entry_side)
-      filled_exits = trade.select_filled_orders(trade.exit_side)
-      has_order_tags = hasattr(filled_entries[0], "ft_order_tag")
+      filled_entries = select_filled_orders(trade.entry_side)
+      filled_exits = select_filled_orders(trade.exit_side)
+      first_filled_entry = filled_entries[0]
+      has_order_tags = hasattr(first_filled_entry, "ft_order_tag")
       for order in filled_exits:
         order_tag = ""
         if has_order_tags:
@@ -1216,7 +1218,7 @@ class NostalgiaForInfinityX7(IStrategy):
           is_derisk = True
           break
       if not is_derisk:
-        is_derisk = trade.amount < (filled_entries[0].safe_filled * 0.95)
+        is_derisk = trade.amount < (first_filled_entry.safe_filled * 0.95)
     if previous_sell_reason in [f"exit_{mode_name}_stoploss_doom", f"exit_{mode_name}_stoploss"]:
       # return right away for system v3
       if is_system_v3 or is_system_v3_1 or is_system_v3_2:


### PR DESCRIPTION
## Summary
- Reuses a local filled-order helper in `exit_profit_target()` derisk detection.
- Reuses the first filled entry after the entry order list is loaded instead of indexing `filled_entries[0]` twice.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same derisk detection, same stoploss target handling, same mode checks, same profit arithmetic, same candle selection, same thresholds, and same return values.
- The patch only reuses order data already read inside the same branch.
- No indicator, CMF/math, stake-sizing, or order-classification logic is changed.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local order-helper and first-entry reuse inside unchanged derisk detection; it does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
