### PR TITLE
Reuse X7 short grind-v2 custom-data methods

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -69170,6 +69170,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
     is_futures = self.is_futures_mode
     trade_leverage = trade.leverage
+    trade_get_custom_data = trade.get_custom_data
+    trade_set_custom_data = trade.set_custom_data
 
     min_stake = self.correct_min_stake(min_stake)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
@@ -69730,7 +69732,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
-      and (trade.get_custom_data(key="grinding_v2_derisk_level_1_flag") is None)
+      and (trade_get_custom_data(key="grinding_v2_derisk_level_1_flag") is None)
       and (
         profit_stake
         < (
@@ -69740,9 +69742,9 @@ class NostalgiaForInfinityX7(IStrategy):
         / trade_leverage
       )
     ):
-      trade.set_custom_data(key="grinding_v2_derisk_level_1_flag", value=True)
-      trade.set_custom_data(key="grinding_v2_derisk_level_1_profit", value=profit_stake)
-      trade.set_custom_data(key="grinding_v2_derisk_level_1_time", value=current_time.isoformat())
+      trade_set_custom_data(key="grinding_v2_derisk_level_1_flag", value=True)
+      trade_set_custom_data(key="grinding_v2_derisk_level_1_profit", value=profit_stake)
+      trade_set_custom_data(key="grinding_v2_derisk_level_1_time", value=current_time.isoformat())
 
     flag_is_derisk_level_1 = False
     if (
@@ -69750,13 +69752,13 @@ class NostalgiaForInfinityX7(IStrategy):
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
-      and (trade.get_custom_data(key="grinding_v2_derisk_level_1_flag") is True)
+      and (trade_get_custom_data(key="grinding_v2_derisk_level_1_flag") is True)
     ):
-      flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_1_profit")
-      flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_1_time"))
+      flag_profit = trade_get_custom_data(key="grinding_v2_derisk_level_1_profit")
+      flag_time = datetime.fromisoformat(trade_get_custom_data(key="grinding_v2_derisk_level_1_time"))
       if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
-          trade.set_custom_data(key="grinding_v2_derisk_level_1_flag", value=None)
+          trade_set_custom_data(key="grinding_v2_derisk_level_1_flag", value=None)
         else:
           flag_is_derisk_level_1 = True
 
@@ -69817,7 +69819,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
-      and (trade.get_custom_data(key="grinding_v2_derisk_level_2_flag") is None)
+      and (trade_get_custom_data(key="grinding_v2_derisk_level_2_flag") is None)
       and (
         profit_stake
         < (
@@ -69827,9 +69829,9 @@ class NostalgiaForInfinityX7(IStrategy):
         / trade_leverage
       )
     ):
-      trade.set_custom_data(key="grinding_v2_derisk_level_2_flag", value=True)
-      trade.set_custom_data(key="grinding_v2_derisk_level_2_profit", value=profit_stake)
-      trade.set_custom_data(key="grinding_v2_derisk_level_2_time", value=current_time.isoformat())
+      trade_set_custom_data(key="grinding_v2_derisk_level_2_flag", value=True)
+      trade_set_custom_data(key="grinding_v2_derisk_level_2_profit", value=profit_stake)
+      trade_set_custom_data(key="grinding_v2_derisk_level_2_time", value=current_time.isoformat())
 
     flag_is_derisk_level_2 = False
     if (
@@ -69837,13 +69839,13 @@ class NostalgiaForInfinityX7(IStrategy):
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
-      and (trade.get_custom_data(key="grinding_v2_derisk_level_2_flag") is True)
+      and (trade_get_custom_data(key="grinding_v2_derisk_level_2_flag") is True)
     ):
-      flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_2_profit")
-      flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_2_time"))
+      flag_profit = trade_get_custom_data(key="grinding_v2_derisk_level_2_profit")
+      flag_time = datetime.fromisoformat(trade_get_custom_data(key="grinding_v2_derisk_level_2_time"))
       if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
-          trade.set_custom_data(key="grinding_v2_derisk_level_2_flag", value=None)
+          trade_set_custom_data(key="grinding_v2_derisk_level_2_flag", value=None)
         else:
           flag_is_derisk_level_2 = True
 
@@ -69904,7 +69906,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode
-      and (trade.get_custom_data(key="grinding_v2_derisk_level_3_flag") is None)
+      and (trade_get_custom_data(key="grinding_v2_derisk_level_3_flag") is None)
       and (
         profit_stake
         < (
@@ -69914,9 +69916,9 @@ class NostalgiaForInfinityX7(IStrategy):
         / trade_leverage
       )
     ):
-      trade.set_custom_data(key="grinding_v2_derisk_level_3_flag", value=True)
-      trade.set_custom_data(key="grinding_v2_derisk_level_3_profit", value=profit_stake)
-      trade.set_custom_data(key="grinding_v2_derisk_level_3_time", value=current_time.isoformat())
+      trade_set_custom_data(key="grinding_v2_derisk_level_3_flag", value=True)
+      trade_set_custom_data(key="grinding_v2_derisk_level_3_profit", value=profit_stake)
+      trade_set_custom_data(key="grinding_v2_derisk_level_3_time", value=current_time.isoformat())
 
     flag_is_derisk_level_3 = False
     if (
@@ -69924,13 +69926,13 @@ class NostalgiaForInfinityX7(IStrategy):
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode
-      and (trade.get_custom_data(key="grinding_v2_derisk_level_3_flag") is True)
+      and (trade_get_custom_data(key="grinding_v2_derisk_level_3_flag") is True)
     ):
-      flag_profit = trade.get_custom_data(key="grinding_v2_derisk_level_3_profit")
-      flag_time = datetime.fromisoformat(trade.get_custom_data(key="grinding_v2_derisk_level_3_time"))
+      flag_profit = trade_get_custom_data(key="grinding_v2_derisk_level_3_profit")
+      flag_time = datetime.fromisoformat(trade_get_custom_data(key="grinding_v2_derisk_level_3_time"))
       if get_derisk_flag_timeout() > flag_time:
         if profit_stake > flag_profit:
-          trade.set_custom_data(key="grinding_v2_derisk_level_3_flag", value=None)
+          trade_set_custom_data(key="grinding_v2_derisk_level_3_flag", value=None)
         else:
           flag_is_derisk_level_3 = True
 


### PR DESCRIPTION
## Summary
- Reuses local `trade_get_custom_data` and `trade_set_custom_data` method references in the short grind-v2 adjust path.
- Applies those references to the existing derisk flag reads and writes.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same derisk flag keys, same flag timing, same profit arithmetic, same order classification, same candle selection, same thresholds, and same return values.
- The patch only reuses the trade custom-data methods already called inside the same adjust path.
- No indicator, CMF/math, stake-sizing, or order-classification logic is changed.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local method-reference reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
