### PR TITLE
Reuse X7 long grind mode flags

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -45017,6 +45017,9 @@ class NostalgiaForInfinityX7(IStrategy):
       return None
 
     is_futures = self.is_futures_mode
+    derisk_use_grind_stops = self.derisk_use_grind_stops
+    long_rebuy_mode_tags = self.long_rebuy_mode_tags
+    long_grind_mode_tags = self.long_grind_mode_tags
     trade_leverage = trade.leverage
 
     min_stake = self.correct_min_stake(min_stake)
@@ -45069,11 +45072,11 @@ class NostalgiaForInfinityX7(IStrategy):
     current_stake_amount = trade_amount * current_rate
     is_derisk = trade_amount < (first_filled_entry.safe_filled * 0.95)
     is_derisk_calc = False
-    is_rebuy_mode = all(c in self.long_rebuy_mode_tags for c in enter_tags) or (
-      any(c in self.long_rebuy_mode_tags for c in enter_tags)
-      and all(c in (self.long_rebuy_mode_tags + self.long_grind_mode_tags) for c in enter_tags)
+    is_rebuy_mode = all(c in long_rebuy_mode_tags for c in enter_tags) or (
+      any(c in long_rebuy_mode_tags for c in enter_tags)
+      and all(c in (long_rebuy_mode_tags + long_grind_mode_tags) for c in enter_tags)
     )
-    is_grind_mode = all(c in self.long_grind_mode_tags for c in enter_tags)
+    is_grind_mode = all(c in long_grind_mode_tags for c in enter_tags)
 
     fee_open_rate = trade_fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade_fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
@@ -45693,7 +45696,7 @@ class NostalgiaForInfinityX7(IStrategy):
             else:
               return -ft_sell_amount
         # First entry de-risk
-        if self.derisk_use_grind_stops and (
+        if derisk_use_grind_stops and (
           first_entry_distance_ratio
           < (
             self.grind_mode_first_entry_stop_threshold_spot
@@ -45834,7 +45837,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (grind_1_derisk_1_sub_grind_count > 0)
       # and (
       #   ((exit_rate - grind_1_derisk_1_current_open_rate) / grind_1_derisk_1_current_open_rate)
@@ -45981,7 +45984,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (grind_2_derisk_1_sub_grind_count > 0)
       # and (
       #   ((exit_rate - grind_2_derisk_1_current_open_rate) / grind_2_derisk_1_current_open_rate)
@@ -46161,7 +46164,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (
         (grind_1_sub_grind_count > 0)
         # and (((exit_rate - grind_1_current_open_rate) / grind_1_current_open_rate) < grind_1_stop_grinds)
@@ -46299,7 +46302,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (
         (grind_2_sub_grind_count > 0)
         # and (((exit_rate - grind_2_current_open_rate) / grind_2_current_open_rate) < grind_2_stop_grinds)
@@ -46437,7 +46440,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (
         (grind_3_sub_grind_count > 0)
         # and (((exit_rate - grind_3_current_open_rate) / grind_3_current_open_rate) < grind_3_stop_grinds)
@@ -46575,7 +46578,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (
         (grind_4_sub_grind_count > 0)
         # and (((exit_rate - grind_4_current_open_rate) / grind_4_current_open_rate) < grind_4_stop_grinds)
@@ -46713,7 +46716,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (
         (grind_5_sub_grind_count > 0)
         # and (((exit_rate - grind_5_current_open_rate) / grind_5_current_open_rate) < grind_5_stop_grinds)
@@ -46851,7 +46854,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Grind stop
     if (
-      self.derisk_use_grind_stops
+      derisk_use_grind_stops
       and (
         (grind_6_sub_grind_count > 0)
         # and (((exit_rate - grind_6_current_open_rate) / grind_6_current_open_rate) < grind_6_stop_grinds)


### PR DESCRIPTION
## Summary
- Stores long grind mode tags and grind-stop flag once.
- Reuses those values across the existing regular long grind checks.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same long grind adjust conditions, mode-tag checks, grind-stop guards, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
