### PR TITLE
Reuse X7 long grind order references

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -47448,6 +47448,10 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
+    first_filled_entry = filled_entries[0]
+    last_filled_entry = filled_entries[-1]
+    last_filled_order = filled_orders[-1]
+
     has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
     if dp.runmode.value in ("live", "dry_run"):
@@ -47467,15 +47471,15 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
-    slice_amount = filled_entries[0].cost
-    slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
-    slice_profit_entry = (exit_rate - filled_entries[-1].safe_price) / filled_entries[-1].safe_price
+    slice_amount = first_filled_entry.cost
+    slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
+    slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
       ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
     )
 
     current_stake_amount = trade_amount * current_rate
-    is_derisk = trade_amount < (filled_entries[0].safe_filled * 0.95)
+    is_derisk = trade_amount < (first_filled_entry.safe_filled * 0.95)
     is_derisk_calc = False
     is_rebuy_mode = all(c in self.long_rebuy_mode_tags for c in enter_tags) or (
       any(c in self.long_rebuy_mode_tags for c in enter_tags)
@@ -47545,7 +47549,7 @@ class NostalgiaForInfinityX7(IStrategy):
         )
 
     is_not_trade_max_stake = current_stake_amount < (
-      (filled_entries[0].cost * self.grinding_v1_max_stake)
+      (first_filled_entry.cost * self.grinding_v1_max_stake)
       / (
         (self.grind_mode_stake_multiplier_futures[0] if is_futures else self.grind_mode_stake_multiplier_spot[0])
         if is_grind_mode
@@ -48044,7 +48048,7 @@ class NostalgiaForInfinityX7(IStrategy):
           return -ft_sell_amount
 
     if is_grind_mode and (
-      (filled_entries[0].safe_filled * (trade_stake_amount / trade_amount) - (min_stake * 1.5)) > min_stake
+      (first_filled_entry.safe_filled * (trade_stake_amount / trade_amount) - (min_stake * 1.5)) > min_stake
     ):
       is_first_entry_exit_found = False
       for order in filled_orders:
@@ -48060,7 +48064,7 @@ class NostalgiaForInfinityX7(IStrategy):
             is_first_entry_exit_found = True
             break
       if not is_first_entry_exit_found:
-        first_entry = filled_entries[0]
+        first_entry = first_filled_entry
         first_entry_distance_ratio = (exit_rate - first_entry.safe_price) / first_entry.safe_price
         # First entry exit
         if first_entry_distance_ratio > (
@@ -48162,11 +48166,11 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           or ((is_derisk or is_derisk_calc) and grind_1_derisk_1_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -48309,11 +48313,11 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           or ((is_derisk or is_derisk_calc) and grind_2_derisk_1_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -48447,11 +48451,11 @@ class NostalgiaForInfinityX7(IStrategy):
           or ((is_derisk or is_derisk_calc) and grind_1_sub_grind_count == 0)
           or (is_grind_mode and grind_1_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -48626,11 +48630,11 @@ class NostalgiaForInfinityX7(IStrategy):
           or ((is_derisk or is_derisk_calc) and grind_2_sub_grind_count == 0)
           or (is_grind_mode and grind_2_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -48764,11 +48768,11 @@ class NostalgiaForInfinityX7(IStrategy):
           or ((is_derisk or is_derisk_calc) and grind_3_sub_grind_count == 0)
           or (is_grind_mode and grind_3_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -48902,11 +48906,11 @@ class NostalgiaForInfinityX7(IStrategy):
           or ((is_derisk or is_derisk_calc) and grind_4_sub_grind_count == 0)
           or (is_grind_mode and grind_4_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -49040,11 +49044,11 @@ class NostalgiaForInfinityX7(IStrategy):
           or ((is_derisk or is_derisk_calc) and grind_5_sub_grind_count == 0)
           or (is_grind_mode and grind_5_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -49178,11 +49182,11 @@ class NostalgiaForInfinityX7(IStrategy):
           or ((is_derisk or is_derisk_calc) and grind_6_sub_grind_count == 0)
           or (is_grind_mode and grind_6_sub_grind_count == 0)
         )
-        and (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -49318,11 +49322,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
     ):
       if (
-        (grind_entry_retry_time > filled_entries[-1].order_filled_utc)
-        and ((grind_force_order_age_time > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        (grind_entry_retry_time > last_filled_entry.order_filled_utc)
+        and ((grind_force_order_age_time > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and (
           (num_open_grinds == 0)
-          or (grind_order_age_time > filled_orders[-1].order_filled_utc)
+          or (grind_order_age_time > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))


### PR DESCRIPTION
## Summary
- Reuses named first/last filled-order references in `long_grind_adjust_trade_position()`.
- Replaces repeated `filled_entries[...]` and `filled_orders[-1]` indexing after the order snapshot and entry-count guard.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same long grind conditions, order classification, profit arithmetic, stake sizing, thresholds, condition order, and return values.
- The patch only names already-available filled-order references inside the same adjust call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact list-reference reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
