### PR TITLE
Reuse X7 short no-derisk stop flag

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -71030,6 +71030,7 @@ class NostalgiaForInfinityX7(IStrategy):
     is_futures = self.is_futures_mode
     trade_leverage = trade.leverage
     stake_scale_leverage = trade_leverage if is_futures else 1.0
+    regular_mode_use_grind_stops = self.regular_mode_use_grind_stops
 
     last_filled_entry = filled_entries[-1]
     last_filled_order = filled_orders[-1]
@@ -71638,7 +71639,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if (
       (
         (grind_1_sub_grind_count > 0)
-        and self.regular_mode_use_grind_stops
+        and regular_mode_use_grind_stops
         and ((-(exit_rate - grind_1_current_open_rate) / grind_1_current_open_rate) < regular_mode_grind_1_stop_grinds)
       )
       # temporary
@@ -71763,7 +71764,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if (
       (
         (grind_2_sub_grind_count > 0)
-        and self.regular_mode_use_grind_stops
+        and regular_mode_use_grind_stops
         and ((-(exit_rate - grind_2_current_open_rate) / grind_2_current_open_rate) < regular_mode_grind_2_stop_grinds)
       )
       # temporary
@@ -71888,7 +71889,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if (
       (
         (grind_3_sub_grind_count > 0)
-        and self.regular_mode_use_grind_stops
+        and regular_mode_use_grind_stops
         and ((-(exit_rate - grind_3_current_open_rate) / grind_3_current_open_rate) < regular_mode_grind_3_stop_grinds)
       )
       # temporary
@@ -72013,7 +72014,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if (
       (
         (grind_4_sub_grind_count > 0)
-        and self.regular_mode_use_grind_stops
+        and regular_mode_use_grind_stops
         and ((-(exit_rate - grind_4_current_open_rate) / grind_4_current_open_rate) < regular_mode_grind_4_stop_grinds)
       )
       # temporary
@@ -72138,7 +72139,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if (
       (
         (grind_5_sub_grind_count > 0)
-        and self.regular_mode_use_grind_stops
+        and regular_mode_use_grind_stops
         and ((-(exit_rate - grind_5_current_open_rate) / grind_5_current_open_rate) < regular_mode_grind_5_stop_grinds)
       )
       # temporary
@@ -72263,7 +72264,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if (
       (
         (grind_6_sub_grind_count > 0)
-        and self.regular_mode_use_grind_stops
+        and regular_mode_use_grind_stops
         and ((-(exit_rate - grind_6_current_open_rate) / grind_6_current_open_rate) < regular_mode_grind_6_stop_grinds)
       )
       # temporary


### PR DESCRIPTION
## Summary
- Stores the regular-mode grind-stop flag once in short_adjust_trade_position_no_derisk().
- Reuses it across the existing short no-derisk stop checks.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same short no-derisk adjust conditions, grind-stop guards, stake sizing, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
