### PR TITLE
Reuse X7 short-exit candle field reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -55274,9 +55274,15 @@ class NostalgiaForInfinityX7(IStrategy):
     last_roc_9_1d = last_candle["ROC_9_1d"]
     last_rsi_3_1h = last_candle["RSI_3_1h"]
     last_rsi_14 = last_candle["RSI_14"]
+    last_rsi_3_4h = last_candle["RSI_3_4h"]
+    last_willr_14 = last_candle["WILLR_14"]
+    last_stochrsi_k_4h = last_candle["STOCHRSIk_14_14_3_3_4h"]
+    last_stochrsi_k_1h = last_candle["STOCHRSIk_14_14_3_3_1h"]
+    last_stochrsi_k_1d = last_candle["STOCHRSIk_14_14_3_3_1d"]
+    last_roc_9_4h = last_candle["ROC_9_4h"]
     if 0.01 > current_profit >= 0.001:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -55289,7 +55295,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
-        (last_candle["WILLR_14"] <= -99.0)
+        (last_willr_14 <= -99.0)
         and (last_rsi_14 < 22.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -55301,20 +55307,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_2"
       elif (
-        (last_candle["WILLR_14"] <= -99.0)
+        (last_willr_14 <= -99.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
-        (last_candle["WILLR_14"] <= -99.0)
+        (last_willr_14 <= -99.0)
         and (last_rsi_14 < 22.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -55324,10 +55328,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_4"
       elif (
-        (last_candle["WILLR_14"] <= -99.0)
-        and (last_rsi_14 < 22.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 <= -99.0) and (last_rsi_14 < 22.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
@@ -55341,12 +55342,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_7"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -55355,17 +55356,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_3 < 1.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_10"
@@ -55380,53 +55381,45 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_12"
-      elif (last_rsi_3 < 1.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_13"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -99.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_14"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
         (last_rsi_3 < 1.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_0_17"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 < 25.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_19"
       elif (
@@ -55436,105 +55429,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_20"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_0_21"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 2.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -95.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_25"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_27"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_29"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_31"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_33"
       elif (
@@ -55546,17 +55515,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_34"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -95.0)
+        and (last_willr_14 < -95.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -99.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
@@ -55564,85 +55533,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_37"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_0_38"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_40"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -95.0)
+        and (last_willr_14 < -95.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -98.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_43"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_0_45"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 2.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_46"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -55651,123 +55600,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_50"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -95.0)
+        and (last_willr_14 < -95.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -88.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_0_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 66.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_59"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 62.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_60"
-      elif (
-        (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_0_61"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -55775,32 +55708,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
-      elif (
-        (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_65"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
@@ -55809,29 +55735,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 62.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_0_70"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_0_71"
       elif (
         (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_candle["AROOND_14_4h"] > 25.0)
@@ -55840,34 +55756,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_75"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 52.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
@@ -55879,64 +55792,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_82"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_83"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
@@ -55944,22 +55847,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -98.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_0_88"
@@ -55972,9 +55875,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_89"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -55983,20 +55886,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_91"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_92"
@@ -56005,12 +55905,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_93"
@@ -56018,20 +55915,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_94"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_0_95"
@@ -56040,7 +55934,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
@@ -56048,49 +55942,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_97"
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_15m"] < 26.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 < 22.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_101"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_102"
@@ -56099,64 +55990,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_103"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_107"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
         (last_rsi_3 < 5.0)
@@ -56170,20 +56051,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_113"
@@ -56191,7 +56072,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_114"
@@ -56199,14 +56080,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_115"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_116"
@@ -56220,16 +56101,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_119"
       elif (
@@ -56240,80 +56121,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_121"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_0_122"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 5.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_124"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_0_125"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_0_126"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 5.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_0_130"
-      elif (
-        (last_rsi_14 > 64.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
@@ -56325,7 +56182,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_133"
     elif 0.02 > current_profit >= 0.01:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -56338,7 +56195,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 32.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -56350,20 +56207,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_2"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
+        (last_willr_14 < -92.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_3"
       elif (
-        (last_candle["WILLR_14"] < -70.0)
+        (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -56373,10 +56228,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_4"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
-        and (last_rsi_14 < 28.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_5"
       elif (
@@ -56390,12 +56242,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
+        (last_willr_14 < -98.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -56404,17 +56256,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_8"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
+        (last_willr_14 < -98.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_9"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_1_10"
@@ -56429,53 +56281,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_12"
-      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_1_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -96.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_14"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_16"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_1_17"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_14 < 40.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_18"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 < 28.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_19"
       elif (
@@ -56485,105 +56331,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_20"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_1_21"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 5.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 < 25.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_24"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -96.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_25"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_27"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_29"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_1_30"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_31"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_32"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_33"
       elif (
@@ -56595,17 +56417,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_34"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_35"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -85.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_36"
       elif (
@@ -56613,85 +56435,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_37"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_1_38"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_39"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -85.0)
+        and (last_willr_14 < -85.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_40"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_41"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -75.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_43"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -95.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
-      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_1_45"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_46"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -56700,123 +56502,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_48"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -96.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_50"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_1_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_53"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_54"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -86.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_55"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_1_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 64.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -88.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_59"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 60.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_1_61"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -56824,32 +56610,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 32.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_64"
-      elif (
-        (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_65"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_1_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_67"
@@ -56858,29 +56637,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_69"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_1_70"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_1_71"
       elif (
         (last_rsi_3 < 22.0)
@@ -56892,34 +56661,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_73"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_75"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
@@ -56931,64 +56697,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_78"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_80"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_81"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_82"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_83"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_1_84"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_85"
       elif (
@@ -56996,22 +56752,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_86"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_87"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -80.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_1_88"
@@ -57024,9 +56780,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_89"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -57035,20 +56791,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_91"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_92"
@@ -57057,12 +56810,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_93"
@@ -57070,20 +56820,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_94"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_1_95"
@@ -57092,7 +56839,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_96"
       elif (
@@ -57100,49 +56847,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_97"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_15m"] < 28.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_98"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_rsi_14 < 24.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_100"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_101"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_102"
@@ -57151,64 +56895,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_103"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_1_104"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_1_105"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_1_106"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_107"
-      elif (
-        (last_rsi_3 < 44.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_1_108"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_109"
-      elif (
-        (last_rsi_3 < 28.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
         (last_rsi_3 < 50.0)
@@ -57222,20 +56956,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_111"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_113"
@@ -57243,7 +56977,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_114"
@@ -57251,14 +56985,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_115"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_116"
@@ -57272,16 +57006,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_118"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_119"
       elif (
@@ -57295,80 +57029,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_121"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_1_122"
       elif (
-        (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_1_124"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_1_125"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_1_126"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_127"
-      elif (last_rsi_3 < 6.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_129"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_1_130"
-      elif (
-        (last_rsi_14 > 62.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_1_131"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_132"
       elif (
@@ -57380,7 +57090,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_133"
     elif 0.03 > current_profit >= 0.02:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -57393,7 +57103,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 34.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -57405,20 +57115,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_2"
       elif (
-        (last_candle["WILLR_14"] < -90.0)
+        (last_willr_14 < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_3"
       elif (
-        (last_candle["WILLR_14"] < -70.0)
+        (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -57428,10 +57136,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_4"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
-        and (last_rsi_14 < 30.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_5"
       elif (
@@ -57445,12 +57150,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
+        (last_willr_14 < -96.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -57459,17 +57164,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_8"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
+        (last_willr_14 < -96.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_9"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_2_10"
@@ -57484,53 +57189,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_12"
-      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_2_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_14"
-      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_16"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_2_17"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_14 < 40.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_18"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_19"
       elif (
@@ -57540,105 +57239,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_20"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_2_21"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 10.0) and (last_willr_14 < -85.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -80.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_24"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_25"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_27"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_29"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_2_30"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_31"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_32"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_33"
       elif (
@@ -57650,17 +57325,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_34"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -93.0)
+        and (last_willr_14 < -93.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_35"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -80.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_36"
       elif (
@@ -57668,85 +57343,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_37"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_2_38"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_39"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_40"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -85.0)
+        and (last_willr_14 < -85.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_41"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -70.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_43"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
-      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_2_45"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_46"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -57755,123 +57410,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_48"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_50"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_2_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_53"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_54"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -84.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_55"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_2_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 62.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -86.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_59"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 58.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_2_61"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -57879,32 +57518,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 34.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_64"
-      elif (
-        (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_65"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_2_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_67"
@@ -57913,29 +57545,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_69"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_2_70"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_2_71"
       elif (
         (last_rsi_3 < 24.0)
@@ -57947,34 +57569,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_73"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_75"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
@@ -57986,64 +57605,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -82.0)
+        and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_78"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_80"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_81"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -88.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_82"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_83"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_2_84"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_85"
       elif (
@@ -58051,22 +57660,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_86"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_87"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -78.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -78.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_2_88"
@@ -58079,9 +57688,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_89"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -58090,20 +57699,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_91"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_92"
@@ -58112,12 +57718,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_93"
@@ -58125,20 +57728,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_94"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_2_95"
@@ -58147,7 +57747,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_96"
       elif (
@@ -58155,49 +57755,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_97"
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
         (last_rsi_3 < 42.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
       elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_14 < 26.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_100"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -82.0)
+        and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_101"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_102"
@@ -58206,64 +57803,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_103"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_107"
-      elif (
-        (last_rsi_3 < 46.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_109"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
         (last_rsi_3 < 52.0)
@@ -58277,20 +57864,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_111"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -70.0)
+        and (last_willr_14 < -70.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_113"
@@ -58298,7 +57885,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_114"
@@ -58306,14 +57893,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_115"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_116"
@@ -58327,16 +57914,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_118"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_119"
       elif (
@@ -58350,80 +57937,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_121"
-      elif (
-        (last_rsi_3 < 44.0)
-        and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_2_122"
       elif (
-        (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_2_124"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_2_125"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_2_126"
       elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_127"
-      elif (last_rsi_3 < 8.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_129"
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_2_130"
-      elif (
-        (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_2_131"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_132"
       elif (
@@ -58435,7 +57998,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_133"
     elif 0.04 > current_profit >= 0.03:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -58448,7 +58011,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 36.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -58460,20 +58023,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
-        (last_candle["WILLR_14"] < -70.0)
+        (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -58483,10 +58044,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_4"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
-        and (last_rsi_14 < 32.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
@@ -58500,12 +58058,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
+        (last_willr_14 < -94.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -58514,17 +58072,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
+        (last_willr_14 < -94.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_3_10"
@@ -58539,53 +58097,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_12"
-      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_14"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 35.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 35.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_3_17"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_14 < 40.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_19"
       elif (
@@ -58595,105 +58147,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_20"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
       elif (
-        (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -75.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_25"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_27"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_29"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_31"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_33"
       elif (
@@ -58705,17 +58233,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_34"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -75.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
@@ -58723,85 +58251,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_37"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_3_38"
       elif (
-        (last_rsi_3 < 7.0)
-        and (last_candle["WILLR_14"] < -93.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_40"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_41"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -65.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_43"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -85.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_3_45"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_46"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -58810,123 +58318,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 45.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_50"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -82.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -84.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_59"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_3_61"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -58934,32 +58426,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 36.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
-      elif (
-        (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_65"
-      elif (
-        (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
@@ -58968,29 +58453,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_69"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_3_70"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_3_71"
       elif (
         (last_rsi_3 < 26.0)
@@ -59002,34 +58477,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_73"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_75"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 46.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
@@ -59041,64 +58513,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -86.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_83"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
@@ -59106,22 +58568,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_87"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -76.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -76.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_3_88"
@@ -59134,9 +58596,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -59145,20 +58607,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_91"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_92"
@@ -59167,12 +58626,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_93"
@@ -59180,20 +58636,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_94"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_3_95"
@@ -59202,7 +58655,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
@@ -59210,49 +58663,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_97"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_15m"] < 32.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
         (last_rsi_3 < 44.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_14 < 28.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_101"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_102"
@@ -59261,64 +58711,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_103"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_107"
-      elif (
-        (last_rsi_3 < 48.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 < 54.0)
@@ -59332,20 +58772,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_111"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -65.0)
+        and (last_willr_14 < -65.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_113"
@@ -59353,7 +58793,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_114"
@@ -59361,14 +58801,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_115"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_116"
@@ -59382,16 +58822,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_119"
       elif (
@@ -59405,80 +58845,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_121"
-      elif (
-        (last_rsi_3 < 46.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_3_122"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_3_124"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_3_125"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_3_126"
       elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_rsi_3 < 10.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_3_130"
-      elif (
-        (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
@@ -59490,7 +58906,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_133"
     elif 0.05 > current_profit >= 0.04:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -59503,7 +58919,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 38.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -59515,20 +58931,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_2"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_3"
       elif (
-        (last_candle["WILLR_14"] < -70.0)
+        (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -59538,10 +58952,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_4"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
-        and (last_rsi_14 < 34.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_5"
       elif (
@@ -59555,12 +58966,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
+        (last_willr_14 < -92.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -59569,17 +58980,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_8"
       elif (
-        (last_candle["WILLR_14"] < -93.0)
+        (last_willr_14 < -93.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_9"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_4_10"
@@ -59594,53 +59005,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_12"
-      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_14"
-      elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_16"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -70.0)
+        and (last_willr_14 < -70.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_4_17"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_14 < 40.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_18"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_19"
       elif (
@@ -59650,105 +59055,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_20"
-      elif (
-        (last_rsi_3 < 45.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 45.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_4_21"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 20.0) and (last_willr_14 < -75.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_24"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_25"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_27"
       elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_29"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_4_30"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_31"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_32"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_33"
       elif (
@@ -59760,17 +59141,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_34"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -91.0)
+        and (last_willr_14 < -91.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_35"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -70.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_36"
       elif (
@@ -59778,85 +59159,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_37"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_willr_14 < -70.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_4_38"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_39"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -70.0)
+        and (last_willr_14 < -70.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_40"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_41"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -60.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_43"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -80.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
-      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_4_45"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_46"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -59865,123 +59226,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_48"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_50"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_4_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_53"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_54"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -80.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_55"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_4_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 58.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -82.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_59"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 54.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_4_61"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -59989,32 +59334,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 38.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_64"
-      elif (
-        (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_65"
-      elif (
-        (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_4_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_67"
@@ -60023,29 +59361,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
         (last_rsi_3 < 7.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_69"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_4_70"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_4_71"
       elif (
         (last_rsi_3 < 28.0)
@@ -60057,34 +59385,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_73"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_75"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 44.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
@@ -60096,64 +59421,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_77"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -78.0)
+        and (last_willr_14 < -78.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_78"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_80"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_81"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -84.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_82"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_83"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_4_84"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_85"
       elif (
@@ -60161,22 +59476,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_86"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_87"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -74.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -74.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_4_88"
@@ -60189,9 +59504,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_89"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -60200,20 +59515,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_91"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_92"
@@ -60222,12 +59534,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_93"
@@ -60235,20 +59544,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_94"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -82.0)
+        and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_4_95"
@@ -60257,7 +59563,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_96"
       elif (
@@ -60265,49 +59571,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_97"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_15m"] < 34.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_98"
       elif (
         (last_rsi_3 < 46.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_14 < 30.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_100"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -78.0)
+        and (last_willr_14 < -78.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_101"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_102"
@@ -60316,64 +59619,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 38.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_103"
       elif (
         (last_rsi_3 < 42.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_4_104"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_4_105"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_4_106"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_107"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_4_108"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_109"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
         (last_rsi_3 < 56.0)
@@ -60387,20 +59680,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_111"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["WILLR_14"] < -60.0)
+        and (last_willr_14 < -60.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_113"
@@ -60408,7 +59701,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_114"
@@ -60416,14 +59709,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_115"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_116"
@@ -60437,16 +59730,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_118"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_119"
       elif (
@@ -60460,80 +59753,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_121"
-      elif (
-        (last_rsi_3 < 48.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_4_122"
       elif (
-        (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_4_124"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_4_125"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_4_126"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_127"
-      elif (last_rsi_3 < 12.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_129"
       elif (
         (last_rsi_3 < 32.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_4_130"
-      elif (
-        (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_4_131"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_132"
       elif (
@@ -60545,7 +59814,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_133"
     elif 0.06 > current_profit >= 0.05:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -60558,7 +59827,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 40.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -60570,20 +59839,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
-        (last_candle["WILLR_14"] < -70.0)
+        (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -60593,10 +59860,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_4"
       elif (
-        (last_candle["WILLR_14"] < -90.0)
-        and (last_rsi_14 < 36.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -90.0) and (last_rsi_14 < 36.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
@@ -60610,12 +59874,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
-        (last_candle["WILLR_14"] < -90.0)
+        (last_willr_14 < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -60624,17 +59888,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_8"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
+        (last_willr_14 < -92.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_9"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_5_10"
@@ -60649,53 +59913,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_12"
-      elif (last_rsi_3 < 20.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -88.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_14"
-      elif (last_rsi_3 < 14.0) and (last_rsi_14 > 58.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_14 > 58.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_16"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -65.0)
+        and (last_willr_14 < -65.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_5_17"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_14 < 40.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 < 36.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_19"
       elif (
@@ -60705,105 +59963,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_20"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 25.0) and (last_willr_14 < -70.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 < 36.0)
-        and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -65.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -88.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_25"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_willr_14 < -88.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_27"
       elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_29"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_31"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_33"
       elif (
@@ -60815,17 +60049,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_34"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -65.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
@@ -60833,85 +60067,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_37"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_willr_14 < -65.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_38"
       elif (
-        (last_rsi_3 < 9.0)
-        and (last_candle["WILLR_14"] < -91.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 9.0) and (last_willr_14 < -91.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["WILLR_14"] < -65.0)
+        and (last_willr_14 < -65.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_40"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -70.0)
+        and (last_willr_14 < -70.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_41"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -55.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_43"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -75.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_rsi_3 < 14.0) and (last_candle["WILLR_14"] < -86.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -86.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_5_45"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_46"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -60920,123 +60134,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 55.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -88.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_50"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 46.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 46.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 46.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -78.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -78.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 56.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -80.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_59"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 52.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_5_61"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -61044,32 +60242,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 40.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
-      elif (
-        (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_65"
-      elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 44.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 44.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
@@ -61078,29 +60269,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_70"
-      elif (
-        (last_rsi_3 < 44.0)
-        and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_5_71"
       elif (
         (last_rsi_3 < 30.0)
@@ -61112,34 +60293,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_73"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_75"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 42.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
@@ -61151,64 +60329,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -76.0)
+        and (last_willr_14 < -76.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -82.0)
+        and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -82.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_82"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_83"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
@@ -61216,22 +60384,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
         (last_rsi_3 < 42.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_87"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -72.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -72.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_5_88"
@@ -61244,9 +60412,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -61255,20 +60423,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_91"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_92"
@@ -61277,12 +60442,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_93"
@@ -61290,20 +60452,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_94"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_5_95"
@@ -61312,7 +60471,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
@@ -61320,49 +60479,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_97"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["RSI_3_15m"] < 36.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_98"
       elif (
         (last_rsi_3 < 48.0)
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 < 32.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 10.0) and (last_rsi_14 < 32.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -76.0)
+        and (last_willr_14 < -76.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_101"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_102"
@@ -61371,64 +60527,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 36.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
         (last_rsi_3 < 44.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_107"
-      elif (
-        (last_rsi_3 < 52.0)
-        and (last_rsi_14 > 44.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 52.0) and (last_rsi_14 > 44.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 < 58.0)
@@ -61442,20 +60588,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_111"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["WILLR_14"] < -55.0)
+        and (last_willr_14 < -55.0)
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_113"
@@ -61463,7 +60609,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_114"
@@ -61471,14 +60617,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_115"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_116"
@@ -61492,16 +60638,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_119"
       elif (
@@ -61515,80 +60661,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 48.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_121"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_5_122"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_5_124"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_5_125"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_5_126"
       elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 18.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_rsi_3 < 14.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
         (last_rsi_3 < 34.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_5_130"
-      elif (
-        (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
@@ -61600,7 +60722,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_133"
     elif 0.07 > current_profit >= 0.06:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -61613,7 +60735,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 38.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -61625,20 +60747,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_2"
       elif (
-        (last_candle["WILLR_14"] < -85.0)
+        (last_willr_14 < -85.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
-        (last_candle["WILLR_14"] < -75.0)
+        (last_willr_14 < -75.0)
         and (last_rsi_14 < 32.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -61648,10 +60768,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_4"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
-        and (last_rsi_14 < 34.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
@@ -61665,12 +60782,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
+        (last_willr_14 < -92.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -61679,17 +60796,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_8"
       elif (
-        (last_candle["WILLR_14"] < -93.0)
+        (last_willr_14 < -93.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_9"
       elif (
-        (last_candle["WILLR_14"] < -85.0)
+        (last_willr_14 < -85.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_6_10"
@@ -61704,53 +60821,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_12"
-      elif (last_rsi_3 < 15.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_14"
-      elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
         (last_rsi_3 < 25.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -70.0)
+        and (last_willr_14 < -70.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_6_17"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 < 35.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 20.0) and (last_rsi_14 < 35.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_19"
       elif (
@@ -61760,105 +60871,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_20"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 20.0) and (last_willr_14 < -75.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_25"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_27"
       elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_29"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_31"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_33"
       elif (
@@ -61870,17 +60957,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_34"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -91.0)
+        and (last_willr_14 < -91.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -70.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
@@ -61888,85 +60975,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_37"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_willr_14 < -70.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_38"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -70.0)
+        and (last_willr_14 < -70.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_40"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_41"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -60.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_43"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -80.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_rsi_3 < 12.0) and (last_candle["WILLR_14"] < -88.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_6_45"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_46"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -61975,123 +61042,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_50"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -80.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 58.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -82.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_59"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 54.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_6_61"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -62099,32 +61150,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 38.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
-      elif (
-        (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_65"
-      elif (
-        (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
@@ -62133,29 +61177,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
         (last_rsi_3 < 7.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_70"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_6_71"
       elif (
         (last_rsi_3 < 28.0)
@@ -62167,34 +61201,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_73"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_75"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 44.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
@@ -62206,64 +61237,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -78.0)
+        and (last_willr_14 < -78.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -84.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_82"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_83"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
@@ -62271,22 +61292,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_87"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -74.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -74.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_6_88"
@@ -62299,9 +61320,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -62310,20 +61331,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_91"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_92"
@@ -62332,12 +61350,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_93"
@@ -62345,20 +61360,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_94"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -82.0)
+        and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_6_95"
@@ -62367,7 +61379,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
@@ -62375,49 +61387,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_97"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["RSI_3_15m"] < 34.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_98"
       elif (
         (last_rsi_3 < 46.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_14 < 30.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -78.0)
+        and (last_willr_14 < -78.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_101"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_102"
@@ -62426,64 +61435,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 38.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_103"
       elif (
         (last_rsi_3 < 42.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_107"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 < 56.0)
@@ -62497,20 +61496,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_111"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["WILLR_14"] < -60.0)
+        and (last_willr_14 < -60.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_113"
@@ -62518,7 +61517,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_114"
@@ -62526,14 +61525,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_115"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_116"
@@ -62547,16 +61546,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_119"
       elif (
@@ -62570,80 +61569,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_121"
-      elif (
-        (last_rsi_3 < 48.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_6_122"
       elif (
-        (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_6_124"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_6_125"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_6_126"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_rsi_3 < 12.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
         (last_rsi_3 < 32.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_6_130"
-      elif (
-        (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
@@ -62655,7 +61630,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_133"
     elif 0.08 > current_profit >= 0.07:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -62668,7 +61643,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 36.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -62680,20 +61655,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_2"
       elif (
-        (last_candle["WILLR_14"] < -90.0)
+        (last_willr_14 < -90.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_3"
       elif (
-        (last_candle["WILLR_14"] < -80.0)
+        (last_willr_14 < -80.0)
         and (last_rsi_14 < 30.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -62703,10 +61676,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_4"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
-        and (last_rsi_14 < 32.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_5"
       elif (
@@ -62720,12 +61690,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
+        (last_willr_14 < -94.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -62734,17 +61704,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_8"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
+        (last_willr_14 < -94.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_9"
       elif (
-        (last_candle["WILLR_14"] < -90.0)
+        (last_willr_14 < -90.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_7_10"
@@ -62759,53 +61729,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_12"
-      elif (last_rsi_3 < 10.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_14"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 38.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 38.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_16"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_7_17"
       elif (
-        (last_rsi_3 < 15.0)
-        and (last_rsi_14 < 30.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 15.0) and (last_rsi_14 < 30.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_18"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_19"
       elif (
@@ -62815,105 +61779,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_20"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_7_21"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
       elif (
-        (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -75.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_24"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_25"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_27"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_29"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_7_30"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_31"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_32"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_33"
       elif (
@@ -62925,17 +61865,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_34"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_35"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -75.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_36"
       elif (
@@ -62943,85 +61883,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_37"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_7_38"
       elif (
-        (last_rsi_3 < 7.0)
-        and (last_candle["WILLR_14"] < -93.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_39"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_40"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_41"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -65.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -65.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_43"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -85.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
-      elif (last_rsi_3 < 10.0) and (last_candle["WILLR_14"] < -90.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_7_45"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_46"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -63030,123 +61950,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 45.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_48"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_50"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_7_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_53"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_54"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -82.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_55"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_7_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -84.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_59"
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_7_61"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -63154,32 +62058,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 36.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_64"
-      elif (
-        (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_65"
-      elif (
-        (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_7_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_67"
@@ -63188,29 +62085,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_69"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_7_70"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_7_71"
       elif (
         (last_rsi_3 < 26.0)
@@ -63222,34 +62109,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_73"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_75"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 46.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
@@ -63261,64 +62145,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_78"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_80"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_81"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -86.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_82"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_83"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_7_84"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_85"
       elif (
@@ -63326,22 +62200,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_86"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_87"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -76.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -76.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_7_88"
@@ -63354,9 +62228,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_89"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -63365,20 +62239,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_91"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_92"
@@ -63387,12 +62258,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_93"
@@ -63400,20 +62268,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_94"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_7_95"
@@ -63422,7 +62287,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_96"
       elif (
@@ -63430,49 +62295,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_97"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["RSI_3_15m"] < 32.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
         (last_rsi_3 < 44.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_14 < 28.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_100"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_101"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_102"
@@ -63481,64 +62343,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_103"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_7_104"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_7_105"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_7_106"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_107"
-      elif (
-        (last_rsi_3 < 48.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_7_108"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_109"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
         (last_rsi_3 < 54.0)
@@ -63552,20 +62404,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_111"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -65.0)
+        and (last_willr_14 < -65.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_113"
@@ -63573,7 +62425,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_114"
@@ -63581,14 +62433,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_115"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_116"
@@ -63602,16 +62454,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_118"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_119"
       elif (
@@ -63625,80 +62477,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_121"
-      elif (
-        (last_rsi_3 < 46.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_7_122"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_7_124"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_7_125"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_7_126"
       elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_127"
-      elif (last_rsi_3 < 10.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_129"
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_7_130"
-      elif (
-        (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_7_131"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_132"
       elif (
@@ -63710,7 +62538,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_133"
     elif 0.09 > current_profit >= 0.08:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -63723,7 +62551,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 34.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -63735,20 +62563,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_2"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
+        (last_willr_14 < -92.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_3"
       elif (
-        (last_candle["WILLR_14"] < -85.0)
+        (last_willr_14 < -85.0)
         and (last_rsi_14 < 28.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -63758,10 +62584,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_4"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
-        and (last_rsi_14 < 30.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_5"
       elif (
@@ -63775,12 +62598,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
+        (last_willr_14 < -96.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -63789,17 +62612,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_8"
       elif (
-        (last_candle["WILLR_14"] < -95.0)
+        (last_willr_14 < -95.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_9"
       elif (
-        (last_candle["WILLR_14"] < -92.0)
+        (last_willr_14 < -92.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_8_10"
@@ -63814,53 +62637,47 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_12"
-      elif (last_rsi_3 < 5.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_14"
-      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 36.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 36.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
         (last_rsi_3 < 15.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_16"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_8_17"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 < 28.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
+        (last_rsi_3 < 10.0) and (last_rsi_14 < 28.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_18"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_19"
       elif (
@@ -63870,105 +62687,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_20"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_8_21"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 10.0) and (last_willr_14 < -85.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -80.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_24"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_25"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_27"
       elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_29"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_8_30"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_31"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_32"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_33"
       elif (
@@ -63980,17 +62773,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_34"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -93.0)
+        and (last_willr_14 < -93.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_35"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -80.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_36"
       elif (
@@ -63998,85 +62791,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_37"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_8_38"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_39"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_40"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -85.0)
+        and (last_willr_14 < -85.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_41"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -70.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_43"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
-      elif (last_rsi_3 < 8.0) and (last_candle["WILLR_14"] < -92.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_8_45"
       elif (
-        (last_rsi_3 < 15.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_46"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -64085,123 +62858,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_48"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_50"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_8_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_53"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_54"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -84.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_55"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_8_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 62.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -86.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_59"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_60"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_8_61"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -64209,32 +62966,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 34.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_64"
-      elif (
-        (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_65"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_8_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_67"
@@ -64243,29 +62993,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_69"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_8_70"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_8_71"
       elif (
         (last_rsi_3 < 24.0)
@@ -64277,34 +63017,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_73"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_75"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
@@ -64316,64 +63053,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -82.0)
+        and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_78"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_80"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_81"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -88.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_82"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_83"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_8_84"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_85"
       elif (
@@ -64381,22 +63108,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_86"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_87"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -78.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -78.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_8_88"
@@ -64409,9 +63136,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_89"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -64420,20 +63147,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_91"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_92"
@@ -64442,12 +63166,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_93"
@@ -64455,20 +63176,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_94"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_8_95"
@@ -64477,7 +63195,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_96"
       elif (
@@ -64485,49 +63203,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_97"
       elif (
         (last_rsi_3 < 12.0)
         and (last_candle["RSI_3_15m"] < 30.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
         (last_rsi_3 < 42.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
       elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_14 < 26.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_100"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -82.0)
+        and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_101"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_102"
@@ -64536,64 +63251,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_103"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_107"
-      elif (
-        (last_rsi_3 < 46.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_109"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
         (last_rsi_3 < 52.0)
@@ -64607,20 +63312,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_111"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -70.0)
+        and (last_willr_14 < -70.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_113"
@@ -64628,7 +63333,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_114"
@@ -64636,14 +63341,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_115"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_116"
@@ -64657,16 +63362,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_118"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_119"
       elif (
@@ -64680,80 +63385,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_121"
-      elif (
-        (last_rsi_3 < 44.0)
-        and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_8_122"
       elif (
-        (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_8_124"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_8_125"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_8_126"
       elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_127"
-      elif (last_rsi_3 < 8.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_129"
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_8_130"
-      elif (
-        (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_8_131"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_132"
       elif (
@@ -64765,7 +63446,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_133"
     elif 0.1 > current_profit >= 0.09:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -64778,7 +63459,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 32.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -64790,20 +63471,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_2"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
+        (last_willr_14 < -94.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_3"
       elif (
-        (last_candle["WILLR_14"] < -90.0)
+        (last_willr_14 < -90.0)
         and (last_rsi_14 < 26.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -64813,10 +63492,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_4"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
-        and (last_rsi_14 < 28.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_5"
       elif (
@@ -64830,12 +63506,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
+        (last_willr_14 < -98.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -64844,17 +63520,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_8"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
+        (last_willr_14 < -96.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_9"
       elif (
-        (last_candle["WILLR_14"] < -94.0)
+        (last_willr_14 < -94.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_9_10"
@@ -64869,53 +63545,45 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_12"
-      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -96.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_14"
-      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 34.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 34.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_16"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -85.0)
+        and (last_willr_14 < -85.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_9_17"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_14 < 26.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 26.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
         return True, f"exit_{mode_name}_d_9_18"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_14 < 28.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_19"
       elif (
@@ -64925,105 +63593,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_20"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_9_21"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 8.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_14 < 28.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -85.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_24"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -96.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_25"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_27"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_29"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_9_30"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_31"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_32"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_33"
       elif (
@@ -65035,17 +63679,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_34"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_35"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -85.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_36"
       elif (
@@ -65053,85 +63697,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_37"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_9_38"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_39"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -85.0)
+        and (last_willr_14 < -85.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_40"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_41"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -75.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_42"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_43"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -95.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
-      elif (last_rsi_3 < 6.0) and (last_candle["WILLR_14"] < -94.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_9_45"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_46"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -65140,123 +63764,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_48"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -96.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_50"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_9_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_53"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_54"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -86.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_55"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_9_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 64.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -88.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_59"
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 60.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_60"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_9_61"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -65264,32 +63872,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 32.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_64"
-      elif (
-        (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_65"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_9_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_67"
@@ -65298,29 +63899,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_69"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_9_70"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_9_71"
       elif (
         (last_rsi_3 < 22.0)
@@ -65332,34 +63923,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_73"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_75"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
@@ -65371,64 +63959,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_78"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_80"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_81"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_82"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_83"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_9_84"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_85"
       elif (
@@ -65436,22 +64014,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_86"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_87"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -80.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_9_88"
@@ -65464,9 +64042,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_89"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -65475,20 +64053,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_91"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_92"
@@ -65497,12 +64072,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_93"
@@ -65510,20 +64082,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_94"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_9_95"
@@ -65532,7 +64101,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_96"
       elif (
@@ -65540,49 +64109,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_97"
       elif (
         (last_rsi_3 < 10.0)
         and (last_candle["RSI_3_15m"] < 28.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_98"
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_rsi_14 < 24.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_100"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -84.0)
+        and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_101"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_102"
@@ -65591,64 +64157,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_103"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_9_104"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_9_105"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_9_106"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_107"
-      elif (
-        (last_rsi_3 < 44.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_9_108"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_109"
-      elif (
-        (last_rsi_3 < 28.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
         (last_rsi_3 < 50.0)
@@ -65662,20 +64218,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_111"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_113"
@@ -65683,7 +64239,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_114"
@@ -65691,14 +64247,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_115"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_116"
@@ -65712,16 +64268,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_118"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_119"
       elif (
@@ -65735,80 +64291,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_121"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_9_122"
       elif (
-        (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_9_124"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_9_125"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_9_126"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_127"
-      elif (last_rsi_3 < 6.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_129"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_9_130"
-      elif (
-        (last_rsi_14 > 62.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_9_131"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_132"
       elif (
@@ -65820,7 +64352,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_133"
     elif 0.12 > current_profit >= 0.1:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -65833,7 +64365,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 30.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -65845,20 +64377,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_2"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
+        (last_willr_14 < -96.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_3"
       elif (
-        (last_candle["WILLR_14"] < -95.0)
+        (last_willr_14 < -95.0)
         and (last_rsi_14 < 24.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -65868,10 +64398,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_4"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_14 < 26.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -99.0) and (last_rsi_14 < 26.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_5"
       elif (
@@ -65885,12 +64412,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -65899,17 +64426,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_8"
       elif (
-        (last_candle["WILLR_14"] < -97.0)
+        (last_willr_14 < -97.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_9"
       elif (
-        (last_candle["WILLR_14"] < -96.0)
+        (last_willr_14 < -96.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_10_10"
@@ -65924,53 +64451,45 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_12"
-      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_13"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_14"
-      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 32.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 32.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_16"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_10_17"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_14 < 24.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 24.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
         return True, f"exit_{mode_name}_d_10_18"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_14 < 26.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_19"
       elif (
@@ -65980,105 +64499,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_20"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_10_21"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_14 < 26.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_24"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_25"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_27"
       elif (
-        (last_rsi_3 < 15.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 15.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_29"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_10_30"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_31"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_32"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_33"
       elif (
@@ -66090,17 +64585,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_34"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -95.0)
+        and (last_willr_14 < -95.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_35"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -90.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_36"
       elif (
@@ -66108,85 +64603,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_37"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_10_38"
       elif (
-        (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_39"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_40"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_41"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -80.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_42"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_43"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
-      elif (last_rsi_3 < 4.0) and (last_candle["WILLR_14"] < -96.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_10_45"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_46"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -66195,123 +64670,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_48"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_49"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_50"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_10_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_53"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_54"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -88.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -88.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_55"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_10_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 66.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_59"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 62.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_60"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_10_61"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -66319,32 +64778,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_64"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_65"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_10_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_67"
@@ -66353,29 +64805,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_69"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 62.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_10_70"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_10_71"
       elif (
         (last_rsi_3 < 20.0)
@@ -66387,34 +64829,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_73"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_75"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
@@ -66426,64 +64865,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_78"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_80"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_81"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_82"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_83"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_10_84"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_85"
       elif (
@@ -66491,22 +64920,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_86"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_87"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -82.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -82.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_10_88"
@@ -66519,9 +64948,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_89"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -66530,20 +64959,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_91"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_92"
@@ -66552,12 +64978,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_93"
@@ -66565,20 +64988,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_94"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_10_95"
@@ -66587,7 +65007,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_96"
       elif (
@@ -66595,49 +65015,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_97"
       elif (
         (last_rsi_3 < 8.0)
         and (last_candle["RSI_3_15m"] < 26.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_98"
       elif (
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 < 22.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_100"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -86.0)
+        and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_101"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_102"
@@ -66646,64 +65063,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_103"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_10_104"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_10_105"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_10_106"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_107"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_10_108"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_109"
-      elif (
-        (last_rsi_3 < 26.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 26.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
         (last_rsi_3 < 48.0)
@@ -66717,20 +65124,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_111"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_113"
@@ -66738,7 +65145,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_114"
@@ -66746,14 +65153,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_115"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_116"
@@ -66767,16 +65174,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_118"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_119"
       elif (
@@ -66790,80 +65197,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_121"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_10_122"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_10_124"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_10_125"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_10_126"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 8.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_127"
-      elif (last_rsi_3 < 4.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_129"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_10_130"
-      elif (
-        (last_rsi_14 > 64.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_10_131"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_132"
       elif (
@@ -66875,7 +65258,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_133"
     elif 0.2 > current_profit >= 0.12:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -66888,7 +65271,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 26.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -66900,20 +65283,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_2"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
+        (last_willr_14 < -98.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_3"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
+        (last_willr_14 < -98.0)
         and (last_rsi_14 < 22.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -66923,10 +65304,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_4"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_14 < 24.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -99.0) and (last_rsi_14 < 24.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_5"
       elif (
@@ -66940,12 +65318,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -66954,17 +65332,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_8"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
+        (last_willr_14 < -98.0)
         and (last_rsi_3 < 5.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_9"
       elif (
-        (last_candle["WILLR_14"] < -98.0)
+        (last_willr_14 < -98.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_11_10"
@@ -66979,53 +65357,45 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_12"
-      elif (last_rsi_3 < 2.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_13"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -99.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_14"
-      elif (last_rsi_3 < 2.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_14 < 30.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
         (last_rsi_3 < 2.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_16"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -95.0)
+        and (last_willr_14 < -95.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_11_17"
-      elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_14 < 22.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 22.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
         return True, f"exit_{mode_name}_d_11_18"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14 < 24.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_19"
       elif (
@@ -67035,105 +65405,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_20"
-      elif (
-        (last_rsi_3 < 2.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_11_21"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14 < 24.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -95.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_24"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -99.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_25"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_27"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 10.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_29"
-      elif (
-        (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_11_30"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_31"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_32"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_33"
       elif (
@@ -67145,17 +65491,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_34"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_35"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -95.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_36"
       elif (
@@ -67163,85 +65509,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_37"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_11_38"
       elif (
-        (last_rsi_3 < 3.0)
-        and (last_candle["WILLR_14"] < -97.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 3.0) and (last_willr_14 < -97.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_39"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -95.0)
+        and (last_willr_14 < -95.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_40"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_41"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -85.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_42"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_43"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
-      elif (last_rsi_3 < 2.0) and (last_candle["WILLR_14"] < -98.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_11_45"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_46"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -67250,123 +65576,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_48"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_49"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_50"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 < 36.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_11_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_53"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_54"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -90.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_55"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_11_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 68.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_58"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -92.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_59"
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 64.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_60"
-      elif (
-        (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_11_61"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -67374,32 +65684,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_64"
-      elif (
-        (last_rsi_3 < 28.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_65"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_11_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 62.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_67"
@@ -67408,29 +65711,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_69"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 64.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_11_70"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 60.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_11_71"
       elif (
         (last_rsi_3 < 18.0)
@@ -67442,34 +65735,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_73"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_75"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
@@ -67481,64 +65771,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_78"
-      elif (
-        (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_80"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_81"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_82"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_83"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_11_84"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_85"
       elif (
@@ -67546,22 +65826,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_86"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_87"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -84.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -84.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_11_88"
@@ -67574,9 +65854,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_89"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -67585,20 +65865,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_91"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_92"
@@ -67607,12 +65884,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_93"
@@ -67620,20 +65894,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_94"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -92.0)
+        and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_11_95"
@@ -67642,7 +65913,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_96"
       elif (
@@ -67650,49 +65921,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_97"
       elif (
         (last_rsi_3 < 6.0)
         and (last_candle["RSI_3_15m"] < 24.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_98"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 < 20.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_100"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -88.0)
+        and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_101"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_102"
@@ -67701,64 +65969,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_103"
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_11_104"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_11_105"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_11_106"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_107"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_11_108"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_109"
-      elif (
-        (last_rsi_3 < 24.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 24.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
         (last_rsi_3 < 46.0)
@@ -67772,20 +66030,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_111"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["WILLR_14"] < -85.0)
+        and (last_willr_14 < -85.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_113"
@@ -67793,7 +66051,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_114"
@@ -67801,14 +66059,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_115"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_116"
@@ -67822,16 +66080,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_118"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_119"
       elif (
@@ -67845,80 +66103,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_121"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 60.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_11_122"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_11_124"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_11_125"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_11_126"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 6.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_127"
-      elif (last_rsi_3 < 2.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_129"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_11_130"
-      elif (
-        (last_rsi_14 > 66.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 66.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_11_131"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_132"
       elif (
@@ -67930,7 +66164,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_133"
     elif current_profit >= 0.2:
       if (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
@@ -67943,7 +66177,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_1"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (
@@ -67955,20 +66189,18 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_2"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
-        and (
-          (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0)
-        )
+        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_3"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 < 20.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
         and (
           isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
         )
@@ -67978,10 +66210,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_4"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_14 < 22.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        (last_willr_14 < -99.0) and (last_rsi_14 < 22.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_5"
       elif (
@@ -67995,12 +66224,12 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_14 > 50.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_7"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
@@ -68009,17 +66238,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_8"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_3 < 1.0)
         and (last_candle["change_pct_4h"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_9"
       elif (
-        (last_candle["WILLR_14"] < -99.0)
+        (last_willr_14 < -99.0)
         and (last_rsi_14 > 50.0)
         and (last_candle["ROC_9_1h"] > 10.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_12_10"
@@ -68034,53 +66263,45 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        and (last_rsi_3_4h > 90.0)
         and (last_candle["ROC_9_1h"] > 20.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_12"
-      elif (last_rsi_3 < 1.0) and (last_candle["RSI_3_4h"] > 95.0) and (last_candle["ROC_9_4h"] > 25.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_13"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 95.0)
+        and (last_willr_14 < -99.0)
+        and (last_rsi_3_4h > 95.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_14"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 25.0) and (last_candle["ROC_9_4h"] > 30.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 25.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
         (last_rsi_3 < 1.0)
         and (last_candle["AROOND_14_4h"] > 25.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
         and (last_candle["change_pct_1d"] > 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_16"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -30.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_12_17"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 < 20.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
         return True, f"exit_{mode_name}_d_12_18"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (last_rsi_3_4h > 90.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_19"
       elif (
@@ -68090,105 +66311,81 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["AROOND_14_1h"] > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_20"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_12_21"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["change_pct_4h"] > 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_1d"] > 95.0)
+        (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
       ):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -99.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROOND_14_4h"] > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_24"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_9_4h"] > 15.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_willr_14 < -99.0)
+        and (last_rsi_3_4h > 90.0)
+        and (last_roc_9_4h > 15.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_25"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_27"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 90.0)
-        and (last_candle["ROC_9_4h"] < -50.0)
+        (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
       ):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_29"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
         return True, f"exit_{mode_name}_d_12_30"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_31"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_3_1h > 85.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_32"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
         and (last_candle["ROC_9_1h"] < -30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_33"
       elif (
@@ -68200,17 +66397,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_34"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 25.0)
+        and (last_stochrsi_k_1h < 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_35"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["ROC_9_4h"] > 25.0)
+        and (last_willr_14 < -99.0)
+        and (last_roc_9_4h > 25.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_36"
       elif (
@@ -68218,85 +66415,65 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
         and (last_candle["RSI_3_1d"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_37"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_12_38"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
+        (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_39"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_stochrsi_k_1h < 70.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_40"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_41"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 30.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_42"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (last_rsi_3_4h > 60.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_43"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
-      elif (last_rsi_3 < 1.0) and (last_candle["WILLR_14"] < -99.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_12_45"
       elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["ROC_2_1d"] > 20.0)
+        (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_46"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 60.0)
         and (last_candle["change_pct_1d"] > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
@@ -68305,123 +66482,107 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 62.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_rsi_3_4h > 80.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_48"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -98.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_willr_14 < -98.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["change_pct_1d"] > 5.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_49"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 10.0)
+        and (last_stochrsi_k_1h < 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_50"
-      elif (
-        (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 60.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_willr_14 < -90.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_12_52"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_53"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["ROC_9_4h"] > 10.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_roc_9_4h > 10.0)
         and (last_candle["change_pct_1d"] > 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_54"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -92.0)
-        and (last_candle["ROC_9_4h"] > 5.0)
+        and (last_willr_14 < -92.0)
+        and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_55"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_12_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 30.0)
+        and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_58"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["WILLR_14"] < -94.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -94.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_59"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 66.0)
         and (last_candle["RSI_14_4h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_60"
-      elif (
-        (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -95.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 70.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -95.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_12_61"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_candle["change_pct_1d"] > 5.0)
       ):
@@ -68429,32 +66590,25 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_64"
-      elif (
-        (last_rsi_3 < 26.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_candle["RSI_3_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_65"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_12_66"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 64.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_67"
@@ -68463,29 +66617,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 75.0)
         and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["ROC_9_4h"] < -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_roc_9_4h < -20.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_4h"] > 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_69"
-      elif (
-        (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 66.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 66.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_12_70"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 62.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_12_71"
       elif (
         (last_rsi_3 < 16.0)
@@ -68497,34 +66641,31 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 85.0)
-        and (last_candle["ROC_9_4h"] > 20.0)
+        and (last_rsi_3_4h > 85.0)
+        and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_73"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["WILLR_14"] < -90.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_willr_14 < -90.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] > 50.0)
+        and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (last_rsi_3_4h > 80.0)
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_75"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
         and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 20.0)
+        and (last_stochrsi_k_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
@@ -68536,64 +66677,54 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (last_candle["RSI_3_1d"] > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_78"
-      elif (
-        (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 90.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 75.0)
+        and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_80"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -96.0)
+        and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_81"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["WILLR_14"] < -96.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_willr_14 < -96.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_82"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_83"
-      elif (
-        (last_rsi_3 < 4.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 80.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_12_84"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 70.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_85"
       elif (
@@ -68601,22 +66732,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_candle["RSI_14_4h"] < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
         and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_86"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 62.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_rsi_3_4h > 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_87"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -86.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_willr_14 < -86.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (last_candle["change_pct_1h"] > 2.0)
       ):
         return True, f"exit_{mode_name}_d_12_88"
@@ -68629,9 +66760,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_89"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["WILLR_14"] < -75.0)
+        and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -68640,20 +66771,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 50.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_91"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_92"
@@ -68662,12 +66790,9 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_candle["RSI_3_15m"] > 50.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_93"
@@ -68675,20 +66800,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["RSI_3_4h"] > 55.0)
+        and (last_rsi_3_4h > 55.0)
         and (last_candle["AROOND_14_1h"] > 75.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 10.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_94"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -94.0)
+        and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
       ):
         return True, f"exit_{mode_name}_d_12_95"
@@ -68697,7 +66819,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 55.0)
         and (last_candle["RSI_3_1d"] > 55.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_96"
       elif (
@@ -68705,49 +66827,46 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 65.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 70.0)
+        and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_97"
       elif (
         (last_rsi_3 < 4.0)
         and (last_candle["RSI_3_15m"] < 22.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["RSI_3_1d"] < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_98"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 < 18.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
-        and (last_candle["RSI_3_4h"] > 20.0)
+        (last_rsi_3 < 1.0) and (last_rsi_14 < 18.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_100"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 60.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -40.0))
+        and (last_stochrsi_k_4h < 60.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_101"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 60.0)
+        and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_102"
@@ -68756,64 +66875,54 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 40.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -80.0))
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_103"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_12_104"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_15m"] > 45.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 10.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
+        and (last_stochrsi_k_4h < 10.0)
+        and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_12_105"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
         and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["ROC_9_4h"] < -40.0)
+        and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_12_106"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 30.0)
+        and (last_stochrsi_k_1h < 30.0)
         and (last_candle["RSI_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_107"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_12_108"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -98.0)
+        and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_3_4h"] > 80.0)
+        and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_109"
-      elif (
-        (last_rsi_3 < 22.0)
-        and (last_candle["RSI_3_4h"] > 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (last_candle["ROC_9_4h"] < -25.0)
-      ):
+      elif (last_rsi_3 < 22.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
         (last_rsi_3 < 44.0)
@@ -68827,20 +66936,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_111"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["WILLR_14"] < -90.0)
+        and (last_willr_14 < -90.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["RSI_3_1d"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_candle["RSI_3_1d"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-        and (isinstance(last_candle["ROC_9_4h"], np.float64) and (last_candle["ROC_9_4h"] < -10.0))
+        and (last_stochrsi_k_4h < 50.0)
+        and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_113"
@@ -68848,7 +66957,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
+        and (last_rsi_3_4h > 70.0)
         and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_114"
@@ -68856,14 +66965,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 58.0)
         and (last_candle["RSI_3_15m"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
+        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_115"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["AROONU_14_4h"] < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_116"
@@ -68877,16 +66986,16 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
+        and (last_rsi_3_4h > 40.0)
         and (last_candle["AROOND_14_4h"] > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_118"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["WILLR_14"] < -80.0)
+        and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_3_4h"] > 40.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_rsi_3_4h > 40.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_119"
       elif (
@@ -68900,80 +67009,56 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_121"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 62.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_12_122"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_candle["WILLR_14"] < -99.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_3_1h > 85.0)
-        and (
-          isinstance(last_candle["STOCHRSIk_14_14_3_3_1d"], np.float64)
-          and (last_candle["STOCHRSIk_14_14_3_3_1d"] < 20.0)
-        )
+        and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_12_124"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["WILLR_14"] < -99.0)
+        and (last_willr_14 < -99.0)
         and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
+        and (last_rsi_3_4h > 60.0)
         and (last_candle["RSI_3_1d"] > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_12_125"
-      elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["RSI_3_4h"] > 60.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_12_126"
       elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        (last_rsi_3 < 4.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_127"
-      elif (last_rsi_3 < 1.0) and (last_candle["RSI_3_4h"] > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_4h"] > 75.0)
+        and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_129"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["RSI_14_1h"] < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 20.0)
+        and (last_stochrsi_k_1h < 20.0)
         and (last_candle["CCI_20_change_pct_1h"] > 0.0)
       ):
         return True, f"exit_{mode_name}_d_12_130"
-      elif (
-        (last_rsi_14 > 68.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_candle["RSI_3_4h"] > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 50.0)
-      ):
+      elif (last_rsi_14 > 68.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_12_131"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["RSI_3_4h"] > 65.0)
+        and (last_rsi_3_4h > 65.0)
         and (last_candle["AROOND_14_1h"] > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_1h"] < 60.0)
+        and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_132"
       elif (


### PR DESCRIPTION
## Summary
- Reuses local candle field values in `short_exit_dec()`.
- Replaces repeated `last_candle[...]` lookups for the same short-exit decision inputs after those fields are first read.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same short-exit conditions, thresholds, signal names, indicator formulas, candle selection, condition order, and return values.
- The patch only reuses existing candle fields inside the same decision call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact candle-field reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
