### PR TITLE
Reuse X7 entry-condition order price

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12401,7 +12401,8 @@ class NostalgiaForInfinityX7(IStrategy):
       filled_orders = trade.select_filled_orders()
     if not filled_orders:
       return False
-    slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
+    last_filled_price = filled_orders[-1].safe_price
+    slice_profit = (exit_rate - last_filled_price) / last_filled_price
     if not trade.is_short:
       return last_candle["enter_long"] or self.long_grind_entry(last_candle, previous_candle, slice_profit, False)
     else:


### PR DESCRIPTION
## Summary
- Reuses the final filled-order price in `has_valid_entry_conditions()`.
- Avoids indexing `filled_orders[-1].safe_price` twice while calculating the same `slice_profit` value.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same filled-order selection, same slice-profit arithmetic, same long/short entry checks, same candle selection, same thresholds, and same return values.
- The patch only reuses the final filled-order price already used by the existing calculation.
- No indicator, CMF/math, stake-sizing, or order-classification logic is changed.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local order-price reuse inside unchanged entry-condition logic; it does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
