### PR TITLE
Reuse X7 short-exit decision fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -52870,6 +52870,17 @@ class NostalgiaForInfinityX7(IStrategy):
     last_roc_9_1d = last_candle["ROC_9_1d"]
     last_rsi_3_1h = last_candle["RSI_3_1h"]
     last_rsi_14 = last_candle["RSI_14"]
+    last_rsi_3_1d = last_candle["RSI_3_1d"]
+    last_aroond_14_4h = last_candle["AROOND_14_4h"]
+    last_roc_9_1h = last_candle["ROC_9_1h"]
+    last_aroond_14_1h = last_candle["AROOND_14_1h"]
+    last_aroonu_14_4h = last_candle["AROONU_14_4h"]
+    last_rsi_3_15m = last_candle["RSI_3_15m"]
+    last_rsi_14_4h = last_candle["RSI_14_4h"]
+    last_ema_200_1h = last_candle["EMA_200_1h"]
+    last_ema_200_4h = last_candle["EMA_200_4h"]
+    last_change_pct_1d = last_candle["change_pct_1d"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
     last_rsi_3_4h = last_candle["RSI_3_4h"]
     last_willr_14 = last_candle["WILLR_14"]
     last_stochrsi_k_4h = last_candle["STOCHRSIk_14_14_3_3_4h"]
@@ -52880,12 +52891,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -52894,17 +52901,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 <= -99.0)
         and (last_rsi_14 < 22.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_2"
       elif (
         (last_willr_14 <= -99.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
+        and (last_stochrsi_k < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -52913,41 +52916,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 <= -99.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
-      elif (
-        (last_willr_14 <= -99.0) and (last_rsi_14 < 22.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 <= -99.0) and (last_rsi_14 < 22.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_7"
       elif (
         (last_willr_14 < -99.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
+        and (last_stochrsi_k < 1.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_0_8"
@@ -52961,7 +52958,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -52970,7 +52967,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_11"
@@ -52978,27 +52975,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_12"
       elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_13"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_14"
       elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
@@ -53018,12 +53010,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_19"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_0_20"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_0_21"
@@ -53035,16 +53022,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
-      elif (
-        (last_rsi_3 < 2.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 < 22.0)
         and (last_willr_14 < -95.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
@@ -53065,9 +53050,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_27"
-      elif (
-        (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
         (last_rsi_3 < 5.0)
@@ -53098,29 +53081,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_0_34"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_willr_14 < -95.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -99.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_36"
@@ -53128,7 +53106,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_37"
@@ -53174,7 +53152,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
@@ -53188,7 +53166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_0_47"
@@ -53204,16 +53182,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -98.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_0_50"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_0_51"
@@ -53239,7 +53212,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
@@ -53285,7 +53258,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 62.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -53298,14 +53271,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_62"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 2.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
@@ -53345,9 +53315,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_70"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_0_71"
-      elif (
-        (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
         (last_rsi_3 < 5.0)
@@ -53361,7 +53329,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_74"
@@ -53372,12 +53340,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_75"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 52.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
         (last_rsi_3 < 5.0)
@@ -53391,7 +53354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
       elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -53416,7 +53379,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -92.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_82"
@@ -53440,9 +53403,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_86"
@@ -53465,7 +53428,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 62.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
@@ -53474,7 +53437,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_90"
@@ -53483,7 +53446,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_91"
@@ -53499,10 +53462,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -53512,7 +53475,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_94"
@@ -53529,7 +53492,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_96"
@@ -53537,16 +53500,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_97"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_15m"] < 26.0)
+        and (last_rsi_3_15m < 26.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_98"
@@ -53555,14 +53518,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
-      elif (
-        (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
         (last_rsi_3 < 14.0)
@@ -53585,7 +53546,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_103"
@@ -53601,7 +53562,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -53611,7 +53572,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_0_106"
@@ -53620,7 +53581,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_107"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -53639,9 +53600,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_0_111"
@@ -53651,14 +53612,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -53669,37 +53630,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_115"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_0_116"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_117"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
         (last_rsi_3 < 5.0)
@@ -53709,19 +53660,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_119"
-      elif (
-        (last_rsi_3 < 5.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 60.0) and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_0_120"
-      elif (
-        (last_rsi_3 < 5.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_0_121"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_0_122"
-      elif (
-        (last_rsi_3 < 5.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
         (last_rsi_3 < 5.0)
@@ -53734,17 +53679,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (
-        (last_rsi_3 < 5.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
         (last_rsi_3 < 5.0)
@@ -53765,14 +53708,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
         (last_rsi_3 < 5.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_133"
@@ -53780,12 +53723,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -53794,17 +53733,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 32.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_2"
       elif (
         (last_willr_14 < -92.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
+        and (last_stochrsi_k < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -53813,41 +53748,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_4"
-      elif (
-        (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_1_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
       elif (
         (last_willr_14 < -98.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_1_8"
@@ -53861,7 +53790,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -53870,7 +53799,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_1_11"
@@ -53878,27 +53807,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_12"
       elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_1_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -96.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_1_14"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_16"
       elif (
@@ -53920,12 +53844,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_19"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_1_20"
       elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_1_21"
@@ -53937,16 +53856,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
-      elif (
-        (last_rsi_3 < 5.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 < 25.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_24"
       elif (
@@ -53967,9 +53884,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_27"
-      elif (
-        (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
         (last_rsi_3 < 10.0)
@@ -54000,29 +53915,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -98.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_1_34"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_willr_14 < -94.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_1_35"
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -85.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_36"
@@ -54030,7 +53940,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_37"
@@ -54076,7 +53986,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_willr_14 < -95.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
@@ -54090,7 +54000,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_1_47"
@@ -54106,16 +54016,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -96.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -96.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_1_50"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_1_51"
@@ -54141,7 +54046,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_54"
       elif (
@@ -54187,7 +54092,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -54200,14 +54105,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_62"
       elif (
-        (last_rsi_3 < 32.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 32.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
@@ -54247,12 +54149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_70"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_1_71"
-      elif (
-        (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_1_72"
       elif (
         (last_rsi_3 < 22.0)
@@ -54266,7 +54163,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_74"
@@ -54277,12 +54174,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_75"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 50.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3 < 24.0)
@@ -54296,7 +54188,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_78"
       elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -54321,7 +54213,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_82"
@@ -54345,9 +54237,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_85"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_86"
@@ -54370,7 +54262,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
@@ -54379,7 +54271,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_90"
@@ -54388,7 +54280,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_91"
@@ -54404,10 +54296,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -54417,7 +54309,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_94"
@@ -54434,7 +54326,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_96"
@@ -54442,16 +54334,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_97"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_15m"] < 28.0)
+        and (last_rsi_3_15m < 28.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_98"
@@ -54460,14 +54352,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
-      elif (
-        (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_1_100"
       elif (
         (last_rsi_3 < 16.0)
@@ -54490,7 +54380,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_103"
@@ -54506,7 +54396,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -54516,7 +54406,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_1_106"
@@ -54525,7 +54415,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_107"
       elif (last_rsi_3 < 44.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -54544,9 +54434,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_1_111"
@@ -54556,14 +54446,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -98.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -54574,37 +54464,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_114"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_115"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_1_116"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_117"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_1_118"
       elif (
         (last_rsi_3 < 14.0)
@@ -54614,22 +54494,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_119"
-      elif (
-        (last_rsi_3 < 46.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_1_120"
-      elif (
-        (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_1_121"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_1_122"
-      elif (
-        (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
         (last_rsi_3 < 12.0)
@@ -54642,17 +54513,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_1_126"
-      elif (
-        (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_1_127"
-      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
       elif (
         (last_rsi_3 < 14.0)
@@ -54673,14 +54542,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_132"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_133"
@@ -54688,12 +54557,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -54702,17 +54567,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 34.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_2"
       elif (
         (last_willr_14 < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
+        and (last_stochrsi_k < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -54721,41 +54582,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_4"
-      elif (
-        (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_2_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
       elif (
         (last_willr_14 < -96.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_2_8"
@@ -54769,7 +54624,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -54778,7 +54633,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_2_11"
@@ -54786,27 +54641,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_12"
       elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_2_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -94.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_2_14"
       elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_16"
       elif (
@@ -54828,12 +54678,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_19"
-      elif (
-        (last_rsi_3 < 52.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 52.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_2_20"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_2_21"
@@ -54845,16 +54690,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
-      elif (
-        (last_rsi_3 < 10.0) and (last_willr_14 < -85.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -85.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
         and (last_willr_14 < -80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_24"
       elif (
@@ -54875,9 +54718,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_27"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
         (last_rsi_3 < 25.0)
@@ -54908,29 +54749,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -96.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_2_34"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_willr_14 < -93.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -93.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_2_35"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -80.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_36"
@@ -54938,7 +54774,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_37"
@@ -54984,7 +54820,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
@@ -54998,7 +54834,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_2_47"
@@ -55014,16 +54850,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -94.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -94.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_2_50"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_2_51"
@@ -55049,7 +54880,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_54"
       elif (
@@ -55095,7 +54926,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -55108,14 +54939,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_62"
       elif (
-        (last_rsi_3 < 34.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 34.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
@@ -55155,12 +54983,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_70"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_2_71"
-      elif (
-        (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_2_72"
       elif (
         (last_rsi_3 < 24.0)
@@ -55174,7 +54997,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 3.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_74"
@@ -55185,12 +55008,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_75"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 48.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 48.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
         (last_rsi_3 < 26.0)
@@ -55204,7 +55022,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_78"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -55229,7 +55047,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -88.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_82"
@@ -55253,9 +55071,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_85"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_86"
@@ -55278,7 +55096,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
@@ -55287,7 +55105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_90"
@@ -55296,7 +55114,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_91"
@@ -55312,10 +55130,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -55325,7 +55143,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_94"
@@ -55342,7 +55160,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_96"
@@ -55350,16 +55168,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_97"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_98"
@@ -55368,14 +55186,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
-      elif (
-        (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_2_100"
       elif (
         (last_rsi_3 < 18.0)
@@ -55398,7 +55214,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_103"
@@ -55414,7 +55230,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -55424,7 +55240,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_2_106"
@@ -55433,7 +55249,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_107"
       elif (last_rsi_3 < 46.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -55452,9 +55268,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 52.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_2_111"
@@ -55464,14 +55280,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -96.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -55482,37 +55298,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_115"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_2_116"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_117"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_2_118"
       elif (
         (last_rsi_3 < 16.0)
@@ -55522,22 +55328,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_119"
-      elif (
-        (last_rsi_3 < 48.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_2_120"
-      elif (
-        (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_2_121"
       elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_2_122"
-      elif (
-        (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
         (last_rsi_3 < 14.0)
@@ -55550,17 +55347,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_2_126"
-      elif (
-        (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_2_127"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
       elif (
         (last_rsi_3 < 16.0)
@@ -55581,14 +55376,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_132"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_133"
@@ -55596,12 +55391,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -55610,17 +55401,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 36.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
         (last_willr_14 < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -55629,41 +55416,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_4"
-      elif (
-        (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
         (last_willr_14 < -94.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_3_8"
@@ -55677,7 +55458,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -55686,7 +55467,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_3_11"
@@ -55694,27 +55475,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_12"
       elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -92.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_14"
       elif (last_rsi_3 < 10.0) and (last_rsi_14 < 35.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
@@ -55736,12 +55512,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_19"
-      elif (
-        (last_rsi_3 < 54.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 54.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_3_20"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_3_21"
@@ -55753,16 +55524,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
-      elif (
-        (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
@@ -55783,9 +55552,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_27"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
         (last_rsi_3 < 25.0)
@@ -55816,29 +55583,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_3_34"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_willr_14 < -92.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -75.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_36"
@@ -55846,7 +55608,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_37"
@@ -55892,7 +55654,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 45.0)
         and (last_willr_14 < -85.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
@@ -55906,7 +55668,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_3_47"
@@ -55922,16 +55684,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -92.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -92.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_3_50"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_3_51"
@@ -55957,7 +55714,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
@@ -56003,7 +55760,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -56016,14 +55773,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_62"
       elif (
-        (last_rsi_3 < 36.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 36.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
@@ -56063,12 +55817,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_70"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_3_71"
-      elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_72"
       elif (
         (last_rsi_3 < 26.0)
@@ -56082,7 +55831,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_74"
@@ -56093,12 +55842,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_75"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 46.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 46.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3 < 28.0)
@@ -56112,7 +55856,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -56137,7 +55881,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -86.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_82"
@@ -56161,9 +55905,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_86"
@@ -56186,7 +55930,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
@@ -56195,7 +55939,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_90"
@@ -56204,7 +55948,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_91"
@@ -56220,10 +55964,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 46.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -56233,7 +55977,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_94"
@@ -56250,7 +55994,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 42.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_96"
@@ -56258,16 +56002,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_97"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_15m"] < 32.0)
+        and (last_rsi_3_15m < 32.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_98"
@@ -56276,14 +56020,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
-      elif (
-        (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
         (last_rsi_3 < 20.0)
@@ -56306,7 +56048,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_103"
@@ -56322,7 +56064,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -56332,7 +56074,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_3_106"
@@ -56341,7 +56083,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_107"
       elif (last_rsi_3 < 48.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -56360,9 +56102,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 54.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_3_111"
@@ -56372,14 +56114,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -56390,37 +56132,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_114"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_115"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_3_116"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_117"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
         (last_rsi_3 < 18.0)
@@ -56430,22 +56162,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_119"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_3_120"
-      elif (
-        (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_3_121"
       elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_3_122"
-      elif (
-        (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
         (last_rsi_3 < 16.0)
@@ -56458,17 +56181,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_3_126"
-      elif (
-        (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
         (last_rsi_3 < 18.0)
@@ -56489,14 +56210,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_133"
@@ -56504,12 +56225,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -56518,17 +56235,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 38.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_2"
       elif (
         (last_willr_14 < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -56537,41 +56250,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_4"
-      elif (
-        (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_4_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
       elif (
         (last_willr_14 < -92.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_4_8"
@@ -56585,7 +56292,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -56594,7 +56301,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_4_11"
@@ -56602,27 +56309,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_12"
       elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_14"
       elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_16"
       elif (
@@ -56644,12 +56346,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_19"
-      elif (
-        (last_rsi_3 < 56.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 56.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_4_20"
       elif (last_rsi_3 < 45.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_4_21"
@@ -56661,16 +56358,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
-      elif (
-        (last_rsi_3 < 20.0) and (last_willr_14 < -75.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -75.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
         and (last_willr_14 < -70.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_24"
       elif (
@@ -56691,9 +56386,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_27"
-      elif (
-        (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
         (last_rsi_3 < 25.0)
@@ -56724,29 +56417,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -92.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_4_34"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_willr_14 < -91.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_willr_14 < -91.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_4_35"
       elif (
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -70.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_36"
@@ -56754,7 +56442,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_37"
@@ -56800,7 +56488,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 50.0)
         and (last_willr_14 < -80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
@@ -56814,7 +56502,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_4_47"
@@ -56830,16 +56518,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -90.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_4_50"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_4_51"
@@ -56865,7 +56548,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_54"
       elif (
@@ -56911,7 +56594,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -56924,14 +56607,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_62"
       elif (
-        (last_rsi_3 < 38.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 38.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
@@ -56971,12 +56651,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_70"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_4_71"
-      elif (
-        (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_72"
       elif (
         (last_rsi_3 < 28.0)
@@ -56990,7 +56665,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_74"
@@ -57001,12 +56676,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_75"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 44.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 44.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
         (last_rsi_3 < 30.0)
@@ -57020,7 +56690,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -78.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_78"
       elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -57045,7 +56715,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_willr_14 < -84.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_82"
@@ -57069,9 +56739,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_85"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_86"
@@ -57094,7 +56764,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
@@ -57103,7 +56773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_90"
@@ -57112,7 +56782,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_91"
@@ -57128,10 +56798,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 44.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -57141,7 +56811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_94"
@@ -57158,7 +56828,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 44.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_96"
@@ -57166,16 +56836,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_97"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_15m"] < 34.0)
+        and (last_rsi_3_15m < 34.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_98"
@@ -57184,14 +56854,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
-      elif (
-        (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_4_100"
       elif (
         (last_rsi_3 < 22.0)
@@ -57214,7 +56882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 38.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_103"
@@ -57230,7 +56898,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -57240,7 +56908,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_4_106"
@@ -57249,7 +56917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_107"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -57268,9 +56936,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 56.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_4_111"
@@ -57280,14 +56948,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -92.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -57298,37 +56966,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_114"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_115"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_4_116"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_117"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_4_118"
       elif (
         (last_rsi_3 < 20.0)
@@ -57338,22 +56996,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_119"
-      elif (
-        (last_rsi_3 < 52.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 52.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_4_120"
-      elif (
-        (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_4_121"
       elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_4_122"
-      elif (
-        (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
         (last_rsi_3 < 18.0)
@@ -57366,17 +57015,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_4_126"
-      elif (
-        (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_4_127"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
       elif (
         (last_rsi_3 < 20.0)
@@ -57397,14 +57044,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_132"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_133"
@@ -57412,12 +57059,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -57426,17 +57069,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 40.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
         (last_willr_14 < -80.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -57445,41 +57084,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_4"
-      elif (
-        (last_willr_14 < -90.0) and (last_rsi_14 < 36.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -90.0) and (last_rsi_14 < 36.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
         (last_willr_14 < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_5_8"
@@ -57493,7 +57126,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -80.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -57502,7 +57135,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_5_11"
@@ -57510,27 +57143,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_12"
       elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -88.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -88.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_14"
       elif (last_rsi_3 < 14.0) and (last_rsi_14 > 58.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_16"
       elif (
@@ -57552,12 +57180,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_19"
-      elif (
-        (last_rsi_3 < 58.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 58.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_5_20"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_5_21"
@@ -57569,16 +57192,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
-      elif (
-        (last_rsi_3 < 25.0) and (last_willr_14 < -70.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_willr_14 < -70.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 < 36.0)
         and (last_willr_14 < -65.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
@@ -57599,9 +57220,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_27"
-      elif (
-        (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
         (last_rsi_3 < 25.0)
@@ -57632,29 +57251,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -90.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_5_34"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -90.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
         (last_rsi_3 < 35.0)
         and (last_willr_14 < -65.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_36"
@@ -57662,7 +57276,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_37"
@@ -57708,7 +57322,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 50.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
@@ -57722,7 +57336,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_5_47"
@@ -57738,16 +57352,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -88.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -88.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_5_50"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 46.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_5_51"
@@ -57773,7 +57382,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
@@ -57819,7 +57428,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -57832,14 +57441,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_62"
       elif (
-        (last_rsi_3 < 40.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 40.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
@@ -57879,12 +57485,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_70"
       elif (last_rsi_3 < 44.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_5_71"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
         (last_rsi_3 < 30.0)
@@ -57898,7 +57499,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_74"
@@ -57909,12 +57510,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_75"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 42.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 42.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
         (last_rsi_3 < 32.0)
@@ -57928,7 +57524,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -76.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
       elif (last_rsi_3 < 16.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -57953,7 +57549,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_willr_14 < -82.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_82"
@@ -57977,9 +57573,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_86"
@@ -58002,7 +57598,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
@@ -58011,7 +57607,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_90"
@@ -58020,7 +57616,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_91"
@@ -58036,10 +57632,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 42.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -58049,7 +57645,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_94"
@@ -58066,7 +57662,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 46.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_96"
@@ -58074,16 +57670,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_97"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["RSI_3_15m"] < 36.0)
+        and (last_rsi_3_15m < 36.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_98"
@@ -58092,14 +57688,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
-      elif (
-        (last_rsi_3 < 10.0) and (last_rsi_14 < 32.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 32.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
         (last_rsi_3 < 24.0)
@@ -58122,7 +57716,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 36.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_103"
@@ -58138,7 +57732,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 44.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -58148,7 +57742,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_5_106"
@@ -58157,7 +57751,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_107"
       elif (last_rsi_3 < 52.0) and (last_rsi_14 > 44.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -58176,9 +57770,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 58.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_5_111"
@@ -58188,14 +57782,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
         (last_rsi_3 < 24.0)
         and (last_willr_14 < -90.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -58206,37 +57800,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_114"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 44.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_115"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_5_116"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_117"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
         (last_rsi_3 < 22.0)
@@ -58246,22 +57830,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_119"
-      elif (
-        (last_rsi_3 < 54.0)
-        and (last_rsi_14 > 44.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 54.0) and (last_rsi_14 > 44.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_5_120"
-      elif (
-        (last_rsi_3 < 48.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_5_121"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_5_122"
-      elif (
-        (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
         (last_rsi_3 < 20.0)
@@ -58274,17 +57849,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_5_126"
-      elif (
-        (last_rsi_3 < 18.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
         (last_rsi_3 < 22.0)
@@ -58305,14 +57878,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
         (last_rsi_3 < 28.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_133"
@@ -58320,12 +57893,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -58334,17 +57903,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 38.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_2"
       elif (
         (last_willr_14 < -85.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
+        and (last_stochrsi_k < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -58353,41 +57918,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -75.0)
         and (last_rsi_14 < 32.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_4"
-      elif (
-        (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
       elif (
         (last_willr_14 < -92.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_6_8"
@@ -58401,7 +57960,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -85.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -58410,7 +57969,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_6_11"
@@ -58418,27 +57977,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_12"
       elif (last_rsi_3 < 15.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_14"
       elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
@@ -58460,12 +58014,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_19"
-      elif (
-        (last_rsi_3 < 56.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 56.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_6_20"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_6_21"
@@ -58477,16 +58026,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
-      elif (
-        (last_rsi_3 < 20.0) and (last_willr_14 < -75.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -75.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
         and (last_willr_14 < -70.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
@@ -58507,9 +58054,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_27"
-      elif (
-        (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
         (last_rsi_3 < 20.0)
@@ -58540,29 +58085,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -92.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_6_34"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_willr_14 < -91.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_willr_14 < -91.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -70.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_36"
@@ -58570,7 +58110,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_37"
@@ -58616,7 +58156,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 45.0)
         and (last_willr_14 < -80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
@@ -58630,7 +58170,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_6_47"
@@ -58646,16 +58186,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -90.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_6_50"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_6_51"
@@ -58681,7 +58216,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
@@ -58727,7 +58262,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -58740,14 +58275,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_62"
       elif (
-        (last_rsi_3 < 38.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 38.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
@@ -58787,12 +58319,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_70"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_6_71"
-      elif (
-        (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_72"
       elif (
         (last_rsi_3 < 28.0)
@@ -58806,7 +58333,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_74"
@@ -58817,12 +58344,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_75"
-      elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 44.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 44.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
         (last_rsi_3 < 30.0)
@@ -58836,7 +58358,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -78.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
       elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -58861,7 +58383,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_willr_14 < -84.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_82"
@@ -58885,9 +58407,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_86"
@@ -58910,7 +58432,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
@@ -58919,7 +58441,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_90"
@@ -58928,7 +58450,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_91"
@@ -58944,10 +58466,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 44.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -58957,7 +58479,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_94"
@@ -58974,7 +58496,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 44.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_96"
@@ -58982,16 +58504,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_97"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["RSI_3_15m"] < 34.0)
+        and (last_rsi_3_15m < 34.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_98"
@@ -59000,14 +58522,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
-      elif (
-        (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
         (last_rsi_3 < 22.0)
@@ -59030,7 +58550,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 38.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_103"
@@ -59046,7 +58566,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -59056,7 +58576,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_6_106"
@@ -59065,7 +58585,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_107"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -59084,9 +58604,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 56.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_6_111"
@@ -59096,14 +58616,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -92.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -59114,37 +58634,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_114"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_115"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_6_116"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_117"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
         (last_rsi_3 < 20.0)
@@ -59154,22 +58664,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_119"
-      elif (
-        (last_rsi_3 < 52.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 52.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_6_120"
-      elif (
-        (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_6_121"
       elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_6_122"
-      elif (
-        (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
         (last_rsi_3 < 18.0)
@@ -59182,17 +58683,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_6_126"
-      elif (
-        (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
         (last_rsi_3 < 20.0)
@@ -59213,14 +58712,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
         (last_rsi_3 < 26.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_133"
@@ -59228,12 +58727,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -59242,17 +58737,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 36.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_2"
       elif (
         (last_willr_14 < -90.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
+        and (last_stochrsi_k < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -59261,41 +58752,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -80.0)
         and (last_rsi_14 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_4"
-      elif (
-        (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_7_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
       elif (
         (last_willr_14 < -94.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_7_8"
@@ -59309,7 +58794,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -90.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -59318,7 +58803,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_7_11"
@@ -59326,27 +58811,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_12"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -92.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_14"
       elif (last_rsi_3 < 10.0) and (last_rsi_14 < 38.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_16"
       elif (
@@ -59368,12 +58848,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_19"
-      elif (
-        (last_rsi_3 < 54.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 54.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_7_20"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_7_21"
@@ -59385,16 +58860,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
-      elif (
-        (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_24"
       elif (
@@ -59415,9 +58888,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_27"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
         (last_rsi_3 < 15.0)
@@ -59448,29 +58919,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_7_34"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_willr_14 < -92.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_7_35"
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -75.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_36"
@@ -59478,7 +58944,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_37"
@@ -59524,7 +58990,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0)
         and (last_willr_14 < -85.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
@@ -59538,7 +59004,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_7_47"
@@ -59554,16 +59020,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -92.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -92.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_7_50"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_7_51"
@@ -59589,7 +59050,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_54"
       elif (
@@ -59635,7 +59096,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -59648,14 +59109,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_62"
       elif (
-        (last_rsi_3 < 36.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 36.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
@@ -59695,12 +59153,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_70"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_7_71"
-      elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_72"
       elif (
         (last_rsi_3 < 26.0)
@@ -59714,7 +59167,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_74"
@@ -59725,12 +59178,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_75"
-      elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 46.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 46.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3 < 28.0)
@@ -59744,7 +59192,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_78"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -59769,7 +59217,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -86.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_82"
@@ -59793,9 +59241,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_85"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_86"
@@ -59818,7 +59266,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
@@ -59827,7 +59275,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_90"
@@ -59836,7 +59284,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_91"
@@ -59852,10 +59300,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 46.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -59865,7 +59313,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_94"
@@ -59882,7 +59330,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 42.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_96"
@@ -59890,16 +59338,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_97"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["RSI_3_15m"] < 32.0)
+        and (last_rsi_3_15m < 32.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_98"
@@ -59908,14 +59356,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
-      elif (
-        (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_7_100"
       elif (
         (last_rsi_3 < 20.0)
@@ -59938,7 +59384,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_103"
@@ -59954,7 +59400,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -59964,7 +59410,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_7_106"
@@ -59973,7 +59419,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_107"
       elif (last_rsi_3 < 48.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -59992,9 +59438,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 54.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_7_111"
@@ -60004,14 +59450,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -60022,37 +59468,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_114"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_115"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_7_116"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_117"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_7_118"
       elif (
         (last_rsi_3 < 18.0)
@@ -60062,22 +59498,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_119"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_7_120"
-      elif (
-        (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_7_121"
       elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_7_122"
-      elif (
-        (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
         (last_rsi_3 < 16.0)
@@ -60090,17 +59517,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_7_126"
-      elif (
-        (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_7_127"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
       elif (
         (last_rsi_3 < 18.0)
@@ -60121,14 +59546,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_132"
       elif (
         (last_rsi_3 < 24.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_133"
@@ -60136,12 +59561,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -60150,17 +59571,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 34.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_2"
       elif (
         (last_willr_14 < -92.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
+        and (last_stochrsi_k < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -60169,41 +59586,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -85.0)
         and (last_rsi_14 < 28.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_4"
-      elif (
-        (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_8_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
       elif (
         (last_willr_14 < -96.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_8_8"
@@ -60217,7 +59628,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -92.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -60226,7 +59637,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_8_11"
@@ -60234,27 +59645,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_12"
       elif (last_rsi_3 < 5.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -94.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_14"
       elif (last_rsi_3 < 8.0) and (last_rsi_14 < 36.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_16"
       elif (
@@ -60276,12 +59682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_19"
-      elif (
-        (last_rsi_3 < 52.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 52.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_8_20"
       elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_8_21"
@@ -60293,16 +59694,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
-      elif (
-        (last_rsi_3 < 10.0) and (last_willr_14 < -85.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -85.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
         and (last_willr_14 < -80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_24"
       elif (
@@ -60323,9 +59722,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_27"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
         (last_rsi_3 < 10.0)
@@ -60356,29 +59753,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -96.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_8_34"
-      elif (
-        (last_rsi_3 < 14.0)
-        and (last_willr_14 < -93.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -93.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_8_35"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -80.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_36"
@@ -60386,7 +59778,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_37"
@@ -60432,7 +59824,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
@@ -60446,7 +59838,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_8_47"
@@ -60462,16 +59854,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -94.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -94.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_8_50"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_8_51"
@@ -60497,7 +59884,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_54"
       elif (
@@ -60543,7 +59930,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -60556,14 +59943,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_62"
       elif (
-        (last_rsi_3 < 34.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 34.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
@@ -60603,12 +59987,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_70"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_8_71"
-      elif (
-        (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_72"
       elif (
         (last_rsi_3 < 24.0)
@@ -60622,7 +60001,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 3.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_74"
@@ -60633,12 +60012,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_75"
-      elif (
-        (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 48.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 48.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
         (last_rsi_3 < 26.0)
@@ -60652,7 +60026,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_78"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -60677,7 +60051,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -88.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_82"
@@ -60701,9 +60075,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_85"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_86"
@@ -60726,7 +60100,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
@@ -60735,7 +60109,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_90"
@@ -60744,7 +60118,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_91"
@@ -60760,10 +60134,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 48.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -60773,7 +60147,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_94"
@@ -60790,7 +60164,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_96"
@@ -60798,16 +60172,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_97"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_candle["RSI_3_15m"] < 30.0)
+        and (last_rsi_3_15m < 30.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_98"
@@ -60816,14 +60190,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
-      elif (
-        (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_8_100"
       elif (
         (last_rsi_3 < 18.0)
@@ -60846,7 +60218,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_103"
@@ -60862,7 +60234,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -60872,7 +60244,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_8_106"
@@ -60881,7 +60253,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_107"
       elif (last_rsi_3 < 46.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -60900,9 +60272,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 52.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_8_111"
@@ -60912,14 +60284,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -96.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -60930,37 +60302,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_115"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_8_116"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_117"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_8_118"
       elif (
         (last_rsi_3 < 16.0)
@@ -60970,22 +60332,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_119"
-      elif (
-        (last_rsi_3 < 48.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_8_120"
-      elif (
-        (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_8_121"
       elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_8_122"
-      elif (
-        (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
         (last_rsi_3 < 14.0)
@@ -60998,17 +60351,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_8_126"
-      elif (
-        (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_8_127"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
       elif (
         (last_rsi_3 < 16.0)
@@ -61029,14 +60380,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_132"
       elif (
         (last_rsi_3 < 22.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_133"
@@ -61044,12 +60395,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -61058,17 +60405,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 32.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_2"
       elif (
         (last_willr_14 < -94.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
+        and (last_stochrsi_k < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -61077,41 +60420,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -90.0)
         and (last_rsi_14 < 26.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_4"
-      elif (
-        (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_9_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
       elif (
         (last_willr_14 < -98.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_9_8"
@@ -61125,7 +60462,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -94.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -61134,7 +60471,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 8.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_9_11"
@@ -61142,27 +60479,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_12"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -96.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_14"
       elif (last_rsi_3 < 6.0) and (last_rsi_14 < 34.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_16"
       elif (
@@ -61182,12 +60514,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_19"
-      elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_9_20"
       elif (last_rsi_3 < 10.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_9_21"
@@ -61199,16 +60526,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
-      elif (
-        (last_rsi_3 < 8.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_14 < 28.0)
         and (last_willr_14 < -85.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_24"
       elif (
@@ -61229,9 +60554,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_27"
-      elif (
-        (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
         (last_rsi_3 < 5.0)
@@ -61262,29 +60585,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -98.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_9_34"
-      elif (
-        (last_rsi_3 < 12.0)
-        and (last_willr_14 < -94.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_9_35"
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -85.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_36"
@@ -61292,7 +60610,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_37"
@@ -61338,7 +60656,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -95.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
@@ -61352,7 +60670,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_9_47"
@@ -61368,16 +60686,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -96.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -96.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_9_50"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_9_51"
@@ -61403,7 +60716,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_54"
       elif (
@@ -61449,7 +60762,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -61462,14 +60775,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_62"
       elif (
-        (last_rsi_3 < 32.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 32.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
@@ -61509,12 +60819,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_70"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_9_71"
-      elif (
-        (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_72"
       elif (
         (last_rsi_3 < 22.0)
@@ -61528,7 +60833,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_74"
@@ -61539,12 +60844,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_75"
-      elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 50.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3 < 24.0)
@@ -61558,7 +60858,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_78"
       elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -61583,7 +60883,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_82"
@@ -61607,9 +60907,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_85"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_86"
@@ -61632,7 +60932,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
@@ -61641,7 +60941,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_90"
@@ -61650,7 +60950,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_91"
@@ -61666,10 +60966,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -61679,7 +60979,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_94"
@@ -61696,7 +60996,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 38.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_96"
@@ -61704,16 +61004,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_97"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_candle["RSI_3_15m"] < 28.0)
+        and (last_rsi_3_15m < 28.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_98"
@@ -61722,14 +61022,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
-      elif (
-        (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_9_100"
       elif (
         (last_rsi_3 < 16.0)
@@ -61752,7 +61050,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_103"
@@ -61768,7 +61066,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -61778,7 +61076,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_9_106"
@@ -61787,7 +61085,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_107"
       elif (last_rsi_3 < 44.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -61806,9 +61104,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_9_111"
@@ -61818,14 +61116,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -98.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -61836,37 +61134,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_114"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_115"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_9_116"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_117"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_9_118"
       elif (
         (last_rsi_3 < 14.0)
@@ -61876,22 +61164,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_119"
-      elif (
-        (last_rsi_3 < 46.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_9_120"
-      elif (
-        (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_9_121"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_9_122"
-      elif (
-        (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
         (last_rsi_3 < 12.0)
@@ -61904,17 +61183,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_9_126"
-      elif (
-        (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_9_127"
-      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
       elif (
         (last_rsi_3 < 14.0)
@@ -61935,14 +61212,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_132"
       elif (
         (last_rsi_3 < 20.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_133"
@@ -61950,12 +61227,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -61964,17 +61237,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 30.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_2"
       elif (
         (last_willr_14 < -96.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
+        and (last_stochrsi_k < 2.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -61983,41 +61252,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -95.0)
         and (last_rsi_14 < 24.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_4"
-      elif (
-        (last_willr_14 < -99.0) and (last_rsi_14 < 26.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -99.0) and (last_rsi_14 < 26.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_10_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
       elif (
         (last_willr_14 < -99.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_10_8"
@@ -62031,7 +61294,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -96.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -62040,7 +61303,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 6.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_10_11"
@@ -62048,27 +61311,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_12"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_13"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -98.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_14"
       elif (last_rsi_3 < 4.0) and (last_rsi_14 < 32.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_16"
       elif (
@@ -62088,12 +61346,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_19"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_10_20"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_10_21"
@@ -62105,16 +61358,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
-      elif (
-        (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_14 < 26.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_24"
       elif (
@@ -62135,9 +61386,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_27"
-      elif (
-        (last_rsi_3 < 15.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
         (last_rsi_3 < 4.0)
@@ -62168,29 +61417,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_10_34"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -95.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -95.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_10_35"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -90.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_36"
@@ -62198,7 +61442,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_37"
@@ -62244,7 +61488,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
@@ -62258,7 +61502,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_10_47"
@@ -62274,16 +61518,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_49"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_willr_14 < -98.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_10_50"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_10_51"
@@ -62309,7 +61548,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_54"
       elif (
@@ -62355,7 +61594,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 62.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -62368,14 +61607,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_62"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 30.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
@@ -62415,12 +61651,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_70"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_10_71"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_72"
       elif (
         (last_rsi_3 < 20.0)
@@ -62434,7 +61665,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_74"
@@ -62445,12 +61676,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_75"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 52.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 52.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
         (last_rsi_3 < 22.0)
@@ -62464,7 +61690,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_78"
       elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -62489,7 +61715,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -92.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_82"
@@ -62513,9 +61739,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_85"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_86"
@@ -62538,7 +61764,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 62.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
@@ -62547,7 +61773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_90"
@@ -62556,7 +61782,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_91"
@@ -62572,10 +61798,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 52.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -62585,7 +61811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_94"
@@ -62602,7 +61828,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_96"
@@ -62610,16 +61836,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_97"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_candle["RSI_3_15m"] < 26.0)
+        and (last_rsi_3_15m < 26.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_98"
@@ -62628,14 +61854,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
-      elif (
-        (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_10_100"
       elif (
         (last_rsi_3 < 14.0)
@@ -62658,7 +61882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_103"
@@ -62674,7 +61898,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -62684,7 +61908,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_10_106"
@@ -62693,7 +61917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_107"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -62712,9 +61936,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 48.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_10_111"
@@ -62724,14 +61948,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -62742,37 +61966,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_114"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_115"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_10_116"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_117"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_10_118"
       elif (
         (last_rsi_3 < 12.0)
@@ -62782,22 +61996,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_119"
-      elif (
-        (last_rsi_3 < 44.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_10_120"
-      elif (
-        (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_10_121"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_10_122"
-      elif (
-        (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
         (last_rsi_3 < 10.0)
@@ -62810,17 +62015,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -98.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_10_126"
-      elif (
-        (last_rsi_3 < 8.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_10_127"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
       elif (
         (last_rsi_3 < 12.0)
@@ -62841,14 +62044,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_132"
       elif (
         (last_rsi_3 < 18.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_133"
@@ -62856,12 +62059,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -62870,17 +62069,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 26.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_2"
       elif (
         (last_willr_14 < -98.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
+        and (last_stochrsi_k < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -62889,41 +62084,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -98.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_4"
-      elif (
-        (last_willr_14 < -99.0) and (last_rsi_14 < 24.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -99.0) and (last_rsi_14 < 24.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_11_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
       elif (
         (last_willr_14 < -99.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 2.0)
+        and (last_stochrsi_k < 2.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_11_8"
@@ -62937,7 +62126,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -98.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -62946,7 +62135,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 4.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_11_11"
@@ -62954,27 +62143,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_12"
       elif (last_rsi_3 < 2.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_13"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_willr_14 < -99.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_14"
       elif (last_rsi_3 < 2.0) and (last_rsi_14 < 30.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_16"
       elif (
@@ -62994,12 +62178,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_19"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_11_20"
       elif (last_rsi_3 < 2.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_11_21"
@@ -63011,16 +62190,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
-      elif (
-        (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14 < 24.0)
         and (last_willr_14 < -95.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_24"
       elif (
@@ -63041,9 +62218,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_27"
-      elif (
-        (last_rsi_3 < 10.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
         (last_rsi_3 < 2.0)
@@ -63074,29 +62249,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_11_34"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_willr_14 < -96.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_11_35"
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -95.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_36"
@@ -63104,7 +62274,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_37"
@@ -63150,7 +62320,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
@@ -63164,7 +62334,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_11_47"
@@ -63180,16 +62350,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_49"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_willr_14 < -98.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_11_50"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_11_51"
@@ -63215,7 +62380,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_54"
       elif (
@@ -63261,7 +62426,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 64.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -63274,14 +62439,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_62"
       elif (
-        (last_rsi_3 < 28.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 28.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
@@ -63321,12 +62483,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_70"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_11_71"
-      elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_14 > 62.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 18.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_72"
       elif (
         (last_rsi_3 < 18.0)
@@ -63340,7 +62497,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_74"
@@ -63351,12 +62508,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_75"
-      elif (
-        (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 54.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 54.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
         (last_rsi_3 < 20.0)
@@ -63370,7 +62522,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_78"
       elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -63395,7 +62547,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -94.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_82"
@@ -63419,9 +62571,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_85"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_86"
@@ -63444,7 +62596,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 64.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
@@ -63453,7 +62605,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_90"
@@ -63462,7 +62614,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_91"
@@ -63478,10 +62630,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 54.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -63491,7 +62643,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_94"
@@ -63508,7 +62660,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_96"
@@ -63516,16 +62668,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_97"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_candle["RSI_3_15m"] < 24.0)
+        and (last_rsi_3_15m < 24.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_98"
@@ -63534,14 +62686,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
-      elif (
-        (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_11_100"
       elif (
         (last_rsi_3 < 12.0)
@@ -63564,7 +62714,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_103"
@@ -63580,7 +62730,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -63590,7 +62740,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_11_106"
@@ -63599,7 +62749,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_107"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -63618,9 +62768,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 46.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_11_111"
@@ -63630,14 +62780,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -63648,37 +62798,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_114"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_115"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_11_116"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_117"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_11_118"
       elif (
         (last_rsi_3 < 10.0)
@@ -63688,22 +62828,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_119"
-      elif (
-        (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_11_120"
-      elif (
-        (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_11_121"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_11_122"
-      elif (
-        (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
         (last_rsi_3 < 8.0)
@@ -63716,17 +62847,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_11_126"
-      elif (
-        (last_rsi_3 < 6.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_11_127"
-      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
       elif (
         (last_rsi_3 < 10.0)
@@ -63747,14 +62876,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_132"
       elif (
         (last_rsi_3 < 16.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_133"
@@ -63762,12 +62891,8 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
         and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
         and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
       ):
@@ -63776,17 +62901,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
         and (last_candle["CMF_20_1h"] > 0.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_2"
       elif (
         (last_willr_14 < -99.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
+        and (last_stochrsi_k < 1.0)
         and (last_candle["CMF_20_1h"] > 0.0)
         and (last_candle["CMF_20_4h"] > 0.0)
         and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
@@ -63795,41 +62916,35 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 20.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (
-          isinstance(last_candle["EMA_200_1h"], np.float64) and (last_candle["EMA_12_1h"] > last_candle["EMA_200_1h"])
-        )
-        and (
-          isinstance(last_candle["EMA_200_4h"], np.float64) and (last_candle["EMA_12_4h"] > last_candle["EMA_200_4h"])
-        )
+        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_4"
-      elif (
-        (last_willr_14 < -99.0) and (last_rsi_14 < 22.0) and (last_candle["ROC_9_1h"] > 5.0) and (last_roc_9_4h > 5.0)
-      ):
+      elif (last_willr_14 < -99.0) and (last_rsi_14 < 22.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_12_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 30.0)
+        and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_6"
       elif (
         (last_rsi_14 > 50.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
+        and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_7"
       elif (
         (last_willr_14 < -99.0)
-        and (last_candle["STOCHRSIk_14_14_3_3"] < 1.0)
+        and (last_stochrsi_k < 1.0)
         and (last_candle["CMF_20_1h"] > 0.1)
         and (last_candle["CMF_20_4h"] > 0.1)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_12_8"
@@ -63843,7 +62958,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 > 50.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -63852,7 +62967,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_rsi_14 > 55.0)
         and (last_candle["ROC_9_15m"] > 10.0)
-        and (last_candle["ROC_9_1h"] > 10.0)
+        and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_12_11"
@@ -63860,27 +62975,22 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_4h > 90.0)
-        and (last_candle["ROC_9_1h"] > 20.0)
+        and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_12"
       elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_13"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
-        and (last_rsi_3_4h > 95.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_14"
       elif (last_rsi_3 < 1.0) and (last_rsi_14 < 25.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
+        and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
         and (last_candle["AROOND_14_1d"] > 50.0)
-        and (last_candle["change_pct_1d"] > 15.0)
+        and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_16"
       elif (
@@ -63900,12 +63010,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_19"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_1h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_12_20"
       elif (last_rsi_3 < 1.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_12_21"
@@ -63917,16 +63022,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
-      elif (
-        (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 85.0) and (last_candle["RSI_3_1d"] > 95.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_14 < 22.0)
         and (last_willr_14 < -99.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_24"
       elif (
@@ -63947,9 +63050,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_27"
-      elif (
-        (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_candle["RSI_3_15m"] > 90.0) and (last_roc_9_4h < -50.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
         (last_rsi_3 < 1.0)
@@ -63980,29 +63081,24 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
         and (last_candle["ROC_2_1h"] > 10.0)
-        and (last_candle["ROC_9_1h"] < -30.0)
+        and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_33"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_candle["ROC_9_1h"] < -40.0)
+        and (last_roc_9_1h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_12_34"
-      elif (
-        (last_rsi_3 < 6.0)
-        and (last_willr_14 < -98.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 25.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_12_35"
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_36"
@@ -64010,7 +63106,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h < 80.0)
-        and (last_candle["RSI_3_1d"] < 75.0)
+        and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_37"
@@ -64056,7 +63152,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 25.0)
+        and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
@@ -64070,7 +63166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_stochrsi_k_1h < 20.0)
         and (last_stochrsi_k_4h < 60.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_12_47"
@@ -64086,16 +63182,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_49"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_willr_14 < -98.0)
-        and (last_candle["RSI_3_1d"] > 90.0)
-        and (last_stochrsi_k_1h < 10.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_12_50"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_12_51"
@@ -64121,7 +63212,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 60.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_roc_9_4h > 10.0)
-        and (last_candle["change_pct_1d"] > 10.0)
+        and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_54"
       elif (
@@ -64167,7 +63258,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 66.0)
-        and (last_candle["RSI_14_4h"] < 35.0)
+        and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h < 50.0)
         and (last_stochrsi_k_1d < 50.0)
       ):
@@ -64180,14 +63271,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_candle["change_pct_1d"] > 5.0)
+        and (last_change_pct_1d > 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_62"
       elif (
-        (last_rsi_3 < 26.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3 < 26.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
@@ -64227,12 +63315,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_70"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_12_71"
-      elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 64.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_candle["AROOND_14_4h"] > 25.0)
-      ):
+      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_72"
       elif (
         (last_rsi_3 < 16.0)
@@ -64246,7 +63329,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["RSI_3_1d"] > 75.0)
+        and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_74"
@@ -64257,12 +63340,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_75"
-      elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 56.0)
-        and (last_candle["ROC_9_1h"] < -80.0)
-        and (last_stochrsi_k_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 56.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
         (last_rsi_3 < 18.0)
@@ -64276,7 +63354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 70.0)
         and (last_rsi_3_4h > 80.0)
-        and (last_candle["RSI_3_1d"] > 80.0)
+        and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_78"
       elif (last_rsi_3 < 2.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
@@ -64301,7 +63379,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -96.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 85.0)
+        and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_82"
@@ -64325,9 +63403,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_85"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_candle["RSI_14_4h"] < 20.0)
+        and (last_rsi_14_4h < 20.0)
         and (last_candle["ROC_2_1h"] > 5.0)
-        and (last_candle["ROC_9_1h"] < -5.0)
+        and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_86"
@@ -64350,7 +63428,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 66.0)
-        and (last_candle["ROC_9_1h"] > 5.0)
+        and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
@@ -64359,7 +63437,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_90"
@@ -64368,7 +63446,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
+        and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_91"
@@ -64384,10 +63462,10 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 56.0)
-        and (last_candle["RSI_3_15m"] > 50.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_rsi_3_15m > 50.0)
+        and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -64397,7 +63475,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_94"
@@ -64414,7 +63492,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 55.0)
-        and (last_candle["RSI_3_1d"] > 55.0)
+        and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_96"
@@ -64422,16 +63500,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_97"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_candle["RSI_3_15m"] < 22.0)
+        and (last_rsi_3_15m < 22.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["RSI_3_1d"] < 20.0)
+        and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_98"
@@ -64440,14 +63518,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 50.0)
+        and (last_aroond_14_4h > 50.0)
         and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
-      elif (
-        (last_rsi_3 < 1.0) and (last_rsi_14 < 18.0) and (last_candle["RSI_3_15m"] < 30.0) and (last_rsi_3_4h > 20.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 18.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_12_100"
       elif (
         (last_rsi_3 < 10.0)
@@ -64470,7 +63546,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 40.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_103"
@@ -64486,7 +63562,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_3_15m"] > 45.0)
+        and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
       ):
@@ -64496,7 +63572,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
+        and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_12_106"
@@ -64505,7 +63581,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
-        and (last_candle["RSI_14_4h"] < 50.0)
+        and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_107"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
@@ -64524,9 +63600,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 44.0)
         and (last_rsi_14 > 62.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_candle["RSI_14_4h"] < 30.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
+        and (last_rsi_14_4h < 30.0)
+        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_12_111"
@@ -64536,14 +63612,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["RSI_3_1d"] > 40.0)
+        and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -64554,37 +63630,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 70.0)
-        and (last_candle["RSI_3_1d"] > 70.0)
+        and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_114"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 58.0)
-        and (last_candle["RSI_3_15m"] > 70.0)
+        and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h < 50.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_115"
-      elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
-        and (last_candle["AROONU_14_4h"] < 50.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_12_116"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h > 50.0)
         and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_candle["AROONU_14_4h"] < 20.0)
+        and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_117"
-      elif (
-        (last_rsi_3 < 4.0)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_candle["AROOND_14_4h"] > 40.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_12_118"
       elif (
         (last_rsi_3 < 8.0)
@@ -64594,22 +63660,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_119"
-      elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 60.0)
-        and (last_candle["AROOND_14_4h"] > 75.0)
-      ):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_12_120"
-      elif (
-        (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 50.0) and (last_candle["RSI_14_4h"] < 15.0)
-      ):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_12_121"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
         return True, f"exit_{mode_name}_d_12_122"
-      elif (
-        (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_candle["RSI_3_1d"] > 70.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
         (last_rsi_3 < 6.0)
@@ -64622,17 +63679,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_candle["RSI_3_1d"] > 60.0)
+        and (last_rsi_3_1d > 60.0)
         and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
         return True, f"exit_{mode_name}_d_12_126"
-      elif (
-        (last_rsi_3 < 4.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_candle["RSI_3_1d"] > 60.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_12_127"
-      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 70.0) and (last_candle["AROOND_14_4h"] > 85.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
       elif (
         (last_rsi_3 < 8.0)
@@ -64653,14 +63708,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
-        and (last_candle["AROOND_14_1h"] > 50.0)
+        and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_132"
       elif (
         (last_rsi_3 < 14.0)
         and (last_candle["AROOND_14_15m"] > 75.0)
-        and (last_candle["AROOND_14_1h"] > 75.0)
+        and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_133"


### PR DESCRIPTION
## Summary
- Stores high-traffic short-exit decision candle fields once.
- Reuses those fields across the existing short_exit_dec() condition matrix.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same short-exit decision conditions, thresholds, signal names, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
