### PR TITLE
Reuse X7 short grind-v2 flags

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -64853,6 +64853,10 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_leverage = trade.leverage
     trade_get_custom_data = trade.get_custom_data
     trade_set_custom_data = trade.set_custom_data
+    trade_is_short = trade.is_short
+    derisk_enable = self.derisk_enable
+    short_rebuy_mode_tags = self.short_rebuy_mode_tags
+    short_grind_mode_tags = self.short_grind_mode_tags
 
     min_stake = self.correct_min_stake(min_stake)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
@@ -64871,7 +64875,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
         exit_price_side = self.config["exit_pricing"]["price_side"]
-        if trade.is_short:
+        if trade_is_short:
           if exit_price_side in ["ask", "other"]:
             if ticker["ask"] is not None:
               exit_rate = ticker["ask"]
@@ -64892,9 +64896,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
     )
 
-    is_rebuy_mode = all(c in self.short_rebuy_mode_tags for c in enter_tags) or (
-      any(c in self.short_rebuy_mode_tags for c in enter_tags)
-      and all(c in (self.short_rebuy_mode_tags + self.short_grind_mode_tags) for c in enter_tags)
+    is_rebuy_mode = all(c in short_rebuy_mode_tags for c in enter_tags) or (
+      any(c in short_rebuy_mode_tags for c in enter_tags)
+      and all(c in (short_rebuy_mode_tags + short_grind_mode_tags) for c in enter_tags)
     )
 
     has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
@@ -65392,8 +65396,8 @@ class NostalgiaForInfinityX7(IStrategy):
         is_futures
         and trade.liquidation_price is not None
         and (
-          (trade.is_short and current_rate > trade.liquidation_price * 0.90)
-          or (not trade.is_short and current_rate < trade.liquidation_price * 1.10)
+          (trade_is_short and current_rate > trade.liquidation_price * 0.90)
+          or (not trade_is_short and current_rate < trade.liquidation_price * 1.10)
         )
         and (slice_profit > 0.03)
         and (last_candle["RSI_3"] < 90.0)
@@ -65409,7 +65413,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # flag it
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
@@ -65429,7 +65433,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     flag_is_derisk_level_1 = False
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
@@ -65444,7 +65448,7 @@ class NostalgiaForInfinityX7(IStrategy):
           flag_is_derisk_level_1 = True
 
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_1_enable
       and (not is_derisk_1_found)
       and not is_rebuy_mode
@@ -65496,7 +65500,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # flag it
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
@@ -65516,7 +65520,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     flag_is_derisk_level_2 = False
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
@@ -65531,7 +65535,7 @@ class NostalgiaForInfinityX7(IStrategy):
           flag_is_derisk_level_2 = True
 
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_2_enable
       and (not is_derisk_2_found)
       and not is_rebuy_mode
@@ -65583,7 +65587,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # flag it
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode
@@ -65603,7 +65607,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     flag_is_derisk_level_3 = False
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode
@@ -65618,7 +65622,7 @@ class NostalgiaForInfinityX7(IStrategy):
           flag_is_derisk_level_3 = True
 
     if (
-      self.derisk_enable
+      derisk_enable
       and self.grinding_v2_derisk_level_3_enable
       and (not is_derisk_3_found)
       and not is_rebuy_mode


### PR DESCRIPTION
## Summary
- Stores repeated short grind-v2 flags and mode tags once.
- Reuses those values for existing live/dry, derisk, and rebuy-mode checks.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same short grind-v2 adjust conditions, mode-tag checks, derisk guards, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
