### PR TITLE
Reuse X7 short grind-entry-v2 fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -66948,9 +66948,16 @@ class NostalgiaForInfinityX7(IStrategy):
     last_roc_2_4h = last_candle["ROC_2_4h"]
     last_roc_9_1h = last_candle["ROC_9_1h"]
     last_roc_9_4h = last_candle["ROC_9_4h"]
+    last_protections_short_global = last_candle["protections_short_global"]
+    last_enter_short = last_candle["enter_short"]
+    last_stochrsi_k_15m = last_candle["STOCHRSIk_14_14_3_3_15m"]
+    last_stochrsi_k_1h = last_candle["STOCHRSIk_14_14_3_3_1h"]
+    last_stochrsi_k_4h = last_candle["STOCHRSIk_14_14_3_3_4h"]
+    last_low_min_24_4h = last_candle["low_min_24_4h"]
+    last_ema_16 = last_candle["EMA_16"]
 
-    if (last_candle["protections_short_global"] == True) and (
-      (last_candle["enter_short"] == True)
+    if (last_protections_short_global == True) and (
+      (last_enter_short == True)
       or (
         (last_rsi_14 > 54.0)
         and (last_rsi_3 < 90.0)
@@ -66973,7 +66980,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_low_min_6_1h * 1.18))
         and (last_close < (last_low_min_12_1h * 1.25))
         and (last_close > (last_high_max_24_4h * 0.85))
-        and (last_close > (last_candle["EMA_16"] * 1.032))
+        and (last_close > (last_ema_16 * 1.032))
       )
       or (
         (last_rsi_14 > 64.0)
@@ -67126,7 +67133,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 95.0)
         and (last_rsi_3_15m < 75.0)
         and (last_rsi_3_1h < 70.0)
-        and (last_close > (last_candle["low_min_24_4h"] * 1.10))
+        and (last_close > (last_low_min_24_4h * 1.10))
         and (last_close > (last_close_min_48 * 1.10))
         and (last_close < (last_candle["close_max_12"] * 0.92))
       )
@@ -67178,7 +67185,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_aroond_14 < 25.0)
         and (last_aroond_14_15m < 30.0)
         and (last_stochrsik_14_14_3_3 > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3_15m"] > 70.0)
+        and (last_stochrsi_k_15m > 70.0)
         and (last_rsi_14_1h > 50.0)
         and (last_candle["RSI_14_4h"] > 50.0)
       )


### PR DESCRIPTION
## Summary
- Stores repeated short grind-entry-v2 candle fields once.
- Reuses those fields across the existing short grind-entry-v2 checks.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same short grind-entry-v2 conditions, thresholds, signal decisions, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
