### PR TITLE
Reuse X7 long grind-v2 flags

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -40641,6 +40641,10 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_leverage = trade.leverage
     trade_get_custom_data = trade.get_custom_data
     trade_set_custom_data = trade.set_custom_data
+    trade_is_short = trade.is_short
+    derisk_enable = self.derisk_enable
+    long_rebuy_mode_tags = self.long_rebuy_mode_tags
+    long_grind_mode_tags = self.long_grind_mode_tags
 
     min_stake = self.correct_min_stake(min_stake)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
@@ -40659,7 +40663,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
         exit_price_side = self.config["exit_pricing"]["price_side"]
-        if trade.is_short:
+        if trade_is_short:
           if exit_price_side in ["ask", "other"]:
             if ticker["ask"] is not None:
               exit_rate = ticker["ask"]
@@ -40680,9 +40684,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
     )
 
-    is_rebuy_mode = all(c in self.long_rebuy_mode_tags for c in enter_tags) or (
-      any(c in self.long_rebuy_mode_tags for c in enter_tags)
-      and all(c in (self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags)
+    is_rebuy_mode = all(c in long_rebuy_mode_tags for c in enter_tags) or (
+      any(c in long_rebuy_mode_tags for c in enter_tags)
+      and all(c in (long_rebuy_mode_tags + long_grind_mode_tags) for c in enter_tags)
     )
 
     has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
@@ -41180,8 +41184,8 @@ class NostalgiaForInfinityX7(IStrategy):
         is_futures
         and trade.liquidation_price is not None
         and (
-          (trade.is_short and current_rate > trade.liquidation_price * 0.90)
-          or (not trade.is_short and current_rate < trade.liquidation_price * 1.10)
+          (trade_is_short and current_rate > trade.liquidation_price * 0.90)
+          or (not trade_is_short and current_rate < trade.liquidation_price * 1.10)
         )
         and (slice_profit < -0.03)
         and (last_candle["RSI_3"] > 10.0)
@@ -41197,7 +41201,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # flag it
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
@@ -41217,7 +41221,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     flag_is_derisk_level_1 = False
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
@@ -41232,7 +41236,7 @@ class NostalgiaForInfinityX7(IStrategy):
           flag_is_derisk_level_1 = True
 
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
@@ -41284,7 +41288,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # flag it
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
@@ -41304,7 +41308,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     flag_is_derisk_level_2 = False
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
@@ -41319,7 +41323,7 @@ class NostalgiaForInfinityX7(IStrategy):
           flag_is_derisk_level_2 = True
 
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
@@ -41371,7 +41375,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # flag it
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode
@@ -41391,7 +41395,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     flag_is_derisk_level_3 = False
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode
@@ -41406,7 +41410,7 @@ class NostalgiaForInfinityX7(IStrategy):
           flag_is_derisk_level_3 = True
 
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode


### PR DESCRIPTION
## Summary
- Stores repeated long grind-v2 flags and mode tags once.
- Reuses those values for existing live/dry, derisk, and rebuy-mode checks.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same long grind-v2 adjust conditions, mode-tag checks, derisk guards, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
