### PR TITLE
Reuse X7 long-exit decision fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -28640,6 +28640,16 @@ class NostalgiaForInfinityX7(IStrategy):
     last_roc_9_1d = last_candle["ROC_9_1d"]
     last_rsi_3_1h = last_candle["RSI_3_1h"]
     last_rsi_14 = last_candle["RSI_14"]
+    last_rsi_3_1d = last_candle["RSI_3_1d"]
+    last_aroonu_14_4h = last_candle["AROONU_14_4h"]
+    last_roc_9_1h = last_candle["ROC_9_1h"]
+    last_aroonu_14_1h = last_candle["AROONU_14_1h"]
+    last_rsi_3_15m = last_candle["RSI_3_15m"]
+    last_rsi_14_4h = last_candle["RSI_14_4h"]
+    last_ema_200_1h = last_candle["EMA_200_1h"]
+    last_ema_200_4h = last_candle["EMA_200_4h"]
+    last_change_pct_1d = last_candle["change_pct_1d"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
     last_rsi_3_4h = last_candle["RSI_3_4h"]
     last_willr_14 = last_candle["WILLR_14"]
     last_stochrsi_k_4h = last_candle["STOCHRSIk_14_14_3_3_4h"]
@@ -28650,12 +28660,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -28664,17 +28670,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_2"
       elif (
         (last_willr_14 > -1.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 99.0)
+        and (last_stochrsi_k > 99.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -28683,41 +28685,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
-      elif (
-        (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_7"
       elif (
         (last_willr_14 > -1.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 99.0)
+        and (last_stochrsi_k > 99.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_0_8"
@@ -28731,7 +28727,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -28740,7 +28736,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_0_11"
@@ -28748,27 +28744,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_0_12"
       elif (last_rsi_3 > 99.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_0_13"
-      elif (
-        (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_14"
       elif (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
@@ -28790,12 +28781,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_0_19"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_0_20"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_0_21"
@@ -28807,16 +28793,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
-      elif (
-        (last_rsi_3 > 98.0) and (last_willr_14 > -5.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 98.0) and (last_willr_14 > -5.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
         (last_rsi_3 > 99.0)
         and (last_rsi_14 > 78.0)
         and (last_willr_14 > -5.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
@@ -28837,9 +28821,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_27"
-      elif (
-        (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
         (last_rsi_3 > 95.0)
@@ -28870,29 +28852,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_34"
-      elif (
-        (last_rsi_3 > 95.0)
-        and (last_willr_14 > -5.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -1.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_36"
@@ -28900,7 +28877,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_37"
@@ -28946,7 +28923,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
@@ -28960,7 +28937,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_0_47"
@@ -28976,16 +28953,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -2.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_0_50"
       elif (last_rsi_3 > 68.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_0_51"
@@ -29011,7 +28983,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
@@ -29057,7 +29029,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -29070,14 +29042,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_0_62"
       elif (
-        (last_rsi_3 > 98.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 98.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
@@ -29117,12 +29086,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_70"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_0_71"
-      elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
         (last_rsi_3 > 95.0)
@@ -29136,7 +29100,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_74"
@@ -29147,12 +29111,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_75"
-      elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 48.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 48.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
         (last_rsi_3 > 95.0)
@@ -29166,7 +29125,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -14.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
       elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -29191,7 +29150,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_82"
@@ -29215,9 +29174,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_86"
@@ -29240,7 +29199,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
@@ -29249,7 +29208,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_90"
@@ -29258,7 +29217,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_91"
@@ -29274,10 +29233,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -29287,7 +29246,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_0_94"
@@ -29304,7 +29263,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_96"
@@ -29312,16 +29271,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_97"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_15m"] > 74.0)
+        and (last_rsi_3_15m > 74.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_98"
@@ -29330,14 +29289,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
-      elif (
-        (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
         (last_rsi_3 > 86.0)
@@ -29360,7 +29317,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_103"
@@ -29376,7 +29333,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -29386,7 +29343,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_106"
@@ -29395,7 +29352,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_107"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -29414,9 +29371,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_111"
@@ -29426,14 +29383,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -29444,37 +29401,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_115"
-      elif (
-        (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_0_116"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 95.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_117"
-      elif (
-        (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
         (last_rsi_3 > 95.0)
@@ -29484,22 +29428,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_119"
-      elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_0_120"
-      elif (
-        (last_rsi_3 > 95.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_121"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_0_122"
-      elif (
-        (last_rsi_3 > 95.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
         (last_rsi_3 > 95.0)
@@ -29512,17 +29447,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -2.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (
-        (last_rsi_3 > 95.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
         (last_rsi_3 > 95.0)
@@ -29543,14 +29476,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
         (last_rsi_3 > 95.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_133"
@@ -29558,12 +29491,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -29572,17 +29501,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 68.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_2"
       elif (
         (last_willr_14 > -8.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 99.0)
+        and (last_stochrsi_k > 99.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -29591,41 +29516,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -30.0)
         and (last_rsi_14 > 65.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_4"
-      elif (
-        (last_willr_14 > -2.0) and (last_rsi_14 > 72.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -2.0) and (last_rsi_14 > 72.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_1_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
       elif (
         (last_willr_14 > -2.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_1_8"
@@ -29639,7 +29558,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -20.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -29648,7 +29567,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_1_11"
@@ -29656,27 +29575,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_1_12"
       elif (last_rsi_3 > 80.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_1_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -4.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_1_14"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 > 75.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_1_16"
       elif (
@@ -29698,12 +29612,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_1_19"
-      elif (
-        (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_1_20"
       elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_1_21"
@@ -29715,16 +29624,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
-      elif (
-        (last_rsi_3 > 95.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
         (last_rsi_3 > 95.0)
         and (last_rsi_14 > 75.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_24"
       elif (
@@ -29745,9 +29652,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_27"
-      elif (
-        (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
         (last_rsi_3 > 90.0)
@@ -29778,29 +29683,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -2.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_34"
-      elif (
-        (last_rsi_3 > 88.0)
-        and (last_willr_14 > -6.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_1_35"
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -15.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_36"
@@ -29808,7 +29708,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_37"
@@ -29854,7 +29754,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_willr_14 > -5.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
@@ -29868,7 +29768,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_1_47"
@@ -29884,16 +29784,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -4.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -4.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_1_50"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_1_51"
@@ -29919,7 +29814,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_1_54"
       elif (
@@ -29965,7 +29860,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -29978,14 +29873,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_1_62"
       elif (
-        (last_rsi_3 > 68.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 68.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
@@ -30025,12 +29917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_70"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_1_71"
-      elif (
-        (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 78.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_1_72"
       elif (
         (last_rsi_3 > 78.0)
@@ -30044,7 +29931,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_74"
@@ -30055,12 +29942,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_75"
-      elif (
-        (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 50.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3 > 76.0)
@@ -30074,7 +29956,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -16.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_78"
       elif (last_rsi_3 > 92.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -30099,7 +29981,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_82"
@@ -30123,9 +30005,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_85"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_86"
@@ -30148,7 +30030,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
@@ -30157,7 +30039,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_90"
@@ -30166,7 +30048,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_91"
@@ -30182,10 +30064,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -30195,7 +30077,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_1_94"
@@ -30212,7 +30094,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 62.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_96"
@@ -30220,16 +30102,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_97"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_15m"] > 72.0)
+        and (last_rsi_3_15m > 72.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_98"
@@ -30238,14 +30120,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
-      elif (
-        (last_rsi_3 > 98.0) and (last_rsi_14 > 76.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 98.0) and (last_rsi_14 > 76.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_1_100"
       elif (
         (last_rsi_3 > 84.0)
@@ -30268,7 +30148,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_103"
@@ -30284,7 +30164,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -30294,7 +30174,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_106"
@@ -30303,7 +30183,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_107"
       elif (last_rsi_3 > 56.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -30322,9 +30202,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_1_111"
@@ -30334,14 +30214,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -2.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -30352,37 +30232,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_114"
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_115"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_1_116"
       elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 86.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_117"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_1_118"
       elif (
         (last_rsi_3 > 86.0)
@@ -30392,22 +30259,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_119"
-      elif (
-        (last_rsi_3 > 54.0)
-        and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_1_120"
-      elif (
-        (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_121"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_1_122"
-      elif (
-        (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
         (last_rsi_3 > 88.0)
@@ -30420,17 +30278,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -4.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_1_126"
-      elif (
-        (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_1_127"
-      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
       elif (
         (last_rsi_3 > 86.0)
@@ -30451,14 +30307,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_132"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_133"
@@ -30466,12 +30322,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -30480,17 +30332,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 66.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_2"
       elif (
         (last_willr_14 > -10.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 99.0)
+        and (last_stochrsi_k > 99.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -30499,41 +30347,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -30.0)
         and (last_rsi_14 > 65.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_4"
-      elif (
-        (last_willr_14 > -4.0) and (last_rsi_14 > 70.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -4.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_2_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
       elif (
         (last_willr_14 > -4.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_2_8"
@@ -30547,7 +30389,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -20.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -30556,7 +30398,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_2_11"
@@ -30564,27 +30406,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_2_12"
       elif (last_rsi_3 > 80.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_2_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -6.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -6.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_2_14"
       elif (last_rsi_3 > 92.0) and (last_rsi_14 > 70.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_2_16"
       elif (
@@ -30606,12 +30443,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_2_19"
-      elif (
-        (last_rsi_3 > 48.0)
-        and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 48.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_2_20"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_2_21"
@@ -30623,16 +30455,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
-      elif (
-        (last_rsi_3 > 90.0) and (last_willr_14 > -15.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -15.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14 > 70.0)
         and (last_willr_14 > -20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_24"
       elif (
@@ -30653,9 +30483,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_27"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
         (last_rsi_3 > 75.0)
@@ -30686,29 +30514,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -4.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_34"
-      elif (
-        (last_rsi_3 > 86.0)
-        and (last_willr_14 > -7.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -7.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_2_35"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -20.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_36"
@@ -30716,7 +30539,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_37"
@@ -30762,7 +30585,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 60.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
@@ -30776,7 +30599,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_2_47"
@@ -30792,16 +30615,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -6.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -6.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_2_50"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_2_51"
@@ -30827,7 +30645,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_2_54"
       elif (
@@ -30873,7 +30691,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -30886,14 +30704,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_2_62"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 66.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
@@ -30933,12 +30748,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_70"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_2_71"
-      elif (
-        (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 76.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_2_72"
       elif (
         (last_rsi_3 > 76.0)
@@ -30952,7 +30762,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 97.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_74"
@@ -30963,12 +30773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_75"
-      elif (
-        (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 52.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 66.0) and (last_rsi_14 < 52.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
         (last_rsi_3 > 74.0)
@@ -30982,7 +30787,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -18.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_78"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -31007,7 +30812,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -12.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_82"
@@ -31031,9 +30836,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_85"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_86"
@@ -31056,7 +30861,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
@@ -31065,7 +30870,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_90"
@@ -31074,7 +30879,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_91"
@@ -31090,10 +30895,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 52.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -31103,7 +30908,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_2_94"
@@ -31120,7 +30925,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 60.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_96"
@@ -31128,16 +30933,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_97"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_98"
@@ -31146,14 +30951,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
-      elif (
-        (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_2_100"
       elif (
         (last_rsi_3 > 82.0)
@@ -31176,7 +30979,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_103"
@@ -31192,7 +30995,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -31202,7 +31005,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_106"
@@ -31211,7 +31014,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_107"
       elif (last_rsi_3 > 54.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -31230,9 +31033,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 48.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_2_111"
@@ -31242,14 +31045,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -4.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -31260,37 +31063,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_115"
-      elif (
-        (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_2_116"
       elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 84.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_117"
-      elif (
-        (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_2_118"
       elif (
         (last_rsi_3 > 84.0)
@@ -31300,22 +31090,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_119"
-      elif (
-        (last_rsi_3 > 52.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_2_120"
-      elif (
-        (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_121"
       elif (last_rsi_3 > 56.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_2_122"
-      elif (
-        (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
         (last_rsi_3 > 86.0)
@@ -31328,17 +31109,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -6.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_2_126"
-      elif (
-        (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_2_127"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
       elif (
         (last_rsi_3 > 84.0)
@@ -31359,14 +31138,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_132"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_133"
@@ -31374,12 +31153,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -31388,17 +31163,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 64.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
         (last_willr_14 > -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -31407,41 +31178,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -30.0)
         and (last_rsi_14 > 65.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_4"
-      elif (
-        (last_willr_14 > -6.0) and (last_rsi_14 > 68.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -6.0) and (last_rsi_14 > 68.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
         (last_willr_14 > -6.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_3_8"
@@ -31455,7 +31220,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -20.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -31464,7 +31229,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_3_11"
@@ -31472,27 +31237,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_3_12"
       elif (last_rsi_3 > 80.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_3_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -8.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -8.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_14"
       elif (last_rsi_3 > 90.0) and (last_rsi_14 > 65.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
@@ -31514,12 +31274,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_3_19"
-      elif (
-        (last_rsi_3 > 46.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 46.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_3_20"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_3_21"
@@ -31531,16 +31286,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
-      elif (
-        (last_rsi_3 > 85.0) and (last_willr_14 > -20.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_willr_14 > -20.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
         (last_rsi_3 > 88.0)
         and (last_rsi_14 > 68.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
@@ -31561,9 +31314,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_27"
-      elif (
-        (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
         (last_rsi_3 > 75.0)
@@ -31594,29 +31345,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -6.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_34"
-      elif (
-        (last_rsi_3 > 84.0)
-        and (last_willr_14 > -8.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_36"
@@ -31624,7 +31370,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_37"
@@ -31670,7 +31416,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 55.0)
         and (last_willr_14 > -15.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
@@ -31684,7 +31430,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_3_47"
@@ -31700,16 +31446,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -8.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_3_50"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_3_51"
@@ -31735,7 +31476,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
@@ -31781,7 +31522,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -31794,14 +31535,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_3_62"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 64.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
@@ -31841,12 +31579,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_70"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_3_71"
-      elif (
-        (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_72"
       elif (
         (last_rsi_3 > 74.0)
@@ -31860,7 +31593,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_74"
@@ -31871,12 +31604,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_75"
-      elif (
-        (last_rsi_3 > 64.0)
-        and (last_rsi_14 < 54.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 54.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3 > 72.0)
@@ -31890,7 +31618,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -31915,7 +31643,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -14.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_82"
@@ -31939,9 +31667,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_86"
@@ -31964,7 +31692,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
@@ -31973,7 +31701,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_90"
@@ -31982,7 +31710,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_91"
@@ -31998,10 +31726,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 68.0)
         and (last_rsi_14 < 54.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -32011,7 +31739,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_3_94"
@@ -32028,7 +31756,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 58.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_96"
@@ -32036,16 +31764,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_97"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_15m"] > 68.0)
+        and (last_rsi_3_15m > 68.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_98"
@@ -32054,14 +31782,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
-      elif (
-        (last_rsi_3 > 94.0) and (last_rsi_14 > 72.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_rsi_14 > 72.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
         (last_rsi_3 > 80.0)
@@ -32084,7 +31810,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 60.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_103"
@@ -32100,7 +31826,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 52.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -32110,7 +31836,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_106"
@@ -32119,7 +31845,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_107"
       elif (last_rsi_3 > 52.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -32138,9 +31864,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 46.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_3_111"
@@ -32150,14 +31876,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -6.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -32168,37 +31894,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_114"
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 52.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_115"
-      elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_3_116"
       elif (
-        (last_rsi_3 > 82.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 82.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_117"
-      elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
         (last_rsi_3 > 82.0)
@@ -32208,22 +31921,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_119"
-      elif (
-        (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_3_120"
-      elif (
-        (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_121"
       elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_3_122"
-      elif (
-        (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
         (last_rsi_3 > 84.0)
@@ -32236,17 +31940,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -8.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_3_126"
-      elif (
-        (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
         (last_rsi_3 > 82.0)
@@ -32267,14 +31969,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_133"
@@ -32282,12 +31984,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -32296,17 +31994,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 62.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_2"
       elif (
         (last_willr_14 > -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -32315,41 +32009,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -30.0)
         and (last_rsi_14 > 65.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_4"
-      elif (
-        (last_willr_14 > -8.0) and (last_rsi_14 > 66.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -8.0) and (last_rsi_14 > 66.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_4_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
       elif (
         (last_willr_14 > -8.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_4_8"
@@ -32363,7 +32051,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -20.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -32372,7 +32060,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_4_11"
@@ -32380,27 +32068,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_4_12"
       elif (last_rsi_3 > 80.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_4_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_14"
       elif (last_rsi_3 > 88.0) and (last_rsi_14 > 60.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_4_16"
       elif (
@@ -32422,12 +32105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_4_19"
-      elif (
-        (last_rsi_3 > 44.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 44.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_4_20"
       elif (last_rsi_3 > 55.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_4_21"
@@ -32439,16 +32117,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
-      elif (
-        (last_rsi_3 > 80.0) and (last_willr_14 > -25.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -25.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
         (last_rsi_3 > 86.0)
         and (last_rsi_14 > 66.0)
         and (last_willr_14 > -30.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_24"
       elif (
@@ -32469,9 +32145,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_27"
-      elif (
-        (last_rsi_3 > 65.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
         (last_rsi_3 > 75.0)
@@ -32502,29 +32176,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -8.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_34"
-      elif (
-        (last_rsi_3 > 82.0)
-        and (last_willr_14 > -9.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_willr_14 > -9.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_4_35"
       elif (
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -30.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_36"
@@ -32532,7 +32201,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_37"
@@ -32578,7 +32247,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 50.0)
         and (last_willr_14 > -20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
@@ -32592,7 +32261,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_4_47"
@@ -32608,16 +32277,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -10.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_4_50"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_4_51"
@@ -32643,7 +32307,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_4_54"
       elif (
@@ -32689,7 +32353,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -32702,14 +32366,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_4_62"
       elif (
-        (last_rsi_3 > 62.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 62.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
@@ -32749,12 +32410,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_70"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_4_71"
-      elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_72"
       elif (
         (last_rsi_3 > 72.0)
@@ -32768,7 +32424,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_74"
@@ -32779,12 +32435,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_75"
-      elif (
-        (last_rsi_3 > 62.0)
-        and (last_rsi_14 < 56.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 56.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
         (last_rsi_3 > 70.0)
@@ -32798,7 +32449,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -22.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_78"
       elif (last_rsi_3 > 86.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -32823,7 +32474,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_willr_14 > -16.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_82"
@@ -32847,9 +32498,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_85"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_86"
@@ -32872,7 +32523,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
@@ -32881,7 +32532,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_90"
@@ -32890,7 +32541,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_91"
@@ -32906,10 +32557,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 56.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -32919,7 +32570,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_4_94"
@@ -32936,7 +32587,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 56.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_96"
@@ -32944,16 +32595,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_97"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_15m"] > 66.0)
+        and (last_rsi_3_15m > 66.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_98"
@@ -32962,14 +32613,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
-      elif (
-        (last_rsi_3 > 92.0) and (last_rsi_14 > 70.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_14 > 70.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_4_100"
       elif (
         (last_rsi_3 > 78.0)
@@ -32992,7 +32641,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 62.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_103"
@@ -33008,7 +32657,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 54.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -33018,7 +32667,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_106"
@@ -33027,7 +32676,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_107"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -33046,9 +32695,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 44.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_4_111"
@@ -33058,14 +32707,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -8.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -33076,37 +32725,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_114"
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 54.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_115"
-      elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_4_116"
       elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 80.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_117"
-      elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_4_118"
       elif (
         (last_rsi_3 > 80.0)
@@ -33116,22 +32752,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_119"
-      elif (
-        (last_rsi_3 > 48.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 48.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_4_120"
-      elif (
-        (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_121"
       elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_4_122"
-      elif (
-        (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
         (last_rsi_3 > 82.0)
@@ -33144,17 +32771,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_4_126"
-      elif (
-        (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_4_127"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
       elif (
         (last_rsi_3 > 80.0)
@@ -33175,14 +32800,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_132"
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_133"
@@ -33190,12 +32815,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -33204,17 +32825,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 60.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
         (last_willr_14 > -20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -33223,44 +32840,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -30.0)
         and (last_rsi_14 > 65.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_4"
-      elif (
-        (last_willr_14 > -10.0)
-        and (last_rsi_14 > 64.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
-        and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -10.0) and (last_rsi_14 > 64.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
         (last_willr_14 > -10.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_5_8"
@@ -33274,7 +32882,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -20.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -33283,7 +32891,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_5_11"
@@ -33291,27 +32899,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_5_12"
       elif (last_rsi_3 > 80.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_5_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -12.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -12.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_14"
       elif (last_rsi_3 > 86.0) and (last_rsi_14 > 58.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_5_16"
       elif (
@@ -33333,12 +32936,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_5_19"
-      elif (
-        (last_rsi_3 > 42.0)
-        and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 42.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_5_20"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_5_21"
@@ -33350,16 +32948,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
-      elif (
-        (last_rsi_3 > 75.0) and (last_willr_14 > -30.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_willr_14 > -30.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 > 64.0)
         and (last_willr_14 > -35.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
@@ -33380,9 +32976,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_27"
-      elif (
-        (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
         (last_rsi_3 > 75.0)
@@ -33413,29 +33007,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -10.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_34"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -10.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
         (last_rsi_3 > 65.0)
         and (last_willr_14 > -35.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_36"
@@ -33443,7 +33032,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_37"
@@ -33489,7 +33078,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 50.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
@@ -33503,7 +33092,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_5_47"
@@ -33519,16 +33108,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -12.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -12.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -12.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_5_50"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 54.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_5_51"
@@ -33554,7 +33138,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
@@ -33600,7 +33184,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -33613,14 +33197,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_5_62"
       elif (
-        (last_rsi_3 > 60.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 60.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
@@ -33660,12 +33241,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_70"
       elif (last_rsi_3 > 56.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_5_71"
-      elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
         (last_rsi_3 > 70.0)
@@ -33679,7 +33255,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_74"
@@ -33690,12 +33266,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_75"
-      elif (
-        (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 58.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 58.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
         (last_rsi_3 > 68.0)
@@ -33709,7 +33280,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -24.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
       elif (last_rsi_3 > 84.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -33734,7 +33305,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_willr_14 > -18.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_82"
@@ -33758,9 +33329,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_86"
@@ -33783,7 +33354,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
@@ -33792,7 +33363,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_90"
@@ -33801,7 +33372,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_91"
@@ -33817,10 +33388,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 64.0)
         and (last_rsi_14 < 58.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -33830,7 +33401,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_5_94"
@@ -33847,7 +33418,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 54.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_96"
@@ -33855,16 +33426,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_97"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["RSI_3_15m"] > 64.0)
+        and (last_rsi_3_15m > 64.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_98"
@@ -33873,14 +33444,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 60.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
-      elif (
-        (last_rsi_3 > 90.0) and (last_rsi_14 > 68.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14 > 68.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
         (last_rsi_3 > 76.0)
@@ -33903,7 +33472,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 64.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_103"
@@ -33919,7 +33488,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 56.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -33929,7 +33498,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_106"
@@ -33938,7 +33507,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_107"
       elif (last_rsi_3 > 48.0) and (last_rsi_14 < 56.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -33957,9 +33526,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 42.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_5_111"
@@ -33969,14 +33538,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 60.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
         (last_rsi_3 > 76.0)
         and (last_willr_14 > -10.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -33987,37 +33556,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_114"
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 56.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_115"
-      elif (
-        (last_rsi_3 > 82.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_5_116"
       elif (
-        (last_rsi_3 > 78.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 78.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_117"
-      elif (
-        (last_rsi_3 > 82.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
         (last_rsi_3 > 78.0)
@@ -34027,22 +33583,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_119"
-      elif (
-        (last_rsi_3 > 46.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 46.0) and (last_rsi_14 < 56.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_5_120"
-      elif (
-        (last_rsi_3 > 52.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_121"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_5_122"
-      elif (
-        (last_rsi_3 > 80.0) and (last_willr_14 > -12.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -12.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
         (last_rsi_3 > 80.0)
@@ -34055,17 +33602,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -12.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_5_126"
-      elif (
-        (last_rsi_3 > 82.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_rsi_3 > 86.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
         (last_rsi_3 > 78.0)
@@ -34086,14 +33631,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
         (last_rsi_3 > 72.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_133"
@@ -34101,12 +33646,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -34115,17 +33656,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 62.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_2"
       elif (
         (last_willr_14 > -15.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 98.0)
+        and (last_stochrsi_k > 98.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -34134,41 +33671,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -25.0)
         and (last_rsi_14 > 68.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_4"
-      elif (
-        (last_willr_14 > -8.0) and (last_rsi_14 > 66.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -8.0) and (last_rsi_14 > 66.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
       elif (
         (last_willr_14 > -8.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_6_8"
@@ -34182,7 +33713,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -15.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -34191,7 +33722,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_6_11"
@@ -34199,27 +33730,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_6_12"
       elif (last_rsi_3 > 85.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_6_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_14"
       elif (last_rsi_3 > 88.0) and (last_rsi_14 > 60.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
@@ -34241,12 +33767,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_6_19"
-      elif (
-        (last_rsi_3 > 44.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 44.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_6_20"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_6_21"
@@ -34258,16 +33779,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
-      elif (
-        (last_rsi_3 > 80.0) and (last_willr_14 > -25.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -25.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
         (last_rsi_3 > 86.0)
         and (last_rsi_14 > 66.0)
         and (last_willr_14 > -30.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
@@ -34288,9 +33807,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_27"
-      elif (
-        (last_rsi_3 > 65.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
         (last_rsi_3 > 80.0)
@@ -34321,29 +33838,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -8.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_34"
-      elif (
-        (last_rsi_3 > 82.0)
-        and (last_willr_14 > -9.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_willr_14 > -9.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -30.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_36"
@@ -34351,7 +33863,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_37"
@@ -34397,7 +33909,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 55.0)
         and (last_willr_14 > -20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
@@ -34411,7 +33923,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_6_47"
@@ -34427,16 +33939,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -10.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_6_50"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_6_51"
@@ -34462,7 +33969,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
@@ -34508,7 +34015,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -34521,14 +34028,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_6_62"
       elif (
-        (last_rsi_3 > 62.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 62.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
@@ -34568,12 +34072,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_70"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_6_71"
-      elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_72"
       elif (
         (last_rsi_3 > 72.0)
@@ -34587,7 +34086,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_74"
@@ -34598,12 +34097,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_75"
-      elif (
-        (last_rsi_3 > 62.0)
-        and (last_rsi_14 < 56.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 56.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
         (last_rsi_3 > 70.0)
@@ -34617,7 +34111,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -22.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
       elif (last_rsi_3 > 86.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -34642,7 +34136,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_willr_14 > -16.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_82"
@@ -34666,9 +34160,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_86"
@@ -34691,7 +34185,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
@@ -34700,7 +34194,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_90"
@@ -34709,7 +34203,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_91"
@@ -34725,10 +34219,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 56.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -34738,7 +34232,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_6_94"
@@ -34755,7 +34249,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 56.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_96"
@@ -34763,16 +34257,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_97"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["RSI_3_15m"] > 66.0)
+        and (last_rsi_3_15m > 66.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_98"
@@ -34781,14 +34275,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
-      elif (
-        (last_rsi_3 > 92.0) and (last_rsi_14 > 70.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_14 > 70.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
         (last_rsi_3 > 78.0)
@@ -34811,7 +34303,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 62.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_103"
@@ -34827,7 +34319,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 54.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -34837,7 +34329,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_106"
@@ -34846,7 +34338,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_107"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -34865,9 +34357,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 44.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_6_111"
@@ -34877,14 +34369,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -8.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -34895,37 +34387,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_114"
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 54.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_115"
-      elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_6_116"
       elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 80.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_117"
-      elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
         (last_rsi_3 > 80.0)
@@ -34935,22 +34414,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_119"
-      elif (
-        (last_rsi_3 > 48.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 48.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_6_120"
-      elif (
-        (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_121"
       elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_6_122"
-      elif (
-        (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
         (last_rsi_3 > 82.0)
@@ -34963,17 +34433,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_6_126"
-      elif (
-        (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
         (last_rsi_3 > 80.0)
@@ -34994,14 +34462,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
         (last_rsi_3 > 74.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_133"
@@ -35009,12 +34477,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -35023,17 +34487,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 64.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_2"
       elif (
         (last_willr_14 > -10.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 98.0)
+        and (last_stochrsi_k > 98.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -35042,41 +34502,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -20.0)
         and (last_rsi_14 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_4"
-      elif (
-        (last_willr_14 > -6.0) and (last_rsi_14 > 68.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -6.0) and (last_rsi_14 > 68.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_7_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
       elif (
         (last_willr_14 > -6.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_7_8"
@@ -35090,7 +34544,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -10.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -35099,7 +34553,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_7_11"
@@ -35107,27 +34561,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_7_12"
       elif (last_rsi_3 > 90.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_7_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -8.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -8.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_14"
       elif (last_rsi_3 > 90.0) and (last_rsi_14 > 62.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_7_16"
       elif (
@@ -35149,12 +34598,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_7_19"
-      elif (
-        (last_rsi_3 > 46.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 46.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_7_20"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_7_21"
@@ -35166,16 +34610,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
-      elif (
-        (last_rsi_3 > 85.0) and (last_willr_14 > -20.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_willr_14 > -20.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
         (last_rsi_3 > 88.0)
         and (last_rsi_14 > 68.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_24"
       elif (
@@ -35196,9 +34638,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_27"
-      elif (
-        (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
         (last_rsi_3 > 85.0)
@@ -35229,29 +34669,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -6.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_34"
-      elif (
-        (last_rsi_3 > 84.0)
-        and (last_willr_14 > -8.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_7_35"
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_36"
@@ -35259,7 +34694,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_37"
@@ -35305,7 +34740,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 60.0)
         and (last_willr_14 > -15.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
@@ -35319,7 +34754,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_7_47"
@@ -35335,16 +34770,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -8.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_7_50"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_7_51"
@@ -35370,7 +34800,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_7_54"
       elif (
@@ -35416,7 +34846,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -35429,14 +34859,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_7_62"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 64.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
@@ -35476,12 +34903,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_70"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_7_71"
-      elif (
-        (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_72"
       elif (
         (last_rsi_3 > 74.0)
@@ -35495,7 +34917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_74"
@@ -35506,12 +34928,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_75"
-      elif (
-        (last_rsi_3 > 64.0)
-        and (last_rsi_14 < 54.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 54.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3 > 72.0)
@@ -35525,7 +34942,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_78"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -35550,7 +34967,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -14.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_82"
@@ -35574,9 +34991,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_85"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_86"
@@ -35599,7 +35016,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
@@ -35608,7 +35025,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_90"
@@ -35617,7 +35034,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_91"
@@ -35633,10 +35050,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 68.0)
         and (last_rsi_14 < 54.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -35646,7 +35063,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_7_94"
@@ -35663,7 +35080,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 58.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_96"
@@ -35671,16 +35088,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_97"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["RSI_3_15m"] > 68.0)
+        and (last_rsi_3_15m > 68.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_98"
@@ -35689,14 +35106,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
-      elif (
-        (last_rsi_3 > 94.0) and (last_rsi_14 > 72.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_rsi_14 > 72.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_7_100"
       elif (
         (last_rsi_3 > 80.0)
@@ -35719,7 +35134,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 60.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_103"
@@ -35735,7 +35150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 52.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -35745,7 +35160,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_106"
@@ -35754,7 +35169,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_107"
       elif (last_rsi_3 > 52.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -35773,9 +35188,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 46.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_7_111"
@@ -35785,14 +35200,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -4.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -35803,37 +35218,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_114"
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 52.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_115"
-      elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_7_116"
       elif (
-        (last_rsi_3 > 82.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 82.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_117"
-      elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_7_118"
       elif (
         (last_rsi_3 > 82.0)
@@ -35843,22 +35245,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_119"
-      elif (
-        (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_7_120"
-      elif (
-        (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_121"
       elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_7_122"
-      elif (
-        (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
         (last_rsi_3 > 84.0)
@@ -35871,17 +35264,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -8.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_7_126"
-      elif (
-        (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_7_127"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
       elif (
         (last_rsi_3 > 82.0)
@@ -35902,14 +35293,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_132"
       elif (
         (last_rsi_3 > 76.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_133"
@@ -35917,12 +35308,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -35931,17 +35318,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 66.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_2"
       elif (
         (last_willr_14 > -8.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 98.0)
+        and (last_stochrsi_k > 98.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -35950,41 +35333,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -15.0)
         and (last_rsi_14 > 72.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_4"
-      elif (
-        (last_willr_14 > -4.0) and (last_rsi_14 > 70.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -4.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_8_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
       elif (
         (last_willr_14 > -4.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_8_8"
@@ -35998,7 +35375,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -8.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -36007,7 +35384,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_8_11"
@@ -36015,27 +35392,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_8_12"
       elif (last_rsi_3 > 95.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_8_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -6.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -6.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_14"
       elif (last_rsi_3 > 92.0) and (last_rsi_14 > 64.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_8_16"
       elif (
@@ -36057,12 +35429,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_8_19"
-      elif (
-        (last_rsi_3 > 48.0)
-        and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 48.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_8_20"
       elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_8_21"
@@ -36074,16 +35441,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
-      elif (
-        (last_rsi_3 > 90.0) and (last_willr_14 > -15.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -15.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14 > 70.0)
         and (last_willr_14 > -20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_24"
       elif (
@@ -36104,9 +35469,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_27"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
         (last_rsi_3 > 90.0)
@@ -36137,29 +35500,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -4.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_34"
-      elif (
-        (last_rsi_3 > 86.0)
-        and (last_willr_14 > -7.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -7.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_8_35"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -20.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_36"
@@ -36167,7 +35525,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_37"
@@ -36213,7 +35571,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
@@ -36227,7 +35585,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_8_47"
@@ -36243,16 +35601,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -6.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -6.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_8_50"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_8_51"
@@ -36278,7 +35631,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_8_54"
       elif (
@@ -36324,7 +35677,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -36337,14 +35690,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_8_62"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 66.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
@@ -36384,12 +35734,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_70"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_8_71"
-      elif (
-        (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 76.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_72"
       elif (
         (last_rsi_3 > 76.0)
@@ -36403,7 +35748,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 97.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_74"
@@ -36414,12 +35759,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_75"
-      elif (
-        (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 52.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 66.0) and (last_rsi_14 < 52.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
         (last_rsi_3 > 74.0)
@@ -36433,7 +35773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -18.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_78"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -36458,7 +35798,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -12.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_82"
@@ -36482,9 +35822,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_85"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_86"
@@ -36507,7 +35847,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
@@ -36516,7 +35856,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_90"
@@ -36525,7 +35865,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_91"
@@ -36541,10 +35881,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 52.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -36554,7 +35894,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_8_94"
@@ -36571,7 +35911,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 60.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_96"
@@ -36579,16 +35919,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_97"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_98"
@@ -36597,14 +35937,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
-      elif (
-        (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_8_100"
       elif (
         (last_rsi_3 > 82.0)
@@ -36627,7 +35965,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_103"
@@ -36643,7 +35981,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -36653,7 +35991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_106"
@@ -36662,7 +36000,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_107"
       elif (last_rsi_3 > 54.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -36681,9 +36019,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 48.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_8_111"
@@ -36693,14 +36031,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -2.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -36711,37 +36049,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_115"
-      elif (
-        (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_8_116"
       elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 84.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_117"
-      elif (
-        (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_8_118"
       elif (
         (last_rsi_3 > 84.0)
@@ -36751,22 +36076,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_119"
-      elif (
-        (last_rsi_3 > 52.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_8_120"
-      elif (
-        (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_121"
       elif (last_rsi_3 > 56.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_8_122"
-      elif (
-        (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
         (last_rsi_3 > 86.0)
@@ -36779,17 +36095,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -6.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_8_126"
-      elif (
-        (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_8_127"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
       elif (
         (last_rsi_3 > 84.0)
@@ -36810,14 +36124,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_132"
       elif (
         (last_rsi_3 > 78.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_133"
@@ -36825,12 +36139,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -36839,17 +36149,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 68.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_2"
       elif (
         (last_willr_14 > -6.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 98.0)
+        and (last_stochrsi_k > 98.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -36858,41 +36164,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -10.0)
         and (last_rsi_14 > 74.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_4"
-      elif (
-        (last_willr_14 > -2.0) and (last_rsi_14 > 72.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -2.0) and (last_rsi_14 > 72.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_9_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
       elif (
         (last_willr_14 > -2.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_9_8"
@@ -36906,7 +36206,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -6.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -36915,7 +36215,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 92.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_9_11"
@@ -36923,27 +36223,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_9_12"
       elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_9_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -4.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_14"
       elif (last_rsi_3 > 94.0) and (last_rsi_14 > 66.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_9_16"
       elif (
@@ -36965,12 +36260,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_9_19"
-      elif (
-        (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_9_20"
       elif (last_rsi_3 > 90.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_9_21"
@@ -36982,16 +36272,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
-      elif (
-        (last_rsi_3 > 92.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
         (last_rsi_3 > 92.0)
         and (last_rsi_14 > 72.0)
         and (last_willr_14 > -15.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_24"
       elif (
@@ -37012,9 +36300,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_27"
-      elif (
-        (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
         (last_rsi_3 > 95.0)
@@ -37045,29 +36331,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -2.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_34"
-      elif (
-        (last_rsi_3 > 88.0)
-        and (last_willr_14 > -6.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_9_35"
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -15.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_36"
@@ -37075,7 +36356,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_37"
@@ -37121,7 +36402,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -5.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
@@ -37135,7 +36416,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_9_47"
@@ -37151,16 +36432,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -4.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -4.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_9_50"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_9_51"
@@ -37186,7 +36462,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_9_54"
       elif (
@@ -37232,7 +36508,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -37245,14 +36521,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_9_62"
       elif (
-        (last_rsi_3 > 68.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 68.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
@@ -37292,12 +36565,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_70"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_9_71"
-      elif (
-        (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 78.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_72"
       elif (
         (last_rsi_3 > 78.0)
@@ -37311,7 +36579,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_74"
@@ -37322,12 +36590,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_75"
-      elif (
-        (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 50.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3 > 76.0)
@@ -37341,7 +36604,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -16.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_78"
       elif (last_rsi_3 > 92.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -37366,7 +36629,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_82"
@@ -37390,9 +36653,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_85"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_86"
@@ -37415,7 +36678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
@@ -37424,7 +36687,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_90"
@@ -37433,7 +36696,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_91"
@@ -37449,10 +36712,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -37462,7 +36725,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_9_94"
@@ -37479,7 +36742,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 62.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_96"
@@ -37487,16 +36750,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_97"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_candle["RSI_3_15m"] > 72.0)
+        and (last_rsi_3_15m > 72.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_98"
@@ -37505,14 +36768,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
-      elif (
-        (last_rsi_3 > 98.0) and (last_rsi_14 > 76.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 98.0) and (last_rsi_14 > 76.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_9_100"
       elif (
         (last_rsi_3 > 84.0)
@@ -37535,7 +36796,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_103"
@@ -37551,7 +36812,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -37561,7 +36822,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_106"
@@ -37570,7 +36831,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_107"
       elif (last_rsi_3 > 56.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -37589,9 +36850,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_9_111"
@@ -37601,14 +36862,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -37619,37 +36880,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_114"
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_115"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_9_116"
       elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 86.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_117"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_9_118"
       elif (
         (last_rsi_3 > 86.0)
@@ -37659,22 +36907,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_119"
-      elif (
-        (last_rsi_3 > 54.0)
-        and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_9_120"
-      elif (
-        (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_121"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_9_122"
-      elif (
-        (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
         (last_rsi_3 > 88.0)
@@ -37687,17 +36926,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -4.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_9_126"
-      elif (
-        (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_9_127"
-      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
       elif (
         (last_rsi_3 > 86.0)
@@ -37718,14 +36955,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_132"
       elif (
         (last_rsi_3 > 80.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_133"
@@ -37733,12 +36970,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -37747,17 +36980,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 70.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_2"
       elif (
         (last_willr_14 > -4.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 98.0)
+        and (last_stochrsi_k > 98.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -37766,41 +36995,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -5.0)
         and (last_rsi_14 > 76.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_4"
-      elif (
-        (last_willr_14 > -1.0) and (last_rsi_14 > 74.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -1.0) and (last_rsi_14 > 74.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_10_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
       elif (
         (last_willr_14 > -1.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_10_8"
@@ -37814,7 +37037,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -4.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -37823,7 +37046,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 94.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_10_11"
@@ -37831,27 +37054,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_10_12"
       elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_10_13"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -2.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_14"
       elif (last_rsi_3 > 96.0) and (last_rsi_14 > 68.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_10_16"
       elif (
@@ -37873,12 +37091,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_10_19"
-      elif (
-        (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_10_20"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_10_21"
@@ -37890,16 +37103,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
-      elif (
-        (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
         (last_rsi_3 > 94.0)
         and (last_rsi_14 > 74.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_24"
       elif (
@@ -37920,9 +37131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_27"
-      elif (
-        (last_rsi_3 > 85.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
         (last_rsi_3 > 96.0)
@@ -37953,29 +37162,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_34"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -5.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -5.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_10_35"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -10.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_36"
@@ -37983,7 +37187,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_37"
@@ -38029,7 +37233,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
@@ -38043,7 +37247,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_10_47"
@@ -38059,16 +37263,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_49"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -2.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_10_50"
       elif (last_rsi_3 > 68.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_10_51"
@@ -38094,7 +37293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_10_54"
       elif (
@@ -38140,7 +37339,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -38153,14 +37352,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_10_62"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 70.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
@@ -38200,12 +37396,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_70"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_10_71"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_72"
       elif (
         (last_rsi_3 > 80.0)
@@ -38219,7 +37410,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_74"
@@ -38230,12 +37421,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_75"
-      elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 48.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 48.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
         (last_rsi_3 > 78.0)
@@ -38249,7 +37435,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -14.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_78"
       elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -38274,7 +37460,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_82"
@@ -38298,9 +37484,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_85"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_86"
@@ -38323,7 +37509,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
@@ -38332,7 +37518,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_90"
@@ -38341,7 +37527,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_91"
@@ -38357,10 +37543,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 48.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -38370,7 +37556,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_10_94"
@@ -38387,7 +37573,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 64.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_96"
@@ -38395,16 +37581,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_97"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_candle["RSI_3_15m"] > 74.0)
+        and (last_rsi_3_15m > 74.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_98"
@@ -38413,14 +37599,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
-      elif (
-        (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_10_100"
       elif (
         (last_rsi_3 > 86.0)
@@ -38443,7 +37627,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_103"
@@ -38459,7 +37643,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -38469,7 +37653,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_106"
@@ -38478,7 +37662,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_107"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -38497,9 +37681,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 52.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_10_111"
@@ -38509,14 +37693,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -38527,37 +37711,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_114"
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_115"
-      elif (
-        (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_10_116"
       elif (
-        (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 88.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_117"
-      elif (
-        (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_10_118"
       elif (
         (last_rsi_3 > 88.0)
@@ -38567,22 +37738,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_119"
-      elif (
-        (last_rsi_3 > 56.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_10_120"
-      elif (
-        (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_121"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_10_122"
-      elif (
-        (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
         (last_rsi_3 > 90.0)
@@ -38595,17 +37757,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -2.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_10_126"
-      elif (
-        (last_rsi_3 > 92.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_10_127"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
       elif (
         (last_rsi_3 > 88.0)
@@ -38626,14 +37786,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_132"
       elif (
         (last_rsi_3 > 82.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_133"
@@ -38641,12 +37801,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -38655,17 +37811,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 74.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_2"
       elif (
         (last_willr_14 > -2.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 99.0)
+        and (last_stochrsi_k > 99.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -38674,41 +37826,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -2.0)
         and (last_rsi_14 > 78.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_4"
-      elif (
-        (last_willr_14 > -1.0) and (last_rsi_14 > 76.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -1.0) and (last_rsi_14 > 76.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_11_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
       elif (
         (last_willr_14 > -1.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 98.0)
+        and (last_stochrsi_k > 98.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_11_8"
@@ -38722,7 +37868,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -2.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -38731,7 +37877,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_11_11"
@@ -38739,27 +37885,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_11_12"
       elif (last_rsi_3 > 98.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_11_13"
-      elif (
-        (last_rsi_3 > 95.0)
-        and (last_willr_14 > -1.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_14"
       elif (last_rsi_3 > 98.0) and (last_rsi_14 > 70.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_11_16"
       elif (
@@ -38781,12 +37922,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_11_19"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_11_20"
       elif (last_rsi_3 > 98.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_11_21"
@@ -38798,16 +37934,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
-      elif (
-        (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
         (last_rsi_3 > 96.0)
         and (last_rsi_14 > 76.0)
         and (last_willr_14 > -5.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_24"
       elif (
@@ -38828,9 +37962,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_27"
-      elif (
-        (last_rsi_3 > 90.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
         (last_rsi_3 > 98.0)
@@ -38861,29 +37993,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_34"
-      elif (
-        (last_rsi_3 > 92.0)
-        and (last_willr_14 > -4.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_11_35"
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -5.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_36"
@@ -38891,7 +38018,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_37"
@@ -38937,7 +38064,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
@@ -38951,7 +38078,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_11_47"
@@ -38967,16 +38094,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_49"
-      elif (
-        (last_rsi_3 > 85.0)
-        and (last_willr_14 > -2.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_11_50"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_11_51"
@@ -39002,7 +38124,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_11_54"
       elif (
@@ -39048,7 +38170,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_rsi_14 < 36.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -39061,14 +38183,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_11_62"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 72.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
@@ -39108,12 +38227,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_70"
       elif (last_rsi_3 > 68.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_11_71"
-      elif (
-        (last_rsi_3 > 82.0)
-        and (last_rsi_14 < 38.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 82.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_72"
       elif (
         (last_rsi_3 > 82.0)
@@ -39127,7 +38241,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_74"
@@ -39138,12 +38252,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_75"
-      elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 46.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 46.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
         (last_rsi_3 > 80.0)
@@ -39157,7 +38266,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -12.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_78"
       elif (last_rsi_3 > 96.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -39182,7 +38291,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -6.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_82"
@@ -39206,9 +38315,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_85"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_86"
@@ -39231,7 +38340,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 36.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
@@ -39240,7 +38349,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_90"
@@ -39249,7 +38358,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_91"
@@ -39265,10 +38374,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 46.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -39278,7 +38387,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_11_94"
@@ -39295,7 +38404,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_96"
@@ -39303,16 +38412,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_97"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_candle["RSI_3_15m"] > 76.0)
+        and (last_rsi_3_15m > 76.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_98"
@@ -39321,14 +38430,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
-      elif (
-        (last_rsi_3 > 99.0) and (last_rsi_14 > 80.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 80.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_11_100"
       elif (
         (last_rsi_3 > 88.0)
@@ -39351,7 +38458,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_103"
@@ -39367,7 +38474,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -39377,7 +38484,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_106"
@@ -39386,7 +38493,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_107"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -39405,9 +38512,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 54.0)
         and (last_rsi_14 < 40.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_11_111"
@@ -39417,14 +38524,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -39435,37 +38542,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_114"
       elif (
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_115"
-      elif (
-        (last_rsi_3 > 94.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_11_116"
       elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 90.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_117"
-      elif (
-        (last_rsi_3 > 94.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_11_118"
       elif (
         (last_rsi_3 > 90.0)
@@ -39475,22 +38569,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_119"
-      elif (
-        (last_rsi_3 > 58.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_11_120"
-      elif (
-        (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_121"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_11_122"
-      elif (
-        (last_rsi_3 > 92.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
         (last_rsi_3 > 92.0)
@@ -39503,17 +38588,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_11_126"
-      elif (
-        (last_rsi_3 > 94.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_11_127"
-      elif (last_rsi_3 > 98.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 98.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
       elif (
         (last_rsi_3 > 90.0)
@@ -39534,14 +38617,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_132"
       elif (
         (last_rsi_3 > 84.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_133"
@@ -39549,12 +38632,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
       ):
@@ -39563,17 +38642,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
         and (last_candle["CMF_20_1h"] < -0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_2"
       elif (
         (last_willr_14 > -1.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 99.0)
+        and (last_stochrsi_k > 99.0)
         and (last_candle["CMF_20_1h"] < -0.0)
         and (last_candle["CMF_20_4h"] < -0.0)
         and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
@@ -39582,41 +38657,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] < last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] < last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_4"
-      elif (
-        (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_candle["ROC_9_1h"] < -5.0) and (last_roc_9_4h < -5.0)
-      ):
+      elif (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_12_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 70.0)
+        and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_6"
       elif (
         (last_rsi_14 < 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
+        and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_7"
       elif (
         (last_willr_14 > -1.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] > 99.0)
+        and (last_stochrsi_k > 99.0)
         and (last_candle["CMF_20_1h"] < -0.1)
         and (last_candle["CMF_20_4h"] < -0.1)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_12_8"
@@ -39630,7 +38699,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 < 50.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -39639,7 +38708,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_rsi_14 < 45.0)
         and (last_candle["ROC_9_15m"] < -10.0)
-        and (last_candle["ROC_9_1h"] < -10.0)
+        and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_12_11"
@@ -39647,27 +38716,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_4h < 10.0)
-        and (last_candle["ROC_9_1h"] < -20.0)
+        and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_12_12"
       elif (last_rsi_3 > 99.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_12_13"
-      elif (
-        (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
-        and (last_rsi_3_4h < 5.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_14"
       elif (last_rsi_3 > 99.0) and (last_rsi_14 > 75.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
+        and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
         and (last_candle["AROONU_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] < -15.0)
+        and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_12_16"
       elif (
@@ -39689,12 +38753,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_12_19"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_12_20"
       elif (last_rsi_3 > 99.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_12_21"
@@ -39706,16 +38765,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
-      elif (
-        (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 15.0) and (last_candle["RSI_3_1d"] < 5.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
         (last_rsi_3 > 98.0)
         and (last_rsi_14 > 78.0)
         and (last_willr_14 > -1.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_24"
       elif (
@@ -39736,9 +38793,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_27"
-      elif (
-        (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_candle["RSI_3_15m"] < 10.0) and (last_roc_9_4h > 50.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
         (last_rsi_3 > 99.0)
@@ -39769,29 +38824,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
         and (last_candle["ROC_2_1h"] < -10.0)
-        and (last_candle["ROC_9_1h"] > 30.0)
+        and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_33"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_candle["ROC_9_1h"] > 40.0)
+        and (last_roc_9_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_34"
-      elif (
-        (last_rsi_3 > 94.0)
-        and (last_willr_14 > -2.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 75.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_12_35"
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_36"
@@ -39799,7 +38849,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_37"
@@ -39845,7 +38895,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
@@ -39859,7 +38909,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_12_47"
@@ -39875,16 +38925,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_49"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_willr_14 > -2.0)
-        and (last_candle["RSI_3_1d"] < 10.0)
-        and (last_stochrsi_k_1h > 90.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_12_50"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_12_51"
@@ -39910,7 +38955,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 40.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_roc_9_4h < -10.0)
-        and (last_candle["change_pct_1d"] < -10.0)
+        and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_12_54"
       elif (
@@ -39956,7 +39001,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["RSI_14_4h"] > 65.0)
+        and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h > 50.0)
         and (last_stochrsi_k_1d > 50.0)
       ):
@@ -39969,14 +39014,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_candle["change_pct_1d"] < -5.0)
+        and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_12_62"
       elif (
-        (last_rsi_3 > 74.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3 > 74.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
@@ -40016,12 +39058,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_70"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 38.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_12_71"
-      elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_14 < 36.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_candle["AROONU_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 > 84.0) and (last_rsi_14 < 36.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_72"
       elif (
         (last_rsi_3 > 84.0)
@@ -40035,7 +39072,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["RSI_3_1d"] < 25.0)
+        and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_74"
@@ -40046,12 +39083,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_75"
-      elif (
-        (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 44.0)
-        and (last_candle["ROC_9_1h"] > 80.0)
-        and (last_stochrsi_k_4h > 80.0)
-      ):
+      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 44.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
         (last_rsi_3 > 82.0)
@@ -40065,7 +39097,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_1h < 30.0)
         and (last_rsi_3_4h < 20.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_78"
       elif (last_rsi_3 > 98.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
@@ -40090,7 +39122,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -4.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 15.0)
+        and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_82"
@@ -40114,9 +39146,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_85"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_candle["RSI_14_4h"] > 80.0)
+        and (last_rsi_14_4h > 80.0)
         and (last_candle["ROC_2_1h"] < -5.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_86"
@@ -40139,7 +39171,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
@@ -40148,7 +39180,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_90"
@@ -40157,7 +39189,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 40.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_91"
@@ -40173,10 +39205,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 44.0)
-        and (last_candle["RSI_3_15m"] < 50.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_rsi_3_15m < 50.0)
+        and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -40186,7 +39218,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_12_94"
@@ -40203,7 +39235,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 68.0)
         and (last_rsi_14 < 40.0)
         and (last_rsi_3_1h < 45.0)
-        and (last_candle["RSI_3_1d"] < 45.0)
+        and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_96"
@@ -40211,16 +39243,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 40.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_97"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_candle["RSI_3_15m"] > 78.0)
+        and (last_rsi_3_15m > 78.0)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_98"
@@ -40229,14 +39261,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
+        and (last_aroonu_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
-      elif (
-        (last_rsi_3 > 99.0) and (last_rsi_14 > 82.0) and (last_candle["RSI_3_15m"] > 70.0) and (last_rsi_3_4h < 80.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 82.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_12_100"
       elif (
         (last_rsi_3 > 90.0)
@@ -40259,7 +39289,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 60.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_103"
@@ -40275,7 +39305,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["RSI_3_15m"] < 55.0)
+        and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
       ):
@@ -40285,7 +39315,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
+        and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_106"
@@ -40294,7 +39324,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
-        and (last_candle["RSI_14_4h"] > 50.0)
+        and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_107"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
@@ -40313,9 +39343,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 56.0)
         and (last_rsi_14 < 38.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_candle["RSI_14_4h"] > 70.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
+        and (last_rsi_14_4h > 70.0)
+        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_12_111"
@@ -40325,14 +39355,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["RSI_3_1d"] < 60.0)
+        and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -40343,37 +39373,24 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 30.0)
-        and (last_candle["RSI_3_1d"] < 30.0)
+        and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_114"
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 42.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h > 50.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_115"
-      elif (
-        (last_rsi_3 > 96.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 50.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
         return True, f"exit_{mode_name}_d_12_116"
       elif (
-        (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_candle["AROONU_14_1h"] > 80.0)
-        and (last_candle["AROONU_14_4h"] > 80.0)
+        (last_rsi_3 > 92.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_117"
-      elif (
-        (last_rsi_3 > 96.0)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_candle["AROONU_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_12_118"
       elif (
         (last_rsi_3 > 92.0)
@@ -40383,22 +39400,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_119"
-      elif (
-        (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 40.0)
-        and (last_candle["AROONU_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_12_120"
-      elif (
-        (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 50.0) and (last_candle["RSI_14_4h"] > 85.0)
-      ):
+      elif (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_121"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 38.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
         return True, f"exit_{mode_name}_d_12_122"
-      elif (
-        (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_candle["RSI_3_1d"] < 30.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
         (last_rsi_3 > 94.0)
@@ -40411,17 +39419,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_candle["RSI_3_1d"] < 40.0)
+        and (last_rsi_3_1d < 40.0)
         and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
         return True, f"exit_{mode_name}_d_12_126"
-      elif (
-        (last_rsi_3 > 96.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_candle["RSI_3_1d"] < 40.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_12_127"
-      elif (last_rsi_3 > 99.0) and (last_rsi_3_4h < 30.0) and (last_candle["AROONU_14_4h"] > 85.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
       elif (
         (last_rsi_3 > 92.0)
@@ -40442,14 +39448,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
-        and (last_candle["AROONU_14_1h"] > 50.0)
+        and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_132"
       elif (
         (last_rsi_3 > 86.0)
         and (last_candle["AROONU_14_15m"] > 75.0)
-        and (last_candle["AROONU_14_1h"] > 75.0)
+        and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_133"


### PR DESCRIPTION
## Summary
- Stores high-traffic long-exit decision candle fields once.
- Reuses those fields across the existing long_exit_dec() condition matrix.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same long-exit decision conditions, thresholds, signal names, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
