### PR TITLE
Reuse X7 entry slippage limit

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12250,6 +12250,8 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           return False
 
+    max_slippage = self.max_slippage
+
     # Slippage Validation
     df, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
     if len(df) >= 1:
@@ -12257,7 +12259,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_close = last_candle["close"]
       if (side == "long" and rate > last_close) or (side == "short" and rate < last_close):
         slippage = (rate / last_close) - 1.0
-        if (side == "long" and slippage < self.max_slippage) or (side == "short" and slippage > -self.max_slippage):
+        if (side == "long" and slippage < max_slippage) or (side == "short" and slippage > -max_slippage):
           return True
         else:
           log.warning(f"[{current_time}] Cancelling entry for {pair} due to slippage {(slippage * 100.0):.2f}%")


### PR DESCRIPTION
## Summary
- Stores the configured max slippage once in confirm_trade_entry().
- Reuses that value for the existing long and short slippage checks.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same entry slippage validation, slot guards, branch conditions, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
