### PR TITLE
Reuse X7 long no-derisk order references

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -49626,6 +49626,9 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_leverage = trade.leverage
     stake_scale_leverage = trade_leverage if is_futures else 1.0
 
+    last_filled_entry = filled_entries[-1]
+    last_filled_order = filled_orders[-1]
+
     max_rebuy_sub_grinds = 0
     regular_mode_rebuy_stakes = scale_stakes_for_min_stake(
       self.regular_mode_rebuy_stakes_futures if is_futures else self.regular_mode_rebuy_stakes_spot,
@@ -50080,8 +50083,8 @@ class NostalgiaForInfinityX7(IStrategy):
           (rebuy_distance_ratio if (rebuy_sub_grind_count > 0) else profit_init_ratio)
           < (regular_mode_rebuy_sub_thresholds[rebuy_sub_grind_count])
         )
-        and (current_time - timedelta(minutes=10) > filled_entries[-1].order_filled_utc)
-        and ((current_time - timedelta(hours=12) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.06))
+        and (current_time - timedelta(minutes=10) > last_filled_entry.order_filled_utc)
+        and ((current_time - timedelta(hours=12) > last_filled_order.order_filled_utc) or (slice_profit < -0.06))
         and is_long_grind_entry
       ):
         buy_amount = slice_amount * regular_mode_rebuy_stakes[rebuy_sub_grind_count] / stake_scale_leverage
@@ -50117,11 +50120,11 @@ class NostalgiaForInfinityX7(IStrategy):
           (grind_1_distance_ratio if (grind_1_sub_grind_count > 0) else profit_init_ratio)
           < (regular_mode_grind_1_sub_thresholds[grind_1_sub_grind_count])
         )
-        and (current_time - timedelta(minutes=10) > filled_entries[-1].order_filled_utc)
-        and ((current_time - timedelta(hours=2) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.02))
+        and (current_time - timedelta(minutes=10) > last_filled_entry.order_filled_utc)
+        and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or (slice_profit < -0.02))
         and (
           (num_open_grinds == 0)
-          or (current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc)
+          or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -50279,11 +50282,11 @@ class NostalgiaForInfinityX7(IStrategy):
           (grind_2_distance_ratio if (grind_2_sub_grind_count > 0) else profit_init_ratio)
           < (regular_mode_grind_2_sub_thresholds[grind_2_sub_grind_count])
         )
-        and (current_time - timedelta(minutes=10) > filled_entries[-1].order_filled_utc)
-        and ((current_time - timedelta(hours=2) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.02))
+        and (current_time - timedelta(minutes=10) > last_filled_entry.order_filled_utc)
+        and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or (slice_profit < -0.02))
         and (
           (num_open_grinds == 0)
-          or (current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc)
+          or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -50404,11 +50407,11 @@ class NostalgiaForInfinityX7(IStrategy):
           (grind_3_distance_ratio if (grind_3_sub_grind_count > 0) else profit_init_ratio)
           < (regular_mode_grind_3_sub_thresholds[grind_3_sub_grind_count])
         )
-        and (current_time - timedelta(minutes=10) > filled_entries[-1].order_filled_utc)
-        and ((current_time - timedelta(hours=2) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.02))
+        and (current_time - timedelta(minutes=10) > last_filled_entry.order_filled_utc)
+        and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or (slice_profit < -0.02))
         and (
           (num_open_grinds == 0)
-          or (current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc)
+          or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -50529,11 +50532,11 @@ class NostalgiaForInfinityX7(IStrategy):
           (grind_4_distance_ratio if (grind_4_sub_grind_count > 0) else profit_init_ratio)
           < (regular_mode_grind_4_sub_thresholds[grind_4_sub_grind_count])
         )
-        and (current_time - timedelta(minutes=10) > filled_entries[-1].order_filled_utc)
-        and ((current_time - timedelta(hours=2) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.02))
+        and (current_time - timedelta(minutes=10) > last_filled_entry.order_filled_utc)
+        and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or (slice_profit < -0.02))
         and (
           (num_open_grinds == 0)
-          or (current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc)
+          or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -50654,11 +50657,11 @@ class NostalgiaForInfinityX7(IStrategy):
           (grind_5_distance_ratio if (grind_5_sub_grind_count > 0) else profit_init_ratio)
           < (regular_mode_grind_5_sub_thresholds[grind_5_sub_grind_count])
         )
-        and (current_time - timedelta(minutes=10) > filled_entries[-1].order_filled_utc)
-        and ((current_time - timedelta(hours=2) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.02))
+        and (current_time - timedelta(minutes=10) > last_filled_entry.order_filled_utc)
+        and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or (slice_profit < -0.02))
         and (
           (num_open_grinds == 0)
-          or (current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc)
+          or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         and ((num_open_grinds == 0) or (slice_profit < -0.03))
@@ -50779,11 +50782,11 @@ class NostalgiaForInfinityX7(IStrategy):
           (grind_6_distance_ratio if (grind_6_sub_grind_count > 0) else profit_init_ratio)
           < (regular_mode_grind_6_sub_thresholds[grind_6_sub_grind_count])
         )
-        and (current_time - timedelta(minutes=10) > filled_entries[-1].order_filled_utc)
-        and ((current_time - timedelta(hours=2) > filled_orders[-1].order_filled_utc) or (slice_profit < -0.02))
+        and (current_time - timedelta(minutes=10) > last_filled_entry.order_filled_utc)
+        and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or (slice_profit < -0.02))
         and (
           (num_open_grinds == 0)
-          or (current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc)
+          or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
           or (slice_profit < -0.06)
         )
         # and ((num_open_grinds == 0) or (slice_profit < -0.03))


### PR DESCRIPTION
## Summary
- Reuses named last filled-order references in `long_adjust_trade_position_no_derisk()`.
- Replaces repeated `filled_entries[-1]` and `filled_orders[-1]` indexing inside the regular-mode long helper.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: same long no-derisk conditions, order classification, profit arithmetic, stake sizing, thresholds, condition order, and return values.
- The patch only names already-available filled-order references inside the same adjust call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact list-reference reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
