### PR TITLE
Reuse X7 rapid-exit stop flag

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -26771,6 +26771,7 @@ class NostalgiaForInfinityX7(IStrategy):
     enter_tags,
   ) -> tuple:
     is_futures_mode = self.is_futures_mode
+    stops_enable = self.stops_enable
 
     mark_profit_target = self.mark_profit_target
     set_profit_target = self._set_profit_target
@@ -26861,21 +26862,21 @@ class NostalgiaForInfinityX7(IStrategy):
             else self.system_v3_2_stop_threshold_rapid_spot
           )
         elif is_system_v3_1:
-          stop_enabled = self.stops_enable
+          stop_enabled = stops_enable
           stop_threshold = (
             self.system_v3_1_stop_threshold_rapid_futures
             if is_futures_mode
             else self.system_v3_1_stop_threshold_rapid_spot
           )
         elif is_system_v3:
-          stop_enabled = self.stops_enable
+          stop_enabled = stops_enable
           stop_threshold = (
             self.system_v3_stop_threshold_rapid_futures
             if is_futures_mode
             else self.system_v3_stop_threshold_rapid_spot
           )
         else:
-          stop_enabled = self.stops_enable
+          stop_enabled = stops_enable
           stop_threshold = self.stop_threshold_rapid_futures if is_futures_mode else self.stop_threshold_rapid_spot
 
         if stop_enabled:
@@ -52804,6 +52805,7 @@ class NostalgiaForInfinityX7(IStrategy):
     enter_tags,
   ) -> tuple:
     is_futures_mode = self.is_futures_mode
+    stops_enable = self.stops_enable
     trade_leverage = trade.leverage
 
     mark_profit_target = self.mark_profit_target
@@ -52939,7 +52941,7 @@ class NostalgiaForInfinityX7(IStrategy):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3_1:
         # Stoplosses
-        if self.stops_enable and (
+        if stops_enable and (
           profit_stake
           < -(
             entry_cost
@@ -52954,7 +52956,7 @@ class NostalgiaForInfinityX7(IStrategy):
           sell, signal_name = True, f"exit_{mode_name}_stoploss_doom"
       elif is_system_v3:
         # Stoplosses
-        if self.stops_enable and (
+        if stops_enable and (
           profit_stake
           < -(
             entry_cost
@@ -52971,7 +52973,7 @@ class NostalgiaForInfinityX7(IStrategy):
         # Stoplosses
         if (
           (
-            self.stops_enable
+            stops_enable
             and (
               profit_stake
               < -(


### PR DESCRIPTION
## Summary
- Reuses a local `stops_enable` value in long/short rapid-exit stoploss branches.
- Avoids repeated reads of the same strategy stop flag inside the same exit call.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same stop thresholds, profit arithmetic, mode checks, target-profit handling, candle selection, condition order, and return values.
- The patch only reuses the existing strategy flag value already read inside each rapid-exit call.
- No indicator, CMF/math, stake-sizing, or order-classification logic is changed.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local flag reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
