### PR TITLE
Reuse X7 entry trend series reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12637,6 +12637,16 @@ class NostalgiaForInfinityX7(IStrategy):
     aroonu_14_1h = df["AROONU_14_1h"]
     stochrsi_k_4h = df["STOCHRSIk_14_14_3_3_4h"]
     stochrsi_k_1h = df["STOCHRSIk_14_14_3_3_1h"]
+    aroonu_14_1d = df["AROONU_14_1d"]
+    rsi_3_1d = df["RSI_3_1d"]
+    aroonu_14_15m = df["AROONU_14_15m"]
+    roc_9_1h = df["ROC_9_1h"]
+    stochrsi_k_15m = df["STOCHRSIk_14_14_3_3_15m"]
+    stochrsi_k_1d = df["STOCHRSIk_14_14_3_3_1d"]
+    rsi_3 = df["RSI_3"]
+    close = df["close"]
+    roc_9_15m = df["ROC_9_15m"]
+    rsi_14_4h = df["RSI_14_4h"]
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
@@ -12695,29 +12705,29 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m & 1h down move
-            ((df["RSI_3"] > 3.0) | (rsi_3_15m > 3.0) | (df["RSI_3_change_pct_1h"] > -50.0))
+            ((rsi_3 > 3.0) | (rsi_3_15m > 3.0) | (df["RSI_3_change_pct_1h"] > -50.0))
             # 5m & 15m down move, 5h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_15m > 5.0) | (df["RSI_14_4h"] < 60.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (rsi_14_4h < 60.0))
             # 5m & 15m down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0))
             # 5m & 1h down move
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 5.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 30.0))
             # 5m & 1h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 30.0))
             # 5m & 4h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
             # 5m down move, 15m high
-            & ((df["RSI_3"] > 3.0) | (df["AROONU_14_15m"] < 80.0))
+            & ((rsi_3 > 3.0) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h high, 4h overbought
-            & ((df["RSI_3"] > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m & 4h down move, 4h high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1h downtrend, 1h high
             & ((rsi_3_15m > 1.0) | (df["CMF_20_1h"] > -0.1) | (aroonu_14_1h < 70.0))
             # 15m & 1h & 4h down move
@@ -12725,13 +12735,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h & 1d down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
@@ -12743,7 +12753,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 1d downtrend
@@ -12751,13 +12761,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (df["CMF_20_15m"] > -0.40) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_15m > 3.0) | (df["CMF_20_15m"] > -0.40) | (roc_9_15m > -20.0))
             # 15m down move, 15m still high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 40.0) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 40.0) | (roc_9_15m > -20.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_15m > -20.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h overbought
@@ -12765,7 +12775,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 15m down move, drop in last half hour, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (df["close"] > (df["close_max_6"] * 0.75)) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_15m > 3.0) | (close > (df["close_max_6"] * 0.75)) | (roc_9_15m > -20.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
@@ -12773,23 +12783,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d < 40.0))
             # 5m & 1h down move, 1h overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 60.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 60.0) | (roc_9_1h < 40.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 60.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 4h still high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 80.0))
             # 15m down move, 15m high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 80.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 80.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h still high
@@ -12801,15 +12811,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (df["RSI_14_4h"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (rsi_14_4h < 80.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h < 80.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 4h downtrend
@@ -12821,13 +12831,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
             # 15m down move & downtrend, 4h high
             & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h high, 1d overbought
@@ -12837,9 +12847,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 1d overbought
-            & ((rsi_3_15m > 10.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | (roc_9_1h < 10.0) | (roc_9_1d < 80.0))
             # 15m down move, 4h high
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 60.0))
             # 15m & 1h down move, 1h high
@@ -12847,31 +12857,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (df["RSI_14_15m"] < 50.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 80.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 80.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 40.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 15m down move, 1d overbought
             & ((rsi_3_15m > 30.0) | (roc_9_1d < 80.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
@@ -12887,21 +12897,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 40.0))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 75.0))
+            & ((rsi_3_1h > 10.0) | (rsi_14_4h < 75.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h overbought
@@ -12921,9 +12931,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down mve, 4h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (roc_9_4h < 80.0))
             # 1h down move, 1h still high, 4h downtrend
@@ -12935,9 +12945,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15n downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_15m > -20.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -12947,7 +12957,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h downtrend, 1h high
@@ -12955,7 +12965,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -15.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
@@ -12963,31 +12973,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 20.0))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (df["RSI_14_4h"] < 90.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (rsi_14_4h < 90.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 1d overbought
@@ -12999,61 +13009,61 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 60.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 5.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h still high, 4h high
-            & ((df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1d high
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
             # 1d down move, 4h still high, 1d overbought
-            & ((df["RSI_3_1d"] > 50.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d > 50.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
             # 1d down move, 1d high & overbought
-            & ((df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h high, 1d overbought
             & ((df["RSI_3_change_pct_1h"] > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m & 1h & 4h downtrend
             & ((df["CMF_20_15m"] > -0.3) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.3))
             # 15m high, 1d overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_15m < 70.0) | (roc_9_1d < 80.0))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 85.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
             # 4h high, 1h downtrend
-            & ((aroonu_14_4h < 80.0) | (df["ROC_9_1h"] > -15.0))
+            & ((aroonu_14_4h < 80.0) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1d > -40.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] > -10.0) | (roc_9_4h > -20.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_1h > -10.0) | (roc_9_4h > -20.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend
-            & ((stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] > -15.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -40.0))
             # 5m down move, 15m still not low enough, 1h high
-            & ((df["ROC_2"] > -10.0) | (df["AROONU_14_15m"] < 30.0) | (aroonu_14_1h < 80.0))
+            & ((df["ROC_2"] > -10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
             # 5m down move, 15m still high
-            & ((df["ROC_2"] > -10.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["ROC_2"] > -10.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 15m & 1h down move, 15m still high
-            & ((df["ROC_9"] > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["ROC_9"] > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 4h down move, 15m downtrend, 1h high
             & ((df["ROC_9"] > -15.0) | (rsi_3_4h > 45.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_1h < 60.0))
             # 1h downtrend, 4h high & overbought
-            & ((df["ROC_9_1h"] > -25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 80.0))
+            & ((roc_9_1h > -25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
-            & ((df["ROC_9_1h"] < 20.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
+            & ((roc_9_1h < 20.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
             # 1d P&D, 1d downtrend
             & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.0))
             # 1d green with top wick, 1h down move
@@ -13065,19 +13075,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green with top wick, 4h overbought
             & ((df["change_pct_1d"] < 50.0) | (df["top_wick_pct_1d"] < 30.0) | (roc_9_4h < 80.0))
             # big drop in the last hour, 15m downtrend
-            & ((df["close"] > (df["close_max_12"] * 0.65)) | (df["CMF_20_15m"] > -0.5))
+            & ((close > (df["close_max_12"] * 0.65)) | (df["CMF_20_15m"] > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
-            & ((df["close"] > (df["high_max_6_1h"] * 0.60)) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0))
+            & ((close > (df["high_max_6_1h"] * 0.60)) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0))
             # big drop in the last 24 hours,  1h still high
-            & ((df["close"] > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h < 45.0))
+            & ((close > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 4 days, 1h high
-            & ((df["close"] > (df["high_max_24_4h"] * 0.20)) | (aroonu_14_1h < 70.0))
+            & ((close > (df["high_max_24_4h"] * 0.20)) | (aroonu_14_1h < 70.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -13085,7 +13091,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.034))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
-            & (df["close"] < (df["BBL_20_2.0"] * 0.999))
+            & (close < (df["BBL_20_2.0"] * 0.999))
           )
 
         # Condition #2 - Normal mode (Long).
@@ -13096,49 +13102,49 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0))
             # 5m & 4h down move, 15m still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 5m & 4h down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m & 1d down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
             # 5m & 1d down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1d down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["CMF_20_1d"] > -0.25))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (df["CMF_20_1d"] > -0.25))
             # 5m & 1d down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high
-            & ((df["RSI_3"] > 3.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3 > 3.0) | (aroonu_14_1h < 80.0))
             # 5m down move, 4h high, 1d overbought
-            & ((df["RSI_3"] > 3.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3 > 3.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 5m down move, 4h high & overbought
-            & ((df["RSI_3"] > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 5m down move, 4h & 1d overbought
-            & ((df["RSI_3"] > 3.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3 > 3.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
             # 5m down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (roc_9_1d > -40.0))
+            & ((rsi_3 > 3.0) | (roc_9_1d > -40.0))
             # 5m & 15m down move, 15m still high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_15m > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 5.0) | (rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0))
             # 5m & 15m down move, 1h high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 5.0) | (rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0))
             # 5m & 4h down move, 1d downtrend
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still not low enough
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
             # 5m down move, 4h high, 1h overbought
-            & ((df["RSI_3"] > 10.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 1.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h down move
@@ -13148,7 +13154,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (df["CMF_20_15m"] > -0.30))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1h still not low enough
@@ -13176,7 +13182,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
@@ -13186,11 +13192,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (rsi_14_4h < 30.0))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (df["CMF_20_4h"] > -0.35))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
@@ -13198,9 +13204,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 20.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h still high, 15m downtrend
@@ -13212,7 +13218,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 4h high
@@ -13220,19 +13226,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1d still high, 4h still high
-            & ((df["RSI_3_1d"] > 50.0) | (df["RSI_14_1d"] < 50.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1d > 50.0) | (df["RSI_14_1d"] < 50.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 4h still high
@@ -13242,31 +13248,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 40.0))
             # 15m & 1d down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m downtrend, 4h still not low enough
             & ((rsi_3_15m > 5.0) | (df["CMF_20_15m"] > -0.30) | (stochrsi_k_4h < 30.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m stil high, 1h still high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
@@ -13280,7 +13286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (df["RSI_14_4h"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 4h high
@@ -13298,37 +13304,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["RSI_14_1d"] < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (df["RSI_14_1d"] < 40.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 20.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 15m sill high, 4h high
-            & ((rsi_3_15m > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h downtrend
@@ -13342,7 +13348,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 1h high
@@ -13350,41 +13356,41 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 25.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 30.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m & 4h still high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 60.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -13398,7 +13404,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
@@ -13406,13 +13412,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
             # 15m & 4h down move, 1h overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 35.0) | (df["ROC_9_1h"] < 100.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 35.0) | (roc_9_1h < 100.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 20.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 1d overbought
@@ -13420,7 +13426,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 50.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (df["ROC_9_1h"] < 50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
@@ -13432,7 +13438,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 80.0))
             # 15m down move, 4h high & overbought
@@ -13442,27 +13448,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 1h still high
             & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h % 4h down move, 4h downtrend
@@ -13470,7 +13476,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h downtrend
@@ -13478,23 +13484,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
@@ -13502,15 +13508,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h high
@@ -13518,19 +13524,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
@@ -13540,17 +13546,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d downtrend
@@ -13562,7 +13568,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h downtrend
@@ -13572,7 +13578,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h downtrend, 1d overbought
@@ -13590,13 +13596,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 1d overbought
@@ -13606,61 +13612,61 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 50.0) | (roc_9_1h < 10.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m still high
-            & ((rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (roc_9_1d > -25.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high. 4h downtrend
@@ -13670,7 +13676,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 60.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d downtrend
             & ((rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
             # 4h down move, 4h & 1d overbought
@@ -13678,53 +13684,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 45.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 50.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 55.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 60.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 60.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 5.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h high
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h overbought, 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 15.0) | (roc_9_1h < 20.0) | (roc_9_1d > -50.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 25.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 1d down move, 4h high & overbought
-            & ((df["RSI_3_1d"] > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 20.0))
+            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
@@ -13734,13 +13740,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 30.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4high, 1d downtrend
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 80.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h high, 1d downtrend
             & ((aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
             # 1h & 4h high, 1d overbought
@@ -13752,19 +13758,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high & overbought
             & ((aroonu_14_4h < 70.0) | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1d high, 1d downtrend
-            & ((df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # 1d high, 1h & 4h down move
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 25.0) | (roc_9_4h < 60.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 15m high, 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_15m < 70.0) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
             # 1h high, 1d overbought
@@ -13774,21 +13780,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1d high, 1h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 80.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 10.0) | (roc_9_1d < 80.0))
             # 1d high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((df["close"] > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((df["close"] > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
           )
 
           # Logic
@@ -13797,8 +13799,8 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["AROONU_14"] < 30.0)
             & (df["STOCHRSIk_14_14_3_3"] < 30.0)
             # & (rsi_3_15m > 5.0)
-            & (df["AROONU_14_15m"] < 50.0)
-            & (df["close"] < (df["EMA_20"] * 0.948))
+            & (aroonu_14_15m < 50.0)
+            & (close < (df["EMA_20"] * 0.948))
           )
 
         # Condition #3 - Normal mode (Long).
@@ -13809,39 +13811,39 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1h still high
-            ((df["RSI_3"] > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0))
+            ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0))
             # 5m down move, 15m high, 1d overbought
-            & ((df["RSI_3"] > 5.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
             # 5m down move, 15m still high, 1d downtrend
-            & ((df["RSI_3"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
             # 5m down move, 1h still high, 4h downtrend
-            & ((df["RSI_3"] > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -10.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -10.0))
             # 5m down move, 1h high. 1d downtrend
-            & ((df["RSI_3"] > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 5m down move, 15m & 1h high
-            & ((df["RSI_3"] > 10.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 5m down move, 15m & 1d high
-            & ((df["RSI_3"] > 10.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
             # 5m down move, 1h & 1d high
-            & ((df["RSI_3"] > 15.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3 > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h dowbn move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 50.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h still high
@@ -13857,31 +13859,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
             # 15m & 1d down move, 15m high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 4h downtrend. 15m high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_4h"] > -0.30) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 15.0) | (df["CMF_20_4h"] > -0.30) | (aroonu_14_15m < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -70.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 15m & 1d high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 50.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h high, 1d overbought
@@ -13895,45 +13897,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 75.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 75.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0))
             # 15m &1d down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 50.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 20.0))
             # 15m down move, 15m still not low enough, 4h overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 30.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (roc_9_4h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -40.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 20.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 50.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
@@ -13951,9 +13953,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 20.0) | (roc_9_4h < 25.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 75.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 75.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_1h < 100.0))
             # 15m & 4h down move, 1h high
@@ -13961,15 +13963,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 75.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 75.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 90.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -20.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1h high, 1d downtrend
@@ -13977,11 +13979,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h high, 1d high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 1h high, 4h high
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h & 1d overbought
@@ -13993,25 +13995,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1d high, 15m high
-            & ((rsi_3_15m > 30.0) | (df["RSI_14_1d"] < 70.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 30.0) | (df["RSI_14_1d"] < 70.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -40.0))
             # 15m down move, 15m high, 15m downtrend
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (df["CMF_20_15m"] > -0.30))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 70.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 60.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 50.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 100.0))
             # 15m down move, 4h high, 1d overbought
@@ -14021,13 +14023,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 15m high, 1h downtrend
-            & ((rsi_3_15m > 40.0) | (df["AROONU_14_15m"] < 70.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1h > -20.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 40.0) | (df["AROONU_14_15m"] < 75.0) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m > 40.0) | (aroonu_14_15m < 75.0) | (aroonu_14_4h < 75.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h down move, 4h still high, 4h downtrend
@@ -14037,17 +14039,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 60.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 60.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
@@ -14055,17 +14057,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
             # 1h down move, 15m & 1h still high
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 1h still high 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
@@ -14077,19 +14079,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 35.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 15m still high, 4h  high
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 15m & 1d high
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h > 35.0) | (df["CMF_20_1h"] > -0.30) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
@@ -14103,11 +14105,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 60.0))
             # 1h down move, 15m still high, 4h downtrend
-            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h still high, 1d overbought
@@ -14123,7 +14125,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1h down move, 15m high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
@@ -14131,13 +14133,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h still high, 1d overbought
@@ -14149,7 +14151,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
@@ -14157,9 +14159,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 65.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high, 4h downtrend
@@ -14167,57 +14169,57 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 3.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1h still high
-            & ((rsi_3_4h > 5.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 35.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -40.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 60.0))
             # 4h down move, 15m & 1d high
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 55.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 55.0) | (roc_9_1d < 50.0))
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 15m high, 1d high
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1d < 70.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 80.0) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still not low enough, 4h downtrend
@@ -14225,19 +14227,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 4h high, 1d downtrend
@@ -14249,13 +14251,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 1d downtrend, 1d overbought
             & ((rsi_3_4h > 30.0) | (df["CMF_20_1d"] > -0.30) | (roc_9_1d < 40.0))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high, 1d downtrend
@@ -14263,63 +14265,63 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 50.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h & 4h high
             & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 30.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 90.0))
             # 45 down move, 15m high, 1h high
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 70.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 30.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 45.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 4h down move, 15m & 1h high
-            & ((rsi_3_4h > 50.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 4h still high, 1h high
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 50.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 50.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
@@ -14329,11 +14331,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h > 60.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h > 60.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -14341,101 +14343,101 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 65.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_4h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 3.0) | (roc_9_4h > -40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | (roc_9_1d > -50.0))
             # 1d down move, 15m still high, 4h high
-            & ((df["RSI_3_1d"] > 10.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -60.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 1d down move, 15m high, 1h high
-            & ((df["RSI_3_1d"] > 20.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
             # 1d down move, 15m high, 1h high
-            & ((df["RSI_3_1d"] > 20.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1d down move, 4h high, 4h downtrend
-            & ((df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h > -20.0))
             # 1d down move, 15m high, 4h high
-            & ((df["RSI_3_1d"] > 25.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 1d down move, 15m high, 4h downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 1d down move, 1h & 1d high
-            & ((df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 1d high & overbought
-            & ((df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 60.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 30.0) | (aroonu_14_1d < 60.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 20.0))
             # 1d down move, 1h & 1d high
-            & ((df["RSI_3_1d"] > 35.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1d > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1d down move, 1h high, 1d overbought
-            & ((df["RSI_3_1d"] > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high & overbought
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1d down move, 1d high & overbought
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((df["RSI_3_1d"] > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1d > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
             # 15m still high, 4h high, 1d overbought
-            & ((df["AROONU_14_15m"] < 50.0) | (df["RSI_14_4h"] < 60.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_15m < 50.0) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
             # 15m still high, 1h downtrend, 4h overbought
-            & ((df["AROONU_14_15m"] < 50.0) | (df["ROC_9_1h"] > -10.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_15m < 50.0) | (roc_9_1h > -10.0) | (roc_9_4h < 40.0))
             # 15m high, 4h high & overbought
-            & ((df["AROONU_14_15m"] < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d overbought
-            & ((df["AROONU_14_15m"] < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 10.0))
+            & ((aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 10.0))
             # 15m high, 15m & 4h overbought
-            & ((df["AROONU_14_15m"] < 60.0) | (df["ROC_9_15m"] < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 60.0) | (roc_9_15m < 10.0) | (roc_9_4h < 20.0))
             # 15m high, 4h downtrend
-            & ((df["AROONU_14_15m"] < 60.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_15m < 60.0) | (roc_9_4h > -30.0))
             # 15m & 1h & 4h high
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h & 1d high
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
             # 15m & 4h high, 4h overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
             # 15m & 4h high, 1d downtrend
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
             # 15m & 1d high, 1d overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 15m high, 4h downtrend, 1d overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h high, 1d high & overbought
-            & ((aroonu_14_1h < 90.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h high, 4h downtrend
             & ((aroonu_14_1h < 90.0) | (roc_9_4h > -20.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 4h & 1d high, 1d downtrend
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
             # 1d high, 4h & 1d downtrend
-            & ((df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend
-            & ((df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -30.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -30.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -30.0) | (roc_9_1d < 70.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 15m & 1h high, 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
             # 15m & 1d high
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d < 90.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 1h high, 4h downtrend
@@ -14445,17 +14447,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -20.0))
             # 1d still high, 4h & 1d downtrend
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 1d P&D, 4h downtrend
             & ((df["change_pct_1d"] > -50.0) | (df["change_pct_1d"].shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # 1d P&D, 15m high
-            & ((df["change_pct_1d"] > -20.0) | (df["change_pct_1d"].shift(288) < 20.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((df["change_pct_1d"] > -20.0) | (df["change_pct_1d"].shift(288) < 20.0) | (aroonu_14_15m < 70.0))
             # 1d red with top wick, 4h high
             & ((df["change_pct_1d"] > -20.0) | (df["top_wick_pct_1d"] < 20.0) | (aroonu_14_4h < 80.0))
             # 1d red, previous 1d top wick, 15m high
-            & (
-              (df["change_pct_1d"] > -10.0) | (df["top_wick_pct_1d"].shift(288) < 40.0) | (df["AROONU_14_15m"] < 70.0)
-            )
+            & ((df["change_pct_1d"] > -10.0) | (df["top_wick_pct_1d"].shift(288) < 40.0) | (aroonu_14_15m < 70.0))
             # 1d green with top wick, 4h overbought
             & ((df["change_pct_1d"] < 15.0) | (df["top_wick_pct_1d"] < 15.0) | (roc_9_4h < 20.0))
             # 1d green, 15m down move, 1h high
@@ -14465,11 +14465,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 4h down move, 1d overbought
             & ((df["top_wick_pct_1d"] < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -14479,8 +14475,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (df["RSI_14"] > 30.0)
             & (df["AROONU_14"] < 20.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["close"] < df["SMA_16"] * 0.965)
-            & (df["close"] < df["SMA_16_1h"] * 0.985)
+            & (close < df["SMA_16"] * 0.965)
+            & (close < df["SMA_16_1h"] * 0.985)
           )
 
         # Condition #4 - Normal mode (Long).
@@ -14492,35 +14488,35 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m > 3.0)
             # 5m & 1h down move, 1d still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 3.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1d < 40.0))
             # 5m & 1h & 4h down move
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
             # 5m & 1d down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high, 4h overbought
-            & ((df["RSI_3"] > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m down move, 4h high, 1h overbought
-            & ((df["RSI_3"] > 10.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
@@ -14530,9 +14526,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 15m stil high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_4h > -40.0))
             # 15m & 1h down move, 1h still high
@@ -14546,7 +14542,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
             # 15m down move, 1h high
@@ -14554,7 +14550,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 80.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
@@ -14566,9 +14562,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 4h high, 4h overbought
@@ -14578,67 +14574,67 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 40.0) | (rsi_3_1h > 50.0) | (roc_9_4h < 50.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["CMF_20_15m"] > -0.40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 15m still high
-            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 50.0))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 10.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (rsi_3_1d > 10.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (df["CMF_20_1h"] > -0.40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (roc_9_1d < 100.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h & 3h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
             # 1h down move, 1d high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_15m"] > -50.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_15m > -50.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 10.0) | (roc_9_4h > -15.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
             # 1h down move, 1h high
@@ -14652,15 +14648,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 70.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 4h & 1d downtrend
@@ -14684,41 +14680,41 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
@@ -14728,13 +14724,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 80.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 80.0))
             # 1h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_1d < 70.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 30.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 30.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 30.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
             # 4h still high, 5m downtrend
@@ -14742,37 +14738,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h high, 1h & 1d overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h high
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 50.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d downtrend
-            & ((df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1d < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
             # 1d high, 1h & 1d overbought
-            & ((df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((df["close"] > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
           )
 
           # Logic
           long_entry_logic.append(
             (df["AROONU_14"] < 25.0)
-            & (df["AROONU_14_15m"] < 25.0)
-            & (df["close"] < (df["EMA_9"] * 0.946))
-            & (df["close"] < (df["EMA_20"] * 0.960))
+            & (aroonu_14_15m < 25.0)
+            & (close < (df["EMA_9"] * 0.946))
+            & (close < (df["EMA_20"] * 0.960))
           )
 
         # Condition #5 - Normal mode (Long).
@@ -14784,13 +14776,13 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m > 20.0)
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 40.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h still high
@@ -14806,11 +14798,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m stil not low enough, 4h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 25.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 15m & 4h down move, 4h high
@@ -14818,31 +14810,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 85.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 25.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 45.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m > 45.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d overbought
@@ -14852,19 +14844,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d overbought
@@ -14874,17 +14866,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend. 4h still not low enough
             & ((rsi_3_1h > 10.0) | (roc_9_4h > -20.0) | (aroonu_14_4h < 30.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 15m high, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (df["CMF_20_15m"] > -0.30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 10.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1h still not low enough
@@ -14894,19 +14886,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 60.0))
             # 1h & 4h down move, 4h high
@@ -14914,13 +14906,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
@@ -14934,7 +14926,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
@@ -14952,7 +14944,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
@@ -14960,15 +14952,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
@@ -14976,15 +14968,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 50.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 55.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h & 1d overbought
@@ -14992,23 +14984,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 15m downtrend, 1d high
-            & ((rsi_3_4h > 10.0) | (df["CMF_20_15m"] > -0.30) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_4h > 10.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -15016,19 +15008,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (roc_9_4h > -40.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1ddown move, 1d high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high. 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
             # 4h down move, 4h high, 1d downtrend
@@ -15038,7 +15030,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d overbought
@@ -15046,78 +15038,74 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 4h downtrend
-            & ((df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h > -30.0))
             # 15m & 1h & 4h downtrend
             & ((df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30) | (df["CMF_20_4h"] > -0.30))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 20.0))
+            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m not low enough, 1h & 4h downtrend
-            & ((df["AROONU_14_15m"] < 20.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_15m < 20.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 15m high, 1h high & overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 85.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (df["ROC_9_1h"] < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 85.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
             # 4h high, 1h & 1d overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1d high, 1h & 4h down move
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 25.0) | (roc_9_4h < 60.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 1h downtrend, 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 15m high, 4h & 1d downtrend
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
             & ((df["change_pct_1d"] > -50.0) | (df["change_pct_1d"].shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((df["close"] > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((df["close"] > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] < 50.0)
+            (rsi_3 < 50.0)
             & (df["AROONU_14"] < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
@@ -15133,59 +15121,59 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
-            ((df["RSI_3"] > 3.0) | (rsi_3_15m > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            ((rsi_3 > 3.0) | (rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0))
             # 5m & 15m down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0))
             # 5m & 15m down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (rsi_3_15m > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (roc_9_1d > -20.0))
             # 5m & 15m down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (rsi_3_15m > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (roc_9_1d > -30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 4h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0))
             # 5m & 4h & 1d down move
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 35.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 35.0))
             # 5m & 4h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 70.0))
             # 5m & 4h down move, 4h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
             # 5m & 1d down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 4h & 1d overbought
-            & ((df["RSI_3"] > 3.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3 > 3.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
             # 5m & 1h down move, 4h high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 60.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0))
             # 5m & 4h down move, 1d downtrend
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 1d overbought
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 60.0))
             # 5m & 4h down move, 4h high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
             # 5m down move, 15m still not low enough, 4h high
-            & ((df["RSI_3"] > 5.0) | (df["AROONU_14_15m"] < 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
             # 5m down move, 1h & 1d high
-            & ((df["RSI_3"] > 5.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 100.0))
             # 5m down move, 4h high & overbought
-            & ((df["RSI_3"] > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 25.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 25.0))
             # 5m down move, 1h high
-            & ((df["RSI_3"] > 5.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0))
             # 5m & 1d down move, 1d still high
-            & ((df["RSI_3"] > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3 > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 20.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still high
@@ -15199,17 +15187,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 20.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 25.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 25.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1d down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 3.0) | (df["RSI_3_1d"] > 55.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 55.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d downtrend, 1d high
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h still high
@@ -15225,17 +15213,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h still high, 1d high
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 40.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m & 1h still not low enough
-            & ((rsi_3_15m > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h still high
@@ -15265,23 +15253,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h downtrend
@@ -15297,19 +15285,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 75.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 50.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 20.0))
             # 15m down move, 15m downtrend, 4h still high
             & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.40) | (stochrsi_k_4h < 50.0))
             # 15m down move, 1h downtrend, 4h still high
             & ((rsi_3_15m > 10.0) | (df["CMF_20_1h"] > -0.30) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 1h still not low enough, 1d overbought
@@ -15335,15 +15323,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 4h high
@@ -15359,15 +15347,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 30.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 30.0) | (roc_9_1d < 10.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
@@ -15375,19 +15363,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 85.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 25.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 25.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 4h downtrend
@@ -15399,11 +15387,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 50.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
@@ -15411,21 +15399,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h < 90.0))
             # 15m & 4h & 1d down move
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 70.0))
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high, 1d overbought
@@ -15433,25 +15421,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m down move, 1d high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 15m down move, 1d high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 10.0))
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 70.0) | (df["CMF_20_15m"] > -0.40))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
@@ -15463,11 +15451,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h high, 4h overbought
@@ -15483,7 +15471,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 30.0))
             # 15m & 1h down move, 1h high
@@ -15491,11 +15479,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h high & overbought
@@ -15507,29 +15495,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 1m still high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 70.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 40.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 4h high
@@ -15543,13 +15531,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d downtrend
@@ -15559,35 +15547,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 20.0) | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["RSI_14_1d"] < 80.0))
             # 1h & 4h down move, 4h high
@@ -15595,49 +15583,49 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h & 1d down move
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 30.0) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 35.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -15.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h still not low enough, 1d downtrend
@@ -15645,13 +15633,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 50.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 50.0) | (roc_9_1h < 10.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 50.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h high
@@ -15661,11 +15649,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 60.0) | (df["RSI_3_1d"] > 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 4 high, 1h overbought
-            & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 1h down move, 1d high, 1h overbought
-            & ((rsi_3_1h > 60.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -10.0))
             # 1h down move, 1h high, 1d overbought
@@ -15679,43 +15667,43 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 3.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -15723,25 +15711,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 35.0) | (df["RSI_3_1d"] > 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 40.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 20.0))
             # 4h down move, 4h high, 1d overbought
@@ -15755,13 +15743,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 60.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 60.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h still high, 4h overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d overbought
@@ -15769,119 +15757,115 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
             # 1d down move, 1d still not low enough, 1d downtrend
-            & ((df["RSI_3_1d"] > 5.0) | (df["AROONU_14_1d"] < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 20.0) | (roc_9_1d > -20.0))
             # 1d down move, 15m still high
-            & ((df["RSI_3_1d"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_1d > 5.0) | (stochrsi_k_15m < 40.0))
             # 1d down move, 1h high
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
             # 1d down move, 4h downtrend, 4h high
-            & ((df["RSI_3_1d"] > 20.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1d > 20.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 4h & 1d high
-            & ((df["RSI_3_1d"] > 40.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 1d down move, 1d high & overbought
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((df["RSI_3_1d"] > 60.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 4h downtrend, 4h high & over
             & ((df["CMF_20_4h"] > -0.10) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
             # 15m still high, 4h high, 1h overbought
-            & ((df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 15m still high, 4h high, 1h overbought
-            & ((df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
             # 1h high, 4h high & overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 30.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4h & 1d high
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 30.0))
             # 1h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h & 1d high, 4h overbought
-            & ((aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 50.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 50.0) | (roc_9_1d > -50.0))
             # 1h high, 4h &1d overbought
             & ((aroonu_14_1h < 85.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 15.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 50.0))
+            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h high, 4h overbought, 1d downtrend
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 1h & 1d overbought
-            & ((df["AROONU_14_1d"] < 80.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d < 50.0))
             # 1d high, 1d downtrend
-            & ((df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
             # 15m still not low enough, 4h high, 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 30.0))
+            & ((stochrsi_k_15m < 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 30.0))
             # 15m still high, 4h high & overbought
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h > -10.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h > -10.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 50.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 50.0))
             # 1h high & overbought
-            & ((stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 40.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 200.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 1d hihg, 1h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
             & ((df["change_pct_1d"] > -50.0) | (df["change_pct_1d"].shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((df["close"] > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((df["close"] > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
           )
 
           # Logic
           long_entry_logic.append(
             (df["RSI_20"] < df["RSI_20"].shift(1))
-            & (df["RSI_3"] < 46.0)
+            & (rsi_3 < 46.0)
             & (df["AROONU_14"] < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["AROONU_14_15m"] < 50.0)
-            & (df["close"] < df["SMA_16"] * 0.960)
+            & (aroonu_14_15m < 50.0)
+            & (close < df["SMA_16"] * 0.960)
           )
 
         # Condition #21 - Pump mode (Long).
@@ -15892,9 +15876,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m down move, 4h high, 1h overbought
-            ((df["RSI_3"] > 10.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 30.0))
+            ((rsi_3 > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 5.0) | (df["ROC_9_1h"] < 25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
@@ -15914,13 +15898,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (roc_9_4h < 100.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 35.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 40.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 4h overbought
@@ -15928,13 +15912,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (df["CMF_20_4h"] > -0.25))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 20.0) | (roc_9_4h < 80.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1d overbought
@@ -15942,21 +15926,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -25.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 25.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 200.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 30.0) | (df["ROC_9_1h"] < 60.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m > 30.0) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 40.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h overbought, 1d downtrend
@@ -15978,7 +15962,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 20.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 1d downtrend
@@ -15986,21 +15970,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 25.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -25.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 25.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 50.0) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h high & overbought
@@ -16008,108 +15992,108 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 250.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_1h < 10.0) | (roc_9_1d < 250.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 65.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 65.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_1h > 65.0) | (roc_9_1h < 40.0))
             # 4h down move, 1h high & overbought
-            & ((rsi_3_4h > 3.0) | (aroonu_14_1h < 85.0) | (df["ROC_9_1h"] < 60.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 60.0))
             # 1d down move, 4h high & overbought
-            & ((df["RSI_3_1d"] > 5.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1d > 5.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 50.0))
             # 1d down move, 1h high
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
             # 1d down move, 4h high, 1h overbought
-            & ((df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 25.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 25.0))
             # 1d down move, 4h high, 4h overbought
-            & ((df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 1d down move, 1h & 4h overbought
-            & ((df["RSI_3_1d"] > 30.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d > 30.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
             # 1d down move, 4h high & overbought
-            & ((df["RSI_3_1d"] > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1d > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 4h & 1d high
-            & ((df["RSI_3_1d"] > 40.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 1d down move, 4h high & overbought
-            & ((df["RSI_3_1d"] > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1d down move, 1h high, 1d overbought
-            & ((df["RSI_3_1d"] > 60.0) | (aroonu_14_1h < 75.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 75.0) | (roc_9_1d < 20.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 65.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 65.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 20.0))
+            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m not low enough, 1h high, 1d overbought
-            & ((df["AROONU_14_15m"] < 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
-            & ((aroonu_14_1h < 50.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_1h < 50.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 30.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 1h & 1d high, 4h overbought
-            & ((aroonu_14_1h < 90.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_1h < 90.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_1h < 80.0) | (stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0))
             # 1h high & overbought
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 80.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 80.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 4h overbought, 1d downtrend
             & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d > -50.0))
             # 1h & 4h high, 15m downtrend
-            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_15m"] > -40.0))
+            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -40.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 10.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_4h < 80.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_4h < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
-            & ((aroonu_14_4h < 85.0) | (df["AROONU_14_1d"] < 100.0) | (df["CMF_20_4h"] > -0.30))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (df["CMF_20_4h"] > -0.30))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 85.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 85.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 60.0))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 60.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h high, 1d high & overbought
-            & ((aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_4h < 90.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
             # 1d high, 1h & 4h overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 60.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 40.0))
+            & ((stochrsi_k_1h < 60.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1h high, 1h overbought
-            & ((stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h high, 4h overbought. 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0) | (df["CMF_20_1d"] > -0.25))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h high & 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d high, 1h & 4h overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1d hihg, 1h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
           )
 
           # Logic
           long_entry_logic.append(
             (df["AROONU_14"] < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["AROONU_14_15m"] < 50.0)
-            & (df["close"] < df["EMA_16"] * 0.960)
-            & (((df["EMA_50"] - df["EMA_200"]) / df["close"] * 100.0) > 6.0)
+            & (aroonu_14_15m < 50.0)
+            & (close < df["EMA_16"] * 0.960)
+            & (((df["EMA_50"] - df["EMA_200"]) / close * 100.0) > 6.0)
           )
 
         # Condition #41 - Quick mode (Long).
@@ -16120,9 +16104,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1d down move, 4h still high
-            ((df["RSI_3"] > 15.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_4h < 40.0))
+            ((rsi_3 > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 15m downtrend
@@ -16140,13 +16124,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
@@ -16156,15 +16140,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h still high, 1d high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 50.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 80.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
@@ -16176,7 +16160,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -16198,13 +16182,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 5.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 5.0) | (df["ROC_9_1h"] < 25.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 5.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h high
@@ -16222,35 +16206,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 15m high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 1h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (df["ROC_9_15m"] > -10.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_1h"] > -25.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -25.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.00) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.00) | (roc_9_15m > -30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
             # 15m down move, 1h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_15m"] > -10.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
@@ -16260,25 +16244,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 50.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -30.0))
             # 15m down move, 4h high & overbought
@@ -16286,9 +16270,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m > 15.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_1h > -20.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
@@ -16296,17 +16280,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0))
             # 15m &4h down move, 4h still high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 50.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -15.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (df["ROC_9_1h"] < 50.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high, 1d overbought
@@ -16314,11 +16298,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h high, 4h overbought
@@ -16330,7 +16314,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
@@ -16338,59 +16322,59 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h downtrend
             & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (roc_9_1h > -20.0))
             # 1h down move, 1h high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 4h high
             & ((rsi_3_1h > 3.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d < 20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 20.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (df["CMF_20_1h"] > -0.30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -50.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 85.0) | (roc_9_1h > -50.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -25.0) | (roc_9_1d > -50.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1h < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -35.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["ROC_9_15m"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_15m > -20.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d downtrend
@@ -16398,19 +16382,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 20.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["CMF_20_1h"] > -0.40))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (df["CMF_20_1h"] > -0.40))
             # 1h down move, 1d downtrend, 4h high
             & ((rsi_3_1h > 10.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h still high, 4h overbought
@@ -16418,31 +16402,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d < 90.0))
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -25.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h downtrend, 1h still high
             & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (stochrsi_k_1h < 40.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1h downtrend
@@ -16452,53 +16436,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h high, 15m downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -15.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_1h"] > -30.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d > -50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 20.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 20.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 20.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d overbought
@@ -16510,13 +16494,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
             # 1h down move, 15m downtrend, 4h overbought
-            & ((rsi_3_1h > 25.0) | (df["ROC_9_15m"] > -25.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_15m > -25.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h & 1d downtrend
-            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_1h > -50.0) | (roc_9_1d > -50.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_1h < 30.0) | (roc_9_4h < 100.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0))
             # 1h & 4h down move, 4h downtrend
@@ -16526,11 +16510,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 30.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (df["ROC_9_1h"] < 50.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1d overbought
@@ -16538,7 +16522,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -40.0))
             # 1h down move, 1h & 4h high
@@ -16554,19 +16538,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 35.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 35.0) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 70.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_15m"] > -10.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_15m > -10.0))
             # 1h down move, 1h  high & overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h & 1d overbought
@@ -16584,27 +16568,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 60.0) | (df["ROC_9_1h"] < 30.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_1h < 30.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 30.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 70.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1h > -40.0))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -50.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 35.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
             # 4h down move, 4h still high, 1d overbought
@@ -16612,17 +16596,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_1h > -40.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still high, 1d overbought
@@ -16630,15 +16614,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -16646,92 +16630,88 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1d down move, 4h still high, 1d downtrend
-            & ((df["RSI_3_1d"] > 3.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1d > 3.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
             # 1d down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1d > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -80.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -30.0))
             # 1d down move, 1h still high, 4h downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 35.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m downtrend, 4h & 1d high
-            & ((df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h high, 1h overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (df["ROC_9_1h"] < 50.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m & 1d high, 1d overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h & 4h high, 1h downtrend
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (df["CMF_20_1h"] > -0.30))
             # 1h high, 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
             # 1h high, 1d high & overbought
-            & ((aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 1h high, 1h & 1d overbought
-            & ((aroonu_14_1h < 70.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1h < 70.0) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
             # 1h high, 4h downtrend, 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
             # 1h high, 1h & 1d overbought
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d > -40.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 4h high, 15m downtrend, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_15m"] > -30.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_15m > -30.0) | (roc_9_4h < 30.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_4h < 70.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 30.0) | (roc_9_4h < 70.0))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 50.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1h < 50.0))
             # 1d still high, 4h & 1d downtrend
-            & ((df["AROONU_14_1d"] < 50.0) | (roc_9_4h > -50.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -50.0) | (roc_9_1d > -50.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h > -15.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
             # 1d P&D, 4h overbought
             & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 30.0) | (roc_9_4h < 10.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] > 5.0)
+            (rsi_3 > 5.0)
             & (df["RSI_14"] < 36.0)
             & (df["AROONU_14"] < 25.0)
             & (df["AROOND_14"] > 75.0)
@@ -16746,25 +16726,25 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1d still high
-            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 40.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (df["ROC_9_1h"] > -50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (roc_9_1h > -50.0))
             # 15m & 1h down move, 1d still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 30.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_1d < 30.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 60.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m down move, 4h still high, 1d downtrend
@@ -16774,11 +16754,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 70.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 4h still high
@@ -16786,11 +16766,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1d downtrend
@@ -16800,49 +16780,49 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 60.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (roc_9_1d > -50.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -10.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h still not low enough
@@ -16850,31 +16830,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] > -50.0))
+            & ((rsi_3_1h > 3.0) | (aroonu_14_1d < 70.0) | (roc_9_1h > -50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 40.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 75.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 75.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d downtrend
@@ -16882,7 +16862,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 1d downtrend
@@ -16892,21 +16872,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1d < 50.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["RSI_14_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (df["RSI_14_1d"] < 50.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h high, 1d downtrend
@@ -16920,11 +16900,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (stochrsi_k_15m < 80.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d still high, 1d downtrend
@@ -16932,23 +16912,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 40.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 60.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
@@ -16956,11 +16936,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d still high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 50.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d downtrend
@@ -16968,35 +16948,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h high, 1d overbought
@@ -17006,49 +16986,49 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 75.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 45.0) | (df["AROONU_14_15m"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 45.0) | (aroonu_14_15m < 90.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 35.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 15m high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -40.0))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high & overbought
@@ -17066,61 +17046,61 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 4h & 1d down move
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
             # 4h down move, 1h downtrend, 4h still high
             & ((rsi_3_4h > 3.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (df["ROC_9_1h"] > -15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 30.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 50.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 20.0))
             # 4h down move, 15m high, 1h downtrend
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0) | (roc_9_1h > -10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
             # 4h down move, 4h still not low e nough, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
             # 15m & 1d down move, 15m high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["RSI_14_1d"] < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (df["RSI_14_1d"] < 50.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
             # 4h down move, 1h high, 1d downtrend
@@ -17128,47 +17108,47 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h > 15.0) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 90.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 70.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -50.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1h > -10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d downtrend
@@ -17178,15 +17158,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h > -40.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 60.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 4h down move, 4h high, 1d downtrend
@@ -17194,11 +17174,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -17208,71 +17188,67 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1d down move, 1d still high
-            & ((df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 1d down move, 15m high
-            & ((df["RSI_3_1d"] > 20.0) | (df["AROONU_14_15m"] < 80.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 80.0))
             # 1d down move, 4h high, 4h downtrend
-            & ((df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -40.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 4h & 1d high
-            & ((df["RSI_3_1d"] > 30.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h downtrend, 4h high
             & ((df["CMF_20_1h"] > -0.40) | (df["CMF_20_4h"] > -0.40) | (aroonu_14_4h < 80.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (df["AROONU_14_1d"] < 85.0))
+            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (aroonu_14_1d < 85.0))
             # 15m & 1d high, 4h overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d downtrend
-            & ((df["AROONU_14_15m"] < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_1d > -20.0))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 50.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1h < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 4h high, 4h & 1d downtrend
             & ((aroonu_14_4h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1d high, 1h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 15m still high, 1h & 4h downtrend
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h > -20.0))
+            & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 30.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 30.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1d still high, 4h & 1d downtrend
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -17282,7 +17258,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (df["WILLR_84_1h"] < -70.0)
             & (stochrsi_k_1h < 20.0)
             & (df["BBB_20_2.0_1h"] > 16.0)
-            & (df["close_max_48"] >= (df["close"] * 1.10))
+            & (df["close_max_48"] >= (close * 1.10))
           )
 
         # Condition #43 - Quick mode (Long).
@@ -17293,57 +17269,57 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
-            ((df["RSI_3"] > 3.0) | (rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 40.0))
+            ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
             # 5m & 1h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0))
             # 5m & 1d down move, 1d still not low enough
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 30.0))
             # 5m down move, 1h & 4h high
-            & ((df["RSI_3"] > 3.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 > 3.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 5m down move, 4h high & overbought
-            & ((df["RSI_3"] > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 5m down move, 1h high, 4h overbought
-            & ((df["RSI_3"] > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m down move, 1d high & overbought
-            & ((df["RSI_3"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 5m & 1h down move, 1d overbought
-            & ((df["RSI_3"] > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 5m & 1d down move, 1h high
-            & ((df["RSI_3"] > 5.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 90.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3 > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h & 1d down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 25.0))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_1d"] < 50.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1h still high
@@ -17351,21 +17327,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 3.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high & overbought
@@ -17373,15 +17349,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 10.0))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m > 3.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 3.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 70.0))
             # 15m & 1h down move, 4h high
@@ -17391,17 +17367,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 15m & 1h still high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 4h overbought
@@ -17409,25 +17385,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 50.0))
             # 15m down move, 1d still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 15m down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (roc_9_1d > -60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 4h high
@@ -17439,13 +17415,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1h high
@@ -17457,23 +17433,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -30.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -10.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -40.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d overbought
@@ -17481,7 +17457,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 90.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 4h high
@@ -17489,9 +17465,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
             # 15m down move. 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 40.0))
             # 15m down move, 4h high & overbought
@@ -17509,7 +17485,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 30.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
@@ -17517,9 +17493,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 1d overbought
@@ -17527,21 +17503,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -30.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (roc_9_1h > -30.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -17549,37 +17525,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h still not low enough
@@ -17587,17 +17563,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h still high, 4h downtrend
@@ -17611,27 +17587,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 20.0) | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 20.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -40.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 50.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -70.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -70.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d downtrend
@@ -17645,23 +17621,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 40.0) | (df["RSI_3_1d"] > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h > 40.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1d overbought
@@ -17673,31 +17649,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (df["ROC_9_1h"] > -10.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d  downtrend
@@ -17711,29 +17687,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 1d down move, 4h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -70.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 35.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 4h downtrend, 1h & 4h high
             & ((df["CMF_20_4h"] > -0.30) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m still high, 1h & 4h overbought
-            & ((df["AROONU_14_15m"] < 50.0) | (df["ROC_9_1h"] < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_15m < 50.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 15m & 1d high, 1d overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h & 4h high, 1d downtrend
@@ -17741,7 +17717,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 200.0))
             # 1h high, 4h downtrend, 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 4h overbought
@@ -17749,25 +17725,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & ((aroonu_14_1h < 80.0) | (roc_9_1d > -60.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 100.0) | (df["ROC_9_1h"] < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_1h < 100.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 70.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (df["ROC_9_1h"] < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend, 4h overbought
-            & ((aroonu_14_4h < 90.0) | (df["ROC_9_1h"] > -40.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h < 90.0) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 100.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 90.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h overbought
@@ -17775,17 +17751,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 85.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 100.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h & 4h overbought, 1d downtrend
-            & ((df["ROC_9_1h"] < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -17796,8 +17768,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.024))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
-            & (df["close"] < (df["EMA_20"] * 0.960))
-            & (df["close"] < (df["BBL_20_2.0"] * 0.999))
+            & (close < (df["EMA_20"] * 0.960))
+            & (close < (df["BBL_20_2.0"] * 0.999))
           )
 
         # Condition #44 - Quick mode (Long).
@@ -17808,7 +17780,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h & 4h down move
-            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 1h high
@@ -17818,15 +17790,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_15m > -30.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 15m & 4h down move, 1h still high
@@ -17838,11 +17810,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 70.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 70.0) | (roc_9_15m > -30.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 30.0))
             # 15m down move, 4h overbought
@@ -17856,43 +17828,43 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 60.0))
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 50.0))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (roc_9_1h > -20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (df["ROC_9_1h"] > -15.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1h > -15.0))
             # 1h downtrend, 4h high
             & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h > 3.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 3.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 1h down move, 1d overbought
@@ -17900,7 +17872,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h still high
@@ -17908,23 +17880,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (df["ROC_9_1h"] > -25.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1h > -25.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 50.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 40.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (roc_9_1h > -10.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h high
@@ -17936,13 +17908,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h overbought
             & ((rsi_3_1h > 10.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
@@ -17954,7 +17926,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d overbought
@@ -17964,9 +17936,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1h down move, 1h & 4h overbought
@@ -17982,15 +17954,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down ove, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 25.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_1h > -20.0) | (roc_9_4h < 20.0))
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 4h high
@@ -17998,23 +17970,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 3.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 40.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (df["ROC_9_1h"] > -15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h high
@@ -18024,17 +17996,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 4h down move, 1h high & overbought
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h high
@@ -18044,9 +18016,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 4h high
             & ((df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
             # 1h & 1d high, 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+            & ((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d downtrend
@@ -18054,61 +18026,57 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h downtrend
             & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h & 1d high, 1h downtrend
-            & ((aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] > -20.0))
+            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1h > -20.0))
             # 4h & 1d high, 1h downtrend
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] > -30.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1h > -30.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
             # 4h high, 1h downtrend
-            & ((aroonu_14_4h < 80.0) | (df["ROC_9_1h"] > -40.0))
+            & ((aroonu_14_4h < 80.0) | (roc_9_1h > -40.0))
             # 4h high & overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
             # 4h high, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1d > -30.0))
             # 1d still high, 1d downtrend
-            & ((df["AROONU_14_1d"] < 50.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 1d high, 15m downtrend
-            & ((df["AROONU_14_1d"] < 70.0) | (df["ROC_9_15m"] > -50.0))
+            & ((aroonu_14_1d < 70.0) | (roc_9_15m > -50.0))
             # 1d high, 1h downtrend
-            & ((df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] > -70.0))
+            & ((aroonu_14_1d < 70.0) | (roc_9_1h > -70.0))
             # 1d high, 4h downtrend
-            & ((df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -70.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_4h > -70.0))
             # 1d high, 4h downtrend
-            & ((df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -40.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
             # 1d high & overbought
-            & ((df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h still high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
             # 1h high, 15m downtrend
-            & ((stochrsi_k_1h < 70.0) | (df["ROC_9_15m"] > -30.0))
+            & ((stochrsi_k_1h < 70.0) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -70.0))
             # 1d high, 1h downtrend
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (df["ROC_9_1h"] > -20.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_1h > -20.0))
             # 1d high, 1d downtrend
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 60.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
             # 15m downtrend, 1d overbought
-            & ((df["ROC_9_15m"] > -60.0) | (roc_9_1d < 200.0))
+            & ((roc_9_15m > -60.0) | (roc_9_1d < 200.0))
             # 1h downtrend, 1d overbought
-            & ((df["ROC_9_1h"] > -60.0) | (roc_9_1d < 200.0))
+            & ((roc_9_1h > -60.0) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] < 40.0)
+            (rsi_3 < 40.0)
             & (rsi_3_15m < 50.0)
-            & (df["AROONU_14_15m"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3_15m"] < 20.0)
+            & (aroonu_14_15m < 25.0)
+            & (stochrsi_k_15m < 20.0)
             & (df["EMA_26_15m"] > df["EMA_12_15m"])
             & ((df["EMA_26_15m"] - df["EMA_12_15m"]) > (df["open_15m"] * 0.050))
             & ((df["EMA_26_15m"].shift() - df["EMA_12_15m"].shift()) > (df["open_15m"] / 100.0))
@@ -18121,17 +18089,17 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["protections_long_global"] == True)
 
           # 5m & 15m down move, 4h still high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
           # 5m & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
           # 15m & 4h down move
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (df["RSI_14_4h"] < 35.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 35.0))
           # 15m down move, 4h still high, 15m downtrend
           long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (df["CMF_20_15m"] > -0.35))
           # 15m & 1h down move
@@ -18143,7 +18111,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 10.0))
           # 15m & 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 30.0))
           # 15m & 1h down move, 1h high
@@ -18153,19 +18121,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 20.0))
           # 15m down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
           # 15m down move, 4h high, 1h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
           # 15m down move, 1h & 4h high
@@ -18193,41 +18161,41 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["ROC_2"] > -0.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
           # 15m & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 70.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0) | (df["AROONU_14_1d"] < 85.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d < 85.0))
           # 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (stochrsi_k_1h < 25.0))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
           # 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1d overbought
@@ -18245,9 +18213,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
           # 1h & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1h < 50.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_14_4h"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_14_4h < 80.0))
           # 14 down move, 1h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
           # 1h down move, 4h high
@@ -18255,7 +18223,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (stochrsi_k_1d < 80.0))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 50.0))
           # 1h down move, 1h & 4h high
@@ -18263,29 +18231,29 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 4h down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (aroonu_14_1d < 100.0))
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
           # 4h downmove, 4h still high
           long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
           # 4h down move, 1h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["RSI_14_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (df["RSI_14_1d"] < 50.0))
           # 4h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_1h < 30.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1d < 90.0))
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 25.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 1h high
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 70.0))
           # 4h down move, 4h still high
@@ -18295,13 +18263,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1d"] > 5.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 30.0))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
           # 1d down move, 4h still high
-          long_entry_logic.append((df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1d > 15.0) | (stochrsi_k_4h < 50.0))
           # 1d down move, 1h high & overbought
-          long_entry_logic.append((df["RSI_3_1d"] > 35.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
           # 15m still high, 1h & 4h high
           long_entry_logic.append((df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 1h & 4h high, 4h overbought
@@ -18309,19 +18277,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 1d overbought
           long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1d < 80.0))
           # 4h high, 1h & 1d downtrend
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h high, 1h & 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
           # 1d high, 4h & 1d downtrend
-          long_entry_logic.append((df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
           # 1h high, 4h overbought
           long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
           # 4h high, 1h & 1d downtrend
-          long_entry_logic.append((stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h high, 1h & 4h overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 1d top wick, 4h still high
@@ -18333,48 +18301,46 @@ class NostalgiaForInfinityX7(IStrategy):
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (df["close"] > (df["high_max_6_4h"] * 0.75))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            | (close > (df["high_max_6_4h"] * 0.75))
+            | (close < (df["low_min_24_4h"] * 1.25))
           )
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_12_1d"] - df["low_min_12_1d"]) / df["low_min_12_1d"]) < 2.0)
-            | (df["close"] > (df["high_max_24_4h"] * 0.70))
-            | (df["close"] < (df["low_min_12_1d"] * 1.25))
+            | (close > (df["high_max_24_4h"] * 0.70))
+            | (close < (df["low_min_12_1d"] * 1.25))
           )
           # big drop in last hour
-          long_entry_logic.append(df["close"] > (df["close_max_12"] * 0.50))
+          long_entry_logic.append(close > (df["close_max_12"] * 0.50))
           # big drop in last hour, 1d down move
-          long_entry_logic.append((df["close"] > (df["close_max_12"] * 0.80)) | (df["RSI_3_1d"] > 15.0))
+          long_entry_logic.append((close > (df["close_max_12"] * 0.80)) | (rsi_3_1d > 15.0))
           # big drop in the last 12 hours, 4h still high
-          long_entry_logic.append((df["close"] > (df["high_max_12_1h"] * 0.50)) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((close > (df["high_max_12_1h"] * 0.50)) | (aroonu_14_4h < 50.0))
           # big drop in the last 6 days, 1h still high
-          long_entry_logic.append((df["close"] > (df["high_max_6_1d"] * 0.25)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (df["high_max_6_1d"] * 0.25)) | (aroonu_14_1h < 50.0))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.45)) | (rsi_3_1h > 5.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.45)) | (rsi_3_1h > 5.0))
           # big drop in the last 12 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.40)) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.40)) | (rsi_3_4h > 15.0))
           # big drop in the last 12 days, 1h still high
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.25)) | (aroonu_14_1h < 75.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.25)) | (aroonu_14_1h < 75.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.35)) | (rsi_3_1h > 10.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.35)) | (rsi_3_1h > 10.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.25)) | (rsi_3_1h > 15.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.25)) | (rsi_3_1h > 15.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (rsi_3_1h > 20.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_1h > 20.0))
           # big drop in the last 20 days, 1d high, 1d downtrend
           long_entry_logic.append(
-            (df["close"] > (df["high_max_20_1d"] * 0.20)) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0) | (roc_9_1d > -15.0)
+            (close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0)
           )
           # big drop in the last 30 days, 4h down move, 4h still high
-          long_entry_logic.append(
-            (df["close"] > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 45.0) | (df["RSI_14_4h"] < 40.0)
-          )
+          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 45.0) | (rsi_14_4h < 40.0))
 
           # Logic
-          long_entry_logic.append(df["RSI_3"] < 50.0)
-          long_entry_logic.append(df["AROONU_14_15m"] < 25.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3_15m"] < 20.0)
+          long_entry_logic.append(rsi_3 < 50.0)
+          long_entry_logic.append(aroonu_14_15m < 25.0)
+          long_entry_logic.append(stochrsi_k_15m < 20.0)
           long_entry_logic.append(df["close_15m"] < (df["EMA_20_15m"] * 0.924))
 
         # Condition #46 - Quick mode (Long).
@@ -18396,7 +18362,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 30.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (rsi_3_4h > 20.0))
           # 15m & 1h down move, 1h still high
@@ -18404,7 +18370,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
           # 15m & 4h down move, 4h downtrend
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
           # 15m & 4h down move, 4h still high
@@ -18412,9 +18378,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
           # 15m down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 90.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 60.0))
           # 15m & 4h down move, 1h still high
@@ -18423,9 +18389,9 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m > 20.0)
             | (rsi_3_1h > 20.0)
-            | (df["RSI_3_1d"] > 30.0)
+            | (rsi_3_1d > 30.0)
             | (df["RSI_14_1h"] < 30.0)
-            | (df["AROONU_14_1d"] < 80.0)
+            | (aroonu_14_1d < 80.0)
           )
           # 15m & 1h down move, 4h still high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h < 10.0))
@@ -18438,11 +18404,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 85.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 15.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 15.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0) | (aroonu_14_1d < 90.0))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
           # 1h & 4h down move, 4h downtrend
@@ -18450,19 +18416,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
           # 1h down move, 1d still high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (stochrsi_k_1d < 50.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 50.0))
           # 1h & 4h down move, 4h high
@@ -18470,67 +18436,67 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 40.0))
           # 1h & 1d down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 1d stll high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 30.0))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h & 4h still high
           long_entry_logic.append(
-            (rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (df["RSI_14_1h"] < 40.0) | (df["RSI_14_4h"] < 50.0)
+            (rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (df["RSI_14_1h"] < 40.0) | (rsi_14_4h < 50.0)
           )
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 50.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
           # 1h & 4h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
           # 1h & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 80.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 65.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 4h high
@@ -18544,9 +18510,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 80.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -30.0))
           # 1h down move, 4h high
@@ -18558,29 +18524,29 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.30))
           # 1h down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1h down move, 1h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
           # 1h down move, 1h overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (roc_9_1h < 40.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
           # 4h down move, 1h & 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["ROC_9_1h"] > -15.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h > -20.0))
           # 4h & 1d down move
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 50.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 4h & 1d still high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d low
-          long_entry_logic.append((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["CMF_20_1d"] > -0.2))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (df["CMF_20_1d"] > -0.2))
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
           # 4h down move, 4h still not low enough, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 4h & 1d downtrend
@@ -18588,25 +18554,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h high
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 90.0))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
           # 4h down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
           # 4h down move, 4h overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 40.0))
           # 1d down move, 4h & 1d downtrend
-          long_entry_logic.append((df["RSI_3_1d"] > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
           # 15m down move, 1d high, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -40.0))
+          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
           # 1d down move, 1d high, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
           # 4h high, 1h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (df["ROC_9_1h"] < 40.0))
+          long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_1h < 40.0))
           # 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_4h < 40.0))
           # 4h high, 1h overbought
-          long_entry_logic.append((stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] < 40.0))
+          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h < 40.0))
           # 4h high, 4h overbought
           long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_4h < 40.0))
           # 4h high, 4h overbought, 1d downtrend
@@ -18618,46 +18584,44 @@ class NostalgiaForInfinityX7(IStrategy):
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_6_1d"] - df["low_min_6_1d"]) / df["low_min_6_1d"]) < 2.0)
-            | (df["close"] > (df["high_max_12_4h"] * 0.50))
-            | (df["close"] < (df["low_min_24_4h"] * 1.05))
+            | (close > (df["high_max_12_4h"] * 0.50))
+            | (close < (df["low_min_24_4h"] * 1.05))
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
-            (roc_9_1d < 50.0)
-            | (df["close"] > (df["high_max_6_1d"] * 0.70))
-            | (df["close"] < (df["low_min_12_1d"] * 1.25))
+            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_12_1d"] - df["low_min_12_1d"]) / df["low_min_12_1d"]) < 2.5)
-            | (df["close"] > (df["high_max_6_1d"] * 0.60))
-            | (df["close"] < (df["low_min_12_1d"] * 1.25))
+            | (close > (df["high_max_6_1d"] * 0.60))
+            | (close < (df["low_min_12_1d"] * 1.25))
           )
           # big drop in the last 2 days, 1d down move
-          long_entry_logic.append((df["close"] > (df["high_max_12_4h"] * 0.30)) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((close > (df["high_max_12_4h"] * 0.30)) | (rsi_3_1d > 30.0))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.30)) | (rsi_3_1h > 20.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.30)) | (rsi_3_1h > 20.0))
           # big drop in the last 12 days, 4h still high
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.40)) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.40)) | (stochrsi_k_4h < 50.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.40)) | (rsi_3_1h > 10.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.40)) | (rsi_3_1h > 10.0))
           # big drop in the last 20 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 25.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 25.0))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_30_1d"] * 0.40)) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.40)) | (rsi_3_4h > 15.0))
           # big drop in the last 30 days, 4h still not low enough
-          long_entry_logic.append((df["close"] > (df["high_max_30_1d"] * 0.25)) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (stochrsi_k_4h < 30.0))
 
           # Logic
-          long_entry_logic.append(df["RSI_3"] < 40.0)
+          long_entry_logic.append(rsi_3 < 40.0)
           long_entry_logic.append(rsi_3_15m < 50.0)
           long_entry_logic.append(df["WILLR_14_15m"] < -50.0)
-          long_entry_logic.append(df["AROONU_14_15m"] < 25.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3_15m"] < 20.0)
+          long_entry_logic.append(aroonu_14_15m < 25.0)
+          long_entry_logic.append(stochrsi_k_15m < 20.0)
           long_entry_logic.append(df["WILLR_84_1h"] < -70.0)
           long_entry_logic.append(stochrsi_k_1h < 20.0)
           long_entry_logic.append(df["BBB_20_2.0_1h"] > 12.0)
-          long_entry_logic.append(df["close_max_48"] >= (df["close"] * 1.10))
+          long_entry_logic.append(df["close_max_48"] >= (close * 1.10))
 
         # Condition #61 - Rebuy mode (Long).
         if long_entry_condition_index == 61:
@@ -18667,17 +18631,17 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
             # 5m & 4h down move, 4h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
             # 5m down move, 1d high & overbought
-            & ((df["RSI_3"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h still not low enough
@@ -18689,13 +18653,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["CMF_20_4h"] > -0.30))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
@@ -18703,11 +18667,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 40.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 40.0) | (rsi_14_4h < 40.0))
             # 15m down move, 15m downtrend. 4h high
             & ((rsi_3_15m > 3.0) | (df["CMF_20_15m"] > -0.50) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0))
             # 15m down move, 4h high
             & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h & 1d downtrend
@@ -18717,23 +18681,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still low, 4h still high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 20.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (aroonu_14_4h < 50.0))
             # 15m down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_4h > -50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 50.0))
             # 15m & 4h down move, 4h still not low enough
@@ -18743,21 +18707,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (roc_9_1d > -30.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1h high
@@ -18765,19 +18729,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 15.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
@@ -18797,15 +18761,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d downtrend
@@ -18819,23 +18783,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["ROC_9_15m"] > -15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_15m > -15.0))
             # 1h & 3h down move, 4h downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 80.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
             & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
             # 1h down move, 4h downtrend, 1d overbought
@@ -18845,13 +18809,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
@@ -18861,7 +18825,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 1d downtrend
@@ -18883,43 +18847,43 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (df["ROC_9_1h"] < 25.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 25.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 30.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 90.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 3.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 3.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 4h downtrend, 4h still high
             & ((rsi_3_4h > 5.0) | (df["CMF_20_4h"] > -0.20) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1h > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18935,27 +18899,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 1d down move, 1h still high, 1d downtrend
-            & ((df["RSI_3_1d"] > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 35.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 100.0))
+            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 15m high, 1h high & overbought
-            & ((df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 85.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 1h high, 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
@@ -18963,36 +18927,32 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1h & 4h overbought
-            & ((df["ROC_9_1h"] < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] < 50.0)
+            (rsi_3 < 50.0)
             & (df["AROONU_14"] < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
@@ -19008,19 +18968,19 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d high
-            ((df["RSI_3"] > 3.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 90.0))
+            ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 90.0))
             # 5m & 1d down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 4h still not low enough
-            & ((df["RSI_3"] > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (df["RSI_14_4h"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h still high
@@ -19032,49 +18992,49 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_15m < 20.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["CMF_20_4h"] > -0.30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 200.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 75.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -25.0))
             # 15m & 1h down move, 4h high
@@ -19086,37 +19046,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 50.0))
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still not low enough, 1d overbought
-            & ((rsi_3_15m > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 30.0) | (roc_9_1d < 80.0))
             # 15m & 4h down move, 15m stil high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 40.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (roc_9_1d > -50.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 15m still not low enough
-            & ((rsi_3_1h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19124,17 +19084,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
@@ -19148,37 +19108,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 30.0))
             # 1h& 1d down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0))
             # 1h & 4h down move, 4h overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h high
@@ -19192,7 +19152,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h high
             & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still not low enough
@@ -19202,13 +19162,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d overbought
@@ -19222,9 +19182,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
@@ -19238,73 +19198,73 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 50.0) | (df["ROC_9_1h"] < 40.0))
+            & ((rsi_3_1h > 50.0) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 5.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 5.0) | (aroonu_14_4h < 60.0))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 30.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (roc_9_1d > -15.0))
             # 4h down move, 1h downtrend, 1d downtrend
             & ((rsi_3_4h > 15.0) | (df["CMF_20_1h"] > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 40.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 100.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h overbought
@@ -19312,27 +19272,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 40.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (df["AROONU_14_1d"] < 85.0))
+            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (aroonu_14_1d < 85.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_4h < 40.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d green, 4h down move, 4h still high
@@ -19341,14 +19301,14 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] < 40.0)
+            (rsi_3 < 40.0)
             & (df["AROONU_14"] < 30.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["STOCHRSIk_14_14_3_3_15m"] < 70.0)
+            & (stochrsi_k_15m < 70.0)
             & (df["WILLR_84_1h"] < -70.0)
             & (stochrsi_k_1h < 30.0)
             & (df["BBB_20_2.0_1h"] > 12.0)
-            & (df["close_max_48"] >= (df["close"] * 1.10))
+            & (df["close_max_48"] >= (close * 1.10))
           )
 
         # Condition #63 - Rebuy mode (Long).
@@ -19360,13 +19320,13 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m > 5.0)
             # 5m & 1h down move, 1h still not low enough
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1d down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["CMF_20_1d"] > -0.25))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (df["CMF_20_1d"] > -0.25))
             # 5m down move, 1h high, 4h overbought
-            & ((df["RSI_3"] > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m down move, 1d high & overbought
-            & ((df["RSI_3"] > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 4h still high
@@ -19374,7 +19334,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h overbought
@@ -19384,51 +19344,51 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 75.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 60.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 60.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
@@ -19438,9 +19398,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 75.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 15m down move, 4h overbought
             & ((rsi_3_15m > 20.0) | (roc_9_4h < 40.0))
             # 15m & 1h down move, 1h high
@@ -19450,7 +19410,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 15m & 1h down move, 1h high
@@ -19460,21 +19420,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m > 30.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
             # 15m down move, 4h high
             & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 20.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
@@ -19482,27 +19442,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high
             & ((rsi_3_15m < 40.0) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 2.0) | (rsi_3_4h > 15.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_1h > 2.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (df["ROC_9_15m"] > -30.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
             # 1h ^ 4h down move, 1d downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_9_1h"] > -40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 15.0) | (roc_9_1h > -40.0))
             # 1h down move, 15m downtrend, 1h still high
             & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 40.0))
             # 1h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_1h > 3.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | (stochrsi_k_1h < 30.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -19510,7 +19470,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h downtrend
@@ -19518,25 +19478,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0))
             # 1h, 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_1d > -50.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_14_4h"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 30.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still high
@@ -19544,11 +19504,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d downtrend, 1d overbought
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.20) | (aroonu_14_1h < 30.0))
             # 1h down move, 1h downtrend, 1h still not low enough
@@ -19556,7 +19516,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend
             & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 20.0))
             # 1h down move, 1d overbought
@@ -19564,25 +19524,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 90.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 90.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -40.0))
             # 1h & 4h down mov, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
@@ -19594,7 +19554,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 1d overbought
@@ -19604,7 +19564,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (df["ROC_9_1h"] > -50.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (roc_9_1h > -50.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d overbought
@@ -19628,11 +19588,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 80.0))
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 50.0))
             # 1h down move, 1h highm 1d overbought
@@ -19652,23 +19612,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 40.0) | (df["RSI_14_1d"] < 80.0) | (roc_9_1d < 150.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
@@ -19678,27 +19638,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 55.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -30.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 3.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -10.0))
             # 4h down move, 1h still high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_4h > -20.0))
             # 4h down move, 15m high, 15m downtrend
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (df["ROC_9_15m"] > -10.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0) | (roc_9_15m > -10.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
@@ -19708,25 +19668,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 45.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 45.0))
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
             # 4h down move, 1h & 4h still high
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
             # 4h dowqn move, 4h still high, 1d downtrend
@@ -19736,15 +19696,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -19754,101 +19714,97 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 20.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 35.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 1d down move, 4h high & overbought
-            & ((df["RSI_3_1d"] > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h downtrend, 1h high
             & ((df["CMF_20_1h"] > -0.20) | (aroonu_14_1h < 80.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.30) | (df["CMF_20_1d"] > -0.30) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((df["CMF_20_4h"] > -0.30) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 100.0))
+            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 20.0))
+            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m still high, 1h overbought
-            & ((df["AROONU_14_15m"] < 40.0) | (df["ROC_9_1h"] < 40.0))
+            & ((aroonu_14_15m < 40.0) | (roc_9_1h < 40.0))
             # 15m still high, 4h overbought
-            & ((df["AROONU_14_15m"] < 40.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_15m < 40.0) | (roc_9_4h < 80.0))
             # 15m still high, 1h high
-            & ((df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+            & ((aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 15m still high, 4h high & overbought
-            & ((df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
             # 15m still high, 4h downtrend, 1d overbought
-            & ((df["AROONU_14_15m"] < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_15m < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h high, 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] < 20.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 70.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_1h < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
             # 1h high, 1d downtrend
             & ((aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 4h still high, 1d high, 4h downtrend
-            & ((aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
             # 4h high, 1h & 1d downtrend
-            & ((aroonu_14_4h < 70.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
             # 1d high, 4h & 1d downtrend
-            & ((df["AROONU_14_1d"] < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1d high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d < 100.0))
             # 1d high, 1h & 4h down move
-            & ((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 25.0) | (roc_9_4h < 60.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 4h still high, 4h & 1d downtrend
             & ((stochrsi_k_4h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 4h high, 1h & 1d downtrend
-            & ((stochrsi_k_4h < 70.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_1d > -20.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 70.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h & 4h overbought
-            & ((df["ROC_9_1h"] < 30.0) | (roc_9_4h < 80.0))
+            & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
             # 1d green with top wick, 4h high
             & ((df["change_pct_1d"] < 30.0) | (df["top_wick_pct_1d"] < 20.0) | (aroonu_14_4h < 80.0))
             # 1d top wick, 4h down move, 1d overbought
             & ((df["top_wick_pct_1d"] < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # drop in last 20 days, 4h high
-            & ((df["close"] > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((df["close"] > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] > 0.0)
-            & (df["RSI_3"] < 50.0)
+            (rsi_3 > 0.0)
+            & (rsi_3 < 50.0)
             & (df["AROONU_14"] < 25.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.022))
@@ -19862,24 +19818,24 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["protections_long_global"] == True)
 
           long_entry_logic.append(df["RSI_14_1h"] < 80.0)
-          long_entry_logic.append(df["RSI_14_4h"] < 80.0)
+          long_entry_logic.append(rsi_14_4h < 80.0)
           long_entry_logic.append(df["RSI_14_1d"] < 80.0)
           # big drop in the last hour
-          long_entry_logic.append(df["close"] > (df["close_max_12"] * 0.50))
+          long_entry_logic.append(close > (df["close_max_12"] * 0.50))
           # 5m & 4h down move, 1d downtrend
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
           # 5m & 4h down move, 15m still high
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
           # 5 & 15m down move, 1h high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (rsi_3_15m > 40.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 40.0) | (stochrsi_k_1h < 90.0))
           # 5m down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 30.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_14_4h < 40.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 75.0))
           # 15m & 1h down move, 1h still not low enough
@@ -19893,15 +19849,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 20.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 20.0))
           # 15m down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 30.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 30.0) | (aroonu_14_1d < 90.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 30.0))
           # 15m & 1h down move, 4h high
@@ -19913,19 +19869,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0))
           # 15m & 4h down move, 1d still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1d down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 5.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1d > 5.0))
           # 15m & 1d down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 30.0))
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 1h still not low enough
@@ -19941,25 +19897,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 10.0))
           # 15m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -25.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 85.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 70.0))
           # 15m & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (aroonu_14_4h < 85.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (stochrsi_k_4h < 75.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 30.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 90.0))
           # 15m & 1h down move, 1h still high
@@ -19967,19 +19923,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 30.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 30.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 50.0))
           # 1h & 1d down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 25.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 4h high & overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 40.0))
           # 15m down move, 1h & 4h high
@@ -19987,9 +19943,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
           # 15m & 1d down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
           # 15m down move, 1h high, 1d downtrend
           long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
           # 15m down move, 1d high & overbought
@@ -19999,15 +19955,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 85.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 25.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 60.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 80.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0))
           # 1h & 4h down move, 15m downtrend
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (df["ROC_9_15m"] > -30.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
           # 1h & 4h down move, 4h downtrend
@@ -20023,27 +19979,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["ROC_2"] > -0.0))
           # 1h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_4h > -30.0))
           # 1h down move, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_1d > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
           # 1h & 4h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 80.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
           # 1h & 4h down move, 1h still high
@@ -20051,31 +20007,31 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 15m high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_15m < 80.0))
           # 1h down move, 1h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
           # 1h down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_4h < 90.0))
           # 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_15m < 40.0))
           # 4h down move, 1d still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
           # 4h down move, 15m 4h still high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 50.0))
           # 4h & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
           # 4h down move, 1h still high
           long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
           # 4h down move, 4h still high
           long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -15.0))
           # 4h down move, 4h & 1d downtrend
@@ -20083,9 +20039,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h dowqn move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
           # 4h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 50.0))
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
           # 4h down move, 4h still high
@@ -20093,19 +20049,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 20.0))
           # 1d down move, 1h still high, 4h high
-          long_entry_logic.append((df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1d > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 85.0))
           # 1d down move, 1h high & overbought
-          long_entry_logic.append((df["RSI_3_1d"] > 35.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
           # 1d down move, 4h high, 1d overbought
-          long_entry_logic.append((df["RSI_3_1d"] > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 10.0))
           # 4h still high, 4h moving lower, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 50.0) | (aroonu_14_4h > aroonu_14_4h.shift(48)) | (roc_9_4h < 40.0))
           # 1h high, 1d downtrend
-          long_entry_logic.append((df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((aroonu_14_1d < 70.0) | (roc_9_1d > -30.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((df["AROONU_14_1d"] < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+          long_entry_logic.append((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
           # 1h high, 4h downtrend
           long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
           # 1h high, 4h overbought
@@ -20113,67 +20069,59 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+          long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d red, 4h down move, 1h still high
           long_entry_logic.append((df["change_pct_1d"] > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (df["close"] > (df["high_max_6_4h"] * 0.75))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            | (close > (df["high_max_6_4h"] * 0.75))
+            | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 70.0)
-            | (df["close"] > (df["high_max_6_4h"] * 0.80))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            (aroonu_14_4h < 70.0) | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 80.0)
-            | (df["close"] > (df["high_max_6_4h"] * 0.85))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            (aroonu_14_4h < 80.0) | (close > (df["high_max_6_4h"] * 0.85)) | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 1h down move, drop but not yet near the previous lows
           long_entry_logic.append(
-            (rsi_3_1h > 30.0)
-            | (df["close"] > (df["high_max_12_4h"] * 0.50))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            (rsi_3_1h > 30.0) | (close > (df["high_max_12_4h"] * 0.50)) | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
-            (roc_9_1d < 50.0)
-            | (df["close"] > (df["high_max_6_1d"] * 0.70))
-            | (df["close"] < (df["low_min_12_1d"] * 1.25))
+            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
           )
           # big drop in last 6 hours, 1d overbought
-          long_entry_logic.append((df["close"] > (df["high_max_6_1h"] * 0.65)) | (roc_9_1d < 50.0))
+          long_entry_logic.append((close > (df["high_max_6_1h"] * 0.65)) | (roc_9_1d < 50.0))
           # big drop in last 4 hours, 4h still not low enough
-          long_entry_logic.append((df["close"] > (df["high_max_24_4h"] * 0.50)) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((close > (df["high_max_24_4h"] * 0.50)) | (stochrsi_k_4h < 30.0))
           # big drop in the last 4 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_24_4h"] * 0.20)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (df["high_max_24_4h"] * 0.20)) | (rsi_3_4h > 20.0))
           # big drop in the last 6 days, 1d down move
-          long_entry_logic.append((df["close"] > (df["high_max_6_1d"] * 0.30)) | (df["RSI_3_1d"] > 15.0))
+          long_entry_logic.append((close > (df["high_max_6_1d"] * 0.30)) | (rsi_3_1d > 15.0))
           # big drop in the last 12 days, 4h high
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.50)) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.50)) | (stochrsi_k_4h < 90.0))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 30.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 30.0))
           # big drop in the last 20 days, 1h still high
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.05)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.05)) | (aroonu_14_1h < 50.0))
           # big drop in the last 20 days, 1d high, 1d downtrend
           long_entry_logic.append(
-            (df["close"] > (df["high_max_20_1d"] * 0.20)) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0) | (roc_9_1d > -15.0)
+            (close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0)
           )
           # big drop in the last 30 days, 1h down move
-          long_entry_logic.append((df["close"] > (df["high_max_30_1d"] * 0.25)) | (rsi_3_1h > 15.0))
+          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_1h > 15.0))
 
           # Logic
-          long_entry_logic.append(df["RSI_3"] > 3.0)
+          long_entry_logic.append(rsi_3 > 3.0)
           long_entry_logic.append(df["RSI_14"] < 36.0)
           long_entry_logic.append(df["AROONU_14"] < 25.0)
           long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
-          long_entry_logic.append(df["close"] < (df["SMA_16"] * 0.946))
-          long_entry_logic.append(df["AROONU_14_15m"] < 50.0)
+          long_entry_logic.append(close < (df["SMA_16"] * 0.946))
+          long_entry_logic.append(aroonu_14_15m < 50.0)
 
         # Condition #102 - Rapid mode (Long).
         if long_entry_condition_index == 102:
@@ -20181,62 +20129,58 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
           long_entry_logic.append(df["protections_long_global"] == True)
 
-          long_entry_logic.append(df["RSI_3"] < 46.0)
+          long_entry_logic.append(rsi_3 < 46.0)
           long_entry_logic.append(rsi_3_15m > 5.0)
           long_entry_logic.append(rsi_3_1h > 10.0)
           long_entry_logic.append(rsi_3_4h > 10.0)
           # 5m & 15m down move, 4h still high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
           # 5m & 15m down move, 15m still high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 40.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0))
           # 5m & 15m down move, 1h still high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_15m > 25.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (stochrsi_k_1h < 40.0))
           # 5m & 1h down move, 4h still high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
           # 5m & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
           # 5m & 1d down move, 15m still high
-          long_entry_logic.append(
-            (df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0)
-          )
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 40.0))
           # 5m down move, 15m high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (df["AROONU_14_15m"] < 70.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (aroonu_14_15m < 70.0))
           # 5m down move, 15m & 1h still high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 40.0))
           # 5m down move, 1h high
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_1h < 50.0))
           # 5m & 1h down move, 1h high
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
           # 5m & 4h down move, 4h high
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
           # 5m down move, 15m still high, 1h high
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0))
           # 5m down move, 15m still high, 1h high
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
           # 5m down move, 15m & 4h high
-          long_entry_logic.append(
-            (df["RSI_3"] > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (stochrsi_k_4h < 90.0)
-          )
+          long_entry_logic.append((rsi_3 > 5.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 90.0))
           # 5m & 15m down move, 4h high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0))
           # 5m & 15m down move, 1d high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (rsi_3_15m > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 20.0) | (stochrsi_k_1d < 80.0))
           # 5m & 15m down move, 1h high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0))
           # 5m & 1h down move, 4h still high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 50.0))
           # 5m down move, 1h & 4h high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
           # 5m down move, 4h high, 1d high
-          long_entry_logic.append((df["RSI_3"] > 10.0) | (aroonu_14_4h < 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
           # 5m down move, 15m still high, 1h high
-          long_entry_logic.append((df["RSI_3"] > 15.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((rsi_3 > 15.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 90.0))
           # 5m down move, 15m still high, 4h high
-          long_entry_logic.append((df["RSI_3"] > 15.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 15.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (df["AROONU_14_15m"] < 20.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 70.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 1h still not low enough
@@ -20250,9 +20194,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
           # 15m& 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 40.0))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 4h still high
@@ -20262,19 +20206,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 40.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 85.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0))
           # 15m & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 50.0))
           # 15m down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 40.0))
           # 15m & 1h down move, 1h still high
@@ -20284,13 +20228,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 25.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 25.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0))
           # 15m & 4h down move, 4h high
@@ -20300,39 +20244,39 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (df["RSI_14_15m"] < 35.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (stochrsi_k_4h < 60.0))
           # 15m down move, 4h still high 1d overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 50.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 30.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 30.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 60.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0))
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 60.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
           # 15m & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 35.0) | (df["RSI_14_4h"] < 85.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 35.0) | (rsi_14_4h < 85.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 15m still high, 4d downtrend
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (roc_9_4h > -20.0))
           # 15m down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 50.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h down move, 1h high
@@ -20340,23 +20284,23 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0))
           # 15m & 1h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 85.0))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 50.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0))
           # 15m & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 70.0))
           # 15m & 1d down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 15m high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
           # 15m down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 85.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 85.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 1h & 4h high
@@ -20366,35 +20310,35 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 60.0))
           # 15m down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 80.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0))
           # 15m down move, 4h still high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h < 20.0))
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (df["RSI_14_15m"] < 50.0) | (aroonu_14_1h < 80.0))
           # 15m down move, 15m high, 1h high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 15m down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 45.0) | (df["AROONU_14_15m"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 90.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["CMF_20_4h"] > -0.40))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (df["CMF_20_4h"] > -0.40))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h high
@@ -20402,7 +20346,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 70.0))
           # 1h down move, 1d still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d downtrend
@@ -20416,79 +20360,79 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (df["RSI_14_4h"] < 75.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (rsi_14_4h < 75.0) | (roc_9_1d < 100.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (df["AROONU_14_1d"] < 85.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 85.0))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
           # 1h down move 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
           # 1h down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
           # 1h down move, 1d high, 1h overbought
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["AROONU_14_1d"] < 90.0) | (df["ROC_9_1h"] < 10.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
           # 4h down move, 4h still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (roc_9_1d < 100.0))
           # 4h down move, 15m still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 30.0))
           # 4h down move, 4h still not low enough, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h > -20.0))
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -30.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
           # 4h down move, 15m high, 4h overbought
-          long_entry_logic.append((rsi_3_4h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 80.0) | (roc_9_4h < 20.0))
           # 4h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
           # 1d down move, 1h high, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
           # 1d down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
           # 15m still not low enough, 1h high, 1d overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
           # 15m still high, 4h high & overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+          long_entry_logic.append((aroonu_14_15m < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
           # 15m & 1h & 4h high
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h high, 4h overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
           # 15m & 1d high, 1d overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
           # 15m high
-          long_entry_logic.append((df["AROONU_14_15m"] < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_15m < 60.0))
           # 15m & 4h high
-          long_entry_logic.append((df["AROONU_14_15m"] < 80.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h < 70.0))
           # 15m high, 1d overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 80.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | (roc_9_1d < 50.0))
           # 15m & 4h high
-          long_entry_logic.append((df["AROONU_14_15m"] < 90.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_4h < 70.0))
           # 15m & 1h high
-          long_entry_logic.append((df["AROONU_14_15m"] < 90.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_1h < 90.0))
           # 1h still high, 4h high & overbought
           long_entry_logic.append((aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
           # 1h & 4h high, 1h overbought
-          long_entry_logic.append((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 40.0))
+          long_entry_logic.append((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 40.0))
           # 1h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
           # 1h high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+          long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 5m red, 1h still high
@@ -20498,45 +20442,37 @@ class NostalgiaForInfinityX7(IStrategy):
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (df["close"] > (df["high_max_6_4h"] * 0.75))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            | (close > (df["high_max_6_4h"] * 0.75))
+            | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (stochrsi_k_4h < 90.0)
-            | (df["close"] > (df["close_max_48"] * 0.85))
-            | (df["close"] < (df["low_min_24_1h"] * 1.25))
+            (stochrsi_k_4h < 90.0) | (close > (df["close_max_48"] * 0.85)) | (close < (df["low_min_24_1h"] * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 70.0)
-            | (df["close"] > (df["high_max_6_4h"] * 0.80))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            (aroonu_14_4h < 70.0) | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
-            (roc_9_1d < 50.0)
-            | (df["close"] > (df["high_max_6_1d"] * 0.70))
-            | (df["close"] < (df["low_min_12_1d"] * 1.25))
+            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
           )
           # big drop in the last 4 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_24_4h"] * 0.20)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (df["high_max_24_4h"] * 0.20)) | (rsi_3_4h > 20.0))
           # big drop in the last 12 days, 1h high
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.30)) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.30)) | (stochrsi_k_1h < 90.0))
           # big drop in the last 20 days, 1d down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.40)) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.40)) | (rsi_3_1d > 30.0))
           # big drop in the last 30 days, 4h down move, 4h still high
-          long_entry_logic.append(
-            (df["close"] > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 45.0) | (df["RSI_14_4h"] < 40.0)
-          )
+          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 45.0) | (rsi_14_4h < 40.0))
           # big drop in the last 30 days, 1h high
-          long_entry_logic.append((df["close"] > (df["high_max_30_1d"] * 0.20)) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.20)) | (stochrsi_k_1h < 80.0))
 
           # Logic
           long_entry_logic.append(df["WILLR_14"] < -95.0)
           long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 10.0)
-          long_entry_logic.append(df["close"] < (df["BBL_20_2.0"] * 0.999))
-          long_entry_logic.append(df["close"] < (df["EMA_20"] * 0.960))
+          long_entry_logic.append(close < (df["BBL_20_2.0"] * 0.999))
+          long_entry_logic.append(close < (df["EMA_20"] * 0.960))
 
         # Condition #103 - Rapid mode (Long).
         if long_entry_condition_index == 103:
@@ -20556,59 +20492,59 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high & overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0))
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
           # 15m down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 4h overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (roc_9_4h < 70.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 80.0))
           # 15m down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 90.0) | (stochrsi_k_1d < 90.0))
           # 15m down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 80.0) | (stochrsi_k_1d < 90.0))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 20.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
           # 1h down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 25.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d overbought
@@ -20618,53 +20554,53 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 30.0))
           # 1h down move, 1h overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (df["ROC_9_1h"] < 30.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 45.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
           # 4h down move, 1h & 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 50.0))
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 70.0))
           # 4h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 30.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 70.0))
           # 4h down move, 1h high, 4h downtrend
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
           # 4h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
           # 4h down move, 1h high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 30.0))
           # 1d down move, 1h high, 1d downtrend
-          long_entry_logic.append((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
           # 1d down move, 4h high
-          long_entry_logic.append((df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | (stochrsi_k_4h < 80.0))
           # 1d down move, 15m still high, 1h high
-          long_entry_logic.append((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
           # 1d down move, 1h & 1d overbought
-          long_entry_logic.append((df["RSI_3_1d"] > 45.0) | (df["ROC_9_1h"] < 80.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append((rsi_3_1d > 45.0) | (roc_9_1h < 80.0) | (roc_9_1d < 80.0))
           # 15m still high, 1h & 4h high
           long_entry_logic.append((df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h still high, 4h high
@@ -20672,31 +20608,29 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 4h high & overbought
           long_entry_logic.append((df["RSI_14_15m"] < 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
           # 15m still high, 1h high, 4h still high
-          long_entry_logic.append((df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_4h < 50.0))
           # 15m still high, 1d high
-          long_entry_logic.append((df["AROONU_14_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 50.0) | (stochrsi_k_1d < 90.0))
           # 15m & 1h
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 15m & 1h & 4h high
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h & 1d high, 4h downtrend
-          long_entry_logic.append((aroonu_14_1h < 40.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
           # 1h high, 1h & 1d overbought
-          long_entry_logic.append((aroonu_14_1h < 90.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
           # 15m still high, 1h high
-          long_entry_logic.append(
-            (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_1h < 90.0)
-          )
+          long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_1h < 90.0))
           # 15m still high, 1d high
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((stochrsi_k_15m < 50.0) | (stochrsi_k_1d < 90.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
           # 1d green, 4h down move, 4h still high
@@ -20710,30 +20644,30 @@ class NostalgiaForInfinityX7(IStrategy):
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (df["close"] > (df["high_max_6_4h"] * 0.85))
-            | (df["close"] < (df["low_min_24_4h"] * 1.25))
+            | (close > (df["high_max_6_4h"] * 0.85))
+            | (close < (df["low_min_24_4h"] * 1.25))
           )
           # pump, 1h high
           long_entry_logic.append(
             (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 4.0) | (stochrsi_k_1h < 90.0)
           )
           # big drop in the last 2 days, 1d down move
-          long_entry_logic.append((df["close"] > (df["high_max_12_4h"] * 0.30)) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((close > (df["high_max_12_4h"] * 0.30)) | (rsi_3_1d > 30.0))
           # big drop in the last 12 days, 1h still high
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.25)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.25)) | (aroonu_14_1h < 50.0))
           # big drop in the last 12 days, 1h still not low enough
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.10)) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.10)) | (stochrsi_k_1h < 30.0))
           # big drop in the last 12 days, 15m still high
-          long_entry_logic.append((df["close"] > (df["high_max_12_1d"] * 0.20)) | (df["AROONU_14_15m"] < 50.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.20)) | (aroonu_14_15m < 50.0))
           # big drop in the last 20 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 20.0))
 
           # Logic
           long_entry_logic.append(df["RSI_4"] < 45.0)
           long_entry_logic.append(df["RSI_14"] > 35.0)
           long_entry_logic.append(df["RSI_20"] < df["RSI_20"].shift(1))
           long_entry_logic.append(df["AROONU_14"] < 25.0)
-          long_entry_logic.append(df["close"] < df["SMA_16"] * 0.960)
+          long_entry_logic.append(close < df["SMA_16"] * 0.960)
 
         # Condition #104 - Rapid mode (Long).
         if long_entry_condition_index == 104:
@@ -20742,23 +20676,23 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["protections_long_global"] == True)
 
           # 5m & 4h & 1d down move
-          long_entry_logic.append((df["RSI_3"] > 3.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0))
+          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
           # 5m & 4h down move, 1d downtrend
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
           # 5m & 1h down move, 1h still high
-          long_entry_logic.append((df["RSI_3"] > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
           # 15m & 1h down move
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (df["RSI_14_4h"] < 35.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (rsi_14_4h < 35.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (df["RSI_14_4h"] < 40.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
           # 15m & 1h & 4h down move, 15m downtrend
@@ -20792,7 +20726,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0))
           # 15m & 4h down move, 4h still high
@@ -20800,7 +20734,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -25.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 20.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
           # 15m & 1h down move, 4h still high
@@ -20814,15 +20748,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
           # 15m down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
           # 15m & 3h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 20.0))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (df["RSI_14_1h"] < 40.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
           # 15m down move, 15m still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 20.0) | (roc_9_1d < 80.0))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
           # 1h & 4h down move, 4h still not low enough
@@ -20842,27 +20776,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 1d still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 50.0))
           # 1h & 1d down move, 1h still moving lower
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["CCI_20_change_pct_1h"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["CCI_20_change_pct_1h"] > -0.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_4h > -10.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_4h > -10.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 20.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 70.0))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
           # 1h & 4h down move, 1d overbought
@@ -20870,15 +20804,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 70.0))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 90.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
           # 1h down move, 1h still high, 1d overbought
@@ -20900,88 +20834,86 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
           # 4h down move, 15m not low enough, 1h still high
-          long_entry_logic.append((rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_4h > 3.0) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 40.0))
           # 4h & 1d down move, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 20.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (roc_9_4h > -20.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 70.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
           # 4h down move, 1d still not low enough, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 30.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_1d < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h downtrend, 1h still not low enough
           long_entry_logic.append((rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.25) | (aroonu_14_1h < 30.0))
           # 4h down move, 1h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 45.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
           # 4h down move, 1h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h high
           long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_1h < 80.0))
           # 4h down move, 1d high, 1h downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0) | (df["ROC_9_1h"] > -10.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
           # 4h down move, 4h high, 1h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (df["ROC_9_1h"] > -30.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h > -30.0))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 100.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((df["RSI_3_1d"] > 5.0) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 20.0))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
           # 4h & 1d high,1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
           # 1d red, 4h down move, 1h still high
           long_entry_logic.append((df["change_pct_1d"] > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (df["close"] > (df["high_max_12_4h"] * 0.60))
-            | (df["close"] < (df["low_min_24_4h"] * 1.10))
+            | (close > (df["high_max_12_4h"] * 0.60))
+            | (close < (df["low_min_24_4h"] * 1.10))
           )
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((df["high_max_12_1d"] - df["low_min_12_1d"]) / df["low_min_12_1d"]) < 5.0)
-            | (df["close"] > (df["high_max_6_1d"] * 0.30))
-            | (df["close"] < (df["low_min_12_1d"] * 1.25))
+            | (close > (df["high_max_6_1d"] * 0.30))
+            | (close < (df["low_min_12_1d"] * 1.25))
           )
           # big drop in the last hour
-          long_entry_logic.append(df["close"] > (df["close_max_12"] * 0.50))
+          long_entry_logic.append(close > (df["close_max_12"] * 0.50))
           # big drop in the last 12 days, 15m & 4h down move
-          long_entry_logic.append(
-            (df["close"] > (df["high_max_12_1d"] * 0.40)) | (rsi_3_15m > 10.0) | (rsi_3_4h > 10.0)
-          )
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.40)) | (rsi_3_15m > 10.0) | (rsi_3_4h > 10.0))
           # big drop in the last 20 days, 15m & 1h down move
           long_entry_logic.append(
-            (df["close"] > (df["high_max_20_1d"] * 0.40)) | (df["RSI_14_15m"] < 10.0) | (df["RSI_14_1h"] < 10.0)
+            (close > (df["high_max_20_1d"] * 0.40)) | (df["RSI_14_15m"] < 10.0) | (df["RSI_14_1h"] < 10.0)
           )
           # big drop in the last 20 days, 1d down move
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.25)) | (df["RSI_3_1d"] > 30.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.25)) | (rsi_3_1d > 30.0))
           # big drop in the last 20 days, 4h still not low enough
-          long_entry_logic.append((df["close"] > (df["high_max_20_1d"] * 0.10)) | (df["RSI_14_4h"] < 30.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_14_4h < 30.0))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((df["close"] > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 20.0))
 
           # Logic
-          long_entry_logic.append(df["RSI_3"] < 40.0)
+          long_entry_logic.append(rsi_3 < 40.0)
           long_entry_logic.append(df["AROONU_14"] < 25.0)
           long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
-          long_entry_logic.append(df["AROONU_14_15m"] < 25.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3_15m"] < 30.0)
-          long_entry_logic.append(df["close"] < df["EMA_16"] * 0.975)
-          long_entry_logic.append(((df["EMA_50"] - df["EMA_200"]) / df["close"] * 100.0) < -5.5)
+          long_entry_logic.append(aroonu_14_15m < 25.0)
+          long_entry_logic.append(stochrsi_k_15m < 30.0)
+          long_entry_logic.append(close < df["EMA_16"] * 0.975)
+          long_entry_logic.append(((df["EMA_50"] - df["EMA_200"]) / close * 100.0) < -5.5)
 
         # Condition #120 - Grind mode (Long).
         if long_entry_condition_index == 120:
@@ -20989,25 +20921,25 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(num_open_long_grind_mode < self.grind_mode_max_slots)
           long_entry_logic.append(df["protections_long_global"] == True)
           long_entry_logic.append(is_pair_long_grind_mode)
-          long_entry_logic.append(df["RSI_3"] <= 50.0)
+          long_entry_logic.append(rsi_3 <= 50.0)
           long_entry_logic.append(rsi_3_15m >= 20.0)
           long_entry_logic.append(rsi_3_1h >= 10.0)
           long_entry_logic.append(rsi_3_4h >= 10.0)
           long_entry_logic.append(df["RSI_14_1h"] < 80.0)
-          long_entry_logic.append(df["RSI_14_4h"] < 80.0)
+          long_entry_logic.append(rsi_14_4h < 80.0)
           long_entry_logic.append(df["RSI_14_1d"] < 80.0)
-          long_entry_logic.append(df["AROONU_14_15m"] < 70.0)
+          long_entry_logic.append(aroonu_14_15m < 70.0)
           long_entry_logic.append(aroonu_14_1h < 100.0)
           long_entry_logic.append(aroonu_14_4h < 100.0)
-          long_entry_logic.append(df["AROONU_14_1d"] < 100.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3_1d"] < 90.0)
+          long_entry_logic.append(aroonu_14_1d < 100.0)
+          long_entry_logic.append(stochrsi_k_1d < 90.0)
 
           # Logic
           long_entry_logic.append(
             (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (df["WILLR_14"] < -80.0)
             & (df["AROONU_14"] < 25.0)
-            & (df["close"] < (df["EMA_20"] * 0.978))
+            & (close < (df["EMA_20"] * 0.978))
           )
 
         # Condition #141 - Top Coins mode (Long).
@@ -21019,35 +20951,35 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m high
-            ((df["RSI_3"] > 3.0) | (rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0))
+            ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0))
             # 5m & 15m down move, 4h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
             # 5m & 15m down move, 15m high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0))
             # 5m & 1h down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 40.0))
             # 5m & 1h down move, 1h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 5.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 1h high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 80.0))
             # 5m & 1d down move, 15m high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0))
             # 5m & 1d down move, 15m stil high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 40.0))
             # 5m & 1d down move, 4h still high
-            & ((df["RSI_3"] > 3.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 5m down move, 1h high
-            & ((df["RSI_3"] > 3.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 90.0))
             # 5m down move, 15m & 1d high
-            & ((df["RSI_3"] > 5.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 100.0))
             # 5m down move, 1h & 1d high
-            & ((df["RSI_3"] > 10.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h still not low enough
@@ -21059,13 +20991,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
@@ -21073,7 +21005,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 15m downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 3.0) | (df["CMF_20_15m"] > -0.30))
             # 15m & 4h down move, 4h still high
@@ -21081,7 +21013,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 3.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h still high
@@ -21089,27 +21021,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 10.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
             # 15m down move, 15m downtrend, 1d high
-            & ((rsi_3_15m > 5.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 5.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
@@ -21117,9 +21049,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
@@ -21127,39 +21059,39 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["RSI_14_1d"] < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 60.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
@@ -21169,11 +21101,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 4h still high
@@ -21181,13 +21113,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h & 1d overbought
@@ -21199,39 +21131,39 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m & 4h down mve, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
@@ -21241,11 +21173,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still high
@@ -21255,13 +21187,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (roc_9_4h > -30.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -21269,9 +21201,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
@@ -21279,13 +21211,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 15m still high, 1d high
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 40.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 80.0))
             # 1h & 4h down move, 4h high
@@ -21293,11 +21225,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["RSI_14_1d"] < 80.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1h still high
@@ -21309,85 +21241,85 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 60.0) | (df["RSI_3_1d"] > 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["RSI_14_1d"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (df["RSI_14_1d"] < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 60.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 30.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 15.0) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 25.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 80.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 70.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m & 4h high
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d downtrend
@@ -21395,49 +21327,49 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -40.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 4h high, 1d overbought
-            & ((df["RSI_3_1d"] > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 10.0))
             # 1d down move, 1d high & overbought
-            & ((df["RSI_3_1d"] > 55.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 55.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1d overbought
-            & ((df["RSI_3_1d"] > 60.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d > 60.0) | (roc_9_1d < 200.0))
             # 15m & 1h high, 4h overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 100.0))
             # 15m & 1h high, 1d downtrend
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
             # 15m high, 1d high & overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 15m high, 1d high & overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 15m high, 1h high, 1d downtrend
-            & ((df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 50.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_1h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 50.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
           )
@@ -21445,9 +21377,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (df["RSI_20"] < df["RSI_20"].shift(1))
-            & (df["RSI_3"] < 30.0)
+            & (rsi_3 < 30.0)
             & (df["AROONU_14"] < 25.0)
-            & (df["close"] < df["SMA_16"] * 0.960)
+            & (close < df["SMA_16"] * 0.960)
           )
 
         # Condition #142 - Top Coins mode (Long).
@@ -21459,17 +21391,17 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 15m high
-            ((df["RSI_3"] > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 40.0))
+            ((rsi_3 > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0))
             # 5m & 1d down move, 15m high
-            & ((df["RSI_3"] > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_15m"] < 80.0))
+            & ((rsi_3 > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h & 1d high
-            & ((df["RSI_3"] > 10.0) | (aroonu_14_1h < 80.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
             # 5m down move, 15m & 1h high
-            & ((df["RSI_3"] > 10.0) | (df["AROONU_14_15m"] < 85.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
@@ -21481,7 +21413,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 1d downtrend
@@ -21497,21 +21429,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1h still high
@@ -21521,19 +21453,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 1d high
@@ -21541,15 +21473,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
             # 14m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 1h high
@@ -21557,15 +21489,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
@@ -21575,7 +21507,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
@@ -21583,33 +21515,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 10.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m & 4h down mve, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h high
@@ -21617,53 +21549,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0) | (roc_9_1d < 50.0))
             # 15m down move, 1d high, 1h overbought
-            & ((rsi_3_15m > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 25.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 25.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 100.0))
             # 1h & 1d downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move. 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 15m & 1d high
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -21673,7 +21605,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
@@ -21681,53 +21613,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
             # 1h & 4g down move, 4h still high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["RSI_14_1d"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (df["RSI_14_1d"] < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 5.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -10.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 90.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 4h downtrend
@@ -21735,29 +21667,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 15m still not low enough, 1d high
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 30.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h high, 1d downtrend
@@ -21765,37 +21697,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 20.0) | (roc_9_1d < 80.0))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 60.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 50.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -21803,64 +21735,64 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -40.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h high, 4h overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 100.0))
             # 15m & 1h high, 1d downtrend
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
             # 15m & 4h & 1d high
-            & ((df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m high, 1d high & overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 15m high, 1h & 4h overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_15m < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 15m high, 4h overbought, 1d downtrend
-            & ((df["AROONU_14_15m"] < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_15m < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d > -30.0))
             # 15m & 1h high
-            & ((df["AROONU_14_15m"] < 90.0) | (aroonu_14_1h < 100.0))
+            & ((aroonu_14_15m < 90.0) | (aroonu_14_1h < 100.0))
             # 15m & 4h high
-            & ((df["AROONU_14_15m"] < 90.0) | (aroonu_14_4h < 100.0))
+            & ((aroonu_14_15m < 90.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 10.0))
+            & ((aroonu_14_1h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
             # 1d high, 4h & 1d downtrend
-            & ((df["AROONU_14_1d"] < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 1d high, 4h & 1d overbought
-            & ((df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_15m < 70.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h high, 1h & 1d overbought
-            & ((stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d < 100.0))
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -20.0))
             # 1d high, 1h & 4h overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] > 5.0)
+            (rsi_3 > 5.0)
             & (df["RSI_4"] < 46.0)
             # & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (df["RSI_20"] < df["RSI_20"].shift(1))
-            & (df["close"] < df["SMA_16"] * 0.960)
+            & (close < df["SMA_16"] * 0.960)
           )
 
         # Condition #143 - Top Coins mode (Long).
@@ -21872,15 +21804,15 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h & 1d down move
-            ((df["RSI_3"] > 3.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0))
+            ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 10.0))
             # 5m & 4h down move, 4h still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 1h still high
@@ -21888,7 +21820,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
@@ -21896,17 +21828,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (df["RSI_14_1d"] < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (df["RSI_14_4h"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 80.0))
             # 15m & 4h down move, 1h still high
@@ -21914,15 +21846,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (df["RSI_3_1d"] > 25.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
@@ -21942,15 +21874,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h still high, 1d downtrend
@@ -21958,21 +21890,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 20.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 20.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d overbought
@@ -21980,19 +21912,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h & 1d overbought
@@ -22000,59 +21932,59 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_15m"] < 20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 5.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 60.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 60.0))
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 80.0))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h > 15.0) | (df["ROC_9_1h"] > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 15.0) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
             # 4h down move, 4h high, 1d downtrend
@@ -22062,14 +21994,14 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 40.0))
             # 1d high, 4h & 1d downtrend
-            & ((df["AROONU_14_1d"] < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_3"] < 40.0)
+            (rsi_3 < 40.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.020))
@@ -22085,21 +22017,21 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((df["RSI_3"] > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 4h down move, 15m still high
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 5.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_15m < 40.0))
             # 5m & 4h & 1d down move
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 10.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 10.0))
             # 5m & 4h down move, 1d downtrend
-            & ((df["RSI_3"] > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -10.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -10.0))
             # 5m & 4h down move, 15m high
-            & ((df["RSI_3"] > 10.0) | (rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3 > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 4h downtrend
@@ -22107,21 +22039,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 5.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_14_4h"] < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 20.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 40.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 4h high
@@ -22131,7 +22063,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
             # 15m & 4h down move, 1d downtrend
@@ -22141,51 +22073,51 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -30.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 25.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_1h < 10.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 35.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.20))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 5.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (aroonu_14_1h < 40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 70.0) | (df["ROC_9_1h"] > -10.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1h > -10.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
@@ -22193,13 +22125,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
@@ -22207,23 +22139,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 4h overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 70.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d overbought
@@ -22231,9 +22163,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["RSI_14_1d"] < 80.0))
             # 1h down move, 1h & 4h high
@@ -22241,89 +22173,89 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 15m high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_15m"] < 20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 3.0) | (df["RSI_3_1d"] > 25.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_15m < 60.0))
             # 4h down move, 15m still high, 4h still not low enough
-            & ((rsi_3_4h > 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 30.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 20.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 15m high
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_15m < 60.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 45.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 4h still not low enough, 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+            & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 30.0) | (df["RSI_3_1d"] > 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (df["AROONU_14_1d"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_4h > -15.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
             # 1d down move, 4h still not low enough, 4h downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1d > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -15.0))
             # 1d down move, 4h & 1d downtrend
-            & ((df["RSI_3_1d"] > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1d down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 85.0) | (df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 10.0))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 15m high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_15m < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 15m still high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_15m < 50.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
-            & ((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # 1d P&D, 4h overbought
@@ -22337,7 +22269,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # & (df["STOCHRSIk_14_14_3_3_15m"] < 40.0)
             & (stochrsi_k_1h < 40.0)
             & (df["BBB_20_2.0_1h"] > 12.0)
-            & (df["close_max_48"] >= (df["close"] * 1.10))
+            & (df["close_max_48"] >= (close * 1.10))
           )
 
         # Condition #145 - Top Coins mode (Long).
@@ -22349,13 +22281,13 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d downtrend
-            ((df["RSI_3"] > 3.0) | (rsi_3_4h > 3.0) | (roc_9_1d > -20.0))
+            ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (roc_9_1d > -20.0))
             # 5m down move, 15m & 1h high
-            & ((df["RSI_3"] > 10.0) | (df["AROONU_14_15m"] < 85.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 5.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (df["ROC_9_1h"] > -20.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (roc_9_1h > -20.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 4h high
@@ -22369,33 +22301,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d overbought
@@ -22403,13 +22335,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
             # 1h down move, 4h still high, 1d high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 90.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 5.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 15.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h downtrend
@@ -22417,25 +22349,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (df["AROONU_14_1d"] < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 20.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d downtrend
@@ -22453,11 +22385,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 20.0) | (df["AROONU_14_15m"] < 40.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high & overbought
@@ -22499,57 +22431,57 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 60.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 4h down move, 15m stil high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (df["RSI_3_1d"] > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 60.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 90.0))
+            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 90.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 45.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 30.0) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 45.0) | (df["RSI_3_1d"] > 45.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((df["RSI_3_1d"] > 15.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h high
-            & ((df["RSI_3_1d"] > 20.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 70.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((df["RSI_3_1d"] > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -30.0))
             # 1d down move, 1d high, 4h downtrend
-            & ((df["RSI_3_1d"] > 35.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
-            & ((df["RSI_3_1d"] > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
             # 15m high, 1d high & overbought
-            & ((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
-            & ((df["AROONU_14_15m"] < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_15m < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d > -30.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h high, 1d overbought
@@ -22557,7 +22489,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h < 100.0) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
           )
@@ -22565,11 +22497,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (df["RSI_14"] < 36.0)
-            & (df["BBD_40_2.0"].gt(df["close"] * 0.020))
-            & (df["close_delta"].gt(df["close"] * 0.02))
+            & (df["BBD_40_2.0"].gt(close * 0.020))
+            & (df["close_delta"].gt(close * 0.02))
             & (df["BBT_40_2.0"].lt(df["BBD_40_2.0"] * 0.3))
-            & (df["close"].lt(df["BBL_40_2.0"].shift()))
-            & (df["close"].le(df["close"].shift()))
+            & (close.lt(df["BBL_40_2.0"].shift()))
+            & (close.le(close.shift()))
           )
 
         # Condition #161 - Scalp mode (Long).
@@ -22579,19 +22511,19 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["protections_long_global"] == True)
 
           # 5m down move, 15m high
-          long_entry_logic.append((df["RSI_3"] > 15.0) | (df["AROONU_14_15m"] < 80.0))
+          long_entry_logic.append((rsi_3 > 15.0) | (aroonu_14_15m < 80.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 80.0))
           # 15m down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_4h < 50.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_4h < 50.0) | (aroonu_14_1d < 90.0))
           # 15m & 1h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 60.0) | (df["AROONU_14_15m"] < 50.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 60.0) | (aroonu_14_15m < 50.0))
           # 15m down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
           # 15m & 1h down move, 1h high
@@ -22601,90 +22533,90 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0))
           # 15m & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 50.0))
           # 15m & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (df["AROONU_14_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 100.0))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 45.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 50.0))
           # 15m down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_15m > 45.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 50.0))
           # 15m down move, 15m still not low enough, 4h still high
-          long_entry_logic.append((rsi_3_15m > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 50.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 45.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 45.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 50.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 50.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 55.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 55.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 85.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 55.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0) | (stochrsi_k_1d < 90.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 50.0))
-          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_1d < 90.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0) | (stochrsi_k_4h < 70.0))
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_4h < 85.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 50.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 45.0) | (stochrsi_k_1h < 60.0))
           # 1h & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (rsi_3_4h > 60.0) | (df["AROONU_14_15m"] < 70.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 15m high, 1h still high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 40.0))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 80.0))
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 60.0) | (aroonu_14_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 90.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 50.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (roc_9_4h < 40.0))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 55.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
           # 1h down move, 5m up move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["RSI_3"] < 60.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3 < 60.0) | (stochrsi_k_1h < 50.0))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 90.0))
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 60.0))
           # 1h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 90.0))
           # 1h down move, 1h high, 4h still high
@@ -22692,97 +22624,97 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 70.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (df["RSI_14_4h"] < 70.0) | (df["RSI_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_14_4h < 70.0) | (df["RSI_14_1d"] < 80.0))
           # 15m & 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 50.0) | (rsi_3_1h > 65.0) | (rsi_3_4h > 65.0) | (aroonu_14_4h < 85.0))
           # 4h down move, 15m high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 80.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_15m < 80.0))
           # 4h down move, 1h high
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1h < 80.0))
           # 4h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
           # 4h down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_1h < 50.0) | (aroonu_14_4h < 50.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 40.0))
           # 4h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 80.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_15m < 80.0) | (stochrsi_k_1h < 70.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 40.0) | (df["AROONU_14_1d"] < 80.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 80.0))
           # 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (df["RSI_14_4h"] < 50.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (rsi_14_4h < 50.0))
           # 4h down move, 1h still high, 4h still moving down
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (df["CCI_20_change_pct_4h"] > -0.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 40.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_4h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 50.0))
           # 4h down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (df["AROONU_14_15m"] < 70.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 40.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
           # 4h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 50.0))
           # 4h down move, 15m high, 4h still not low enough
-          long_entry_logic.append((rsi_3_4h > 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
           # 4h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h < 50.0) | (aroonu_14_4h < 70.0))
           # 4h down move, 15m & 1d high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 90.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 50.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
           # 4h down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (df["AROONU_14_15m"] < 80.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 80.0) | (aroonu_14_4h < 40.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h < 70.0))
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 70.0))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 60.0))
           # 4h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 70.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 15m still high, 1d high & overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 50.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m < 50.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
           # 15m high, 4h high
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_4h < 85.0))
           # 15m & 1d high, 1d overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
           # 15m & 1d high, 4h overbought
-          long_entry_logic.append((df["AROONU_14_15m"] < 70.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
           # 15m high, 4h still high
-          long_entry_logic.append((df["AROONU_14_15m"] < 80.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h < 50.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
           # 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_4h < 40.0))
           # 4h high, 1d overbought
           long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
           # 1d high, 4h overbought
-          long_entry_logic.append((df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1d high & overbought
-          long_entry_logic.append((df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 200.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
           # 15m high, 1h still high
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 40.0))
           # 15m & 4h high
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((stochrsi_k_15m < 70.0) | (aroonu_14_4h < 70.0))
           # 15m high, 1d overbought
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] < 70.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((stochrsi_k_15m < 70.0) | (roc_9_1d < 10.0))
           # 15m high, 1h still not low enough
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] < 80.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((stochrsi_k_15m < 80.0) | (stochrsi_k_1h < 30.0))
           # 1d high, 4h overbought
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h < 40.0))
           # 1d high & overbought
-          long_entry_logic.append((df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
           # 4h & 1d overbought
           long_entry_logic.append((roc_9_4h < 40.0) | (roc_9_1d < 40.0))
           # 1d green with top wick, 1d overbought
@@ -22790,8 +22722,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(df["RSI_14"] < 50.0)
-          long_entry_logic.append(df["AROONU_14_15m"] < 90.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3_15m"] < 90.0)
+          long_entry_logic.append(aroonu_14_15m < 90.0)
+          long_entry_logic.append(stochrsi_k_15m < 90.0)
           long_entry_logic.append(
             (df["SMA_21"].shift(1) < df["SMA_200"].shift(1).infer_objects(copy=False).fillna(value=np.nan))
             & df["SMA_200"].shift(1).notna()
@@ -22800,10 +22732,10 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["SMA_21"] > df["SMA_200"].infer_objects(copy=False).fillna(value=np.nan)) & df["SMA_200"].notna()
           )
           long_entry_logic.append(
-            (df["close"] > df["EMA_200_1h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_1h"].notna()
+            (close > df["EMA_200_1h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_1h"].notna()
           )
           long_entry_logic.append(
-            (df["close"] > df["EMA_200_4h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_4h"].notna()
+            (close > df["EMA_200_4h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_4h"].notna()
           )
           long_entry_logic.append(df["BBB_20_2.0"] > 1.5)
           long_entry_logic.append(df["BBB_20_2.0_1h"] > 6.0)
@@ -22814,9 +22746,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
           long_entry_logic.append(df["protections_long_global"] == True)
 
-          long_entry_logic.append(
-            (df["RSI_3"] > 5.0) & (rsi_3_15m > 5.0) & (df["ROC_9_15m"] > -10.0) & (roc_9_1d < 200.0)
-          )
+          long_entry_logic.append((rsi_3 > 5.0) & (rsi_3_15m > 5.0) & (roc_9_15m > -10.0) & (roc_9_1d < 200.0))
 
           long_entry_logic.append(
             # 15m & 1h down move, 4h high
@@ -22824,19 +22754,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (df["RSI_14_1h"] < 50.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (df["RSI_3_1d"] > 20.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 15m high
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (df["AROONU_14_1d"] < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down nove, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
@@ -22854,11 +22784,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (df["AROONU_14_15m"] < 60.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 150.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (df["RSI_14_4h"] < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (rsi_14_4h < 80.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
@@ -22870,21 +22800,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h & 3h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h > 15.0) | (df["ROC_9_1h"] > -30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (df["AROONU_14_1d"] < 85.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high
@@ -22898,45 +22828,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 45.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1h down move,  4h high, 1d overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 150.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m still high
-            & ((rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_15m < 50.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 90.0))
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 3.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move
-            & ((rsi_3_4h > 5.0) | (df["RSI_3_1d"] > 10.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0))
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_1d"] < 85.0) | (df["ROC_9_1h"] > -30.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1h > -30.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["ROC_9_1h"] > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h > 10.0) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 20.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1d down move, 1h high
-            & ((df["RSI_3_1d"] > 3.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1d > 3.0) | (stochrsi_k_1h < 70.0))
             # 1d down move, 15m still high
-            & ((df["RSI_3_1d"] > 3.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_1d > 3.0) | (aroonu_14_15m < 50.0))
             # 1d down move, 15m still high, 1h high
-            & ((df["RSI_3_1d"] > 10.0) | (df["AROONU_14_15m"] < 40.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 70.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 4h high
-            & ((df["RSI_3_1d"] > 20.0) | (df["RSI_14_4h"] < 80.0))
+            & ((rsi_3_1d > 20.0) | (rsi_14_4h < 80.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 100.0))
+            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
             # 1h & 4h high, 1d overbought
@@ -22944,21 +22874,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high
             & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d still high, 1h & 4h downtrend
-            & ((df["AROONU_14_1d"] < 50.0) | (df["ROC_9_1h"] > -20.0) | (roc_9_4h > -20.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 1h high, 1h overbought
-            & ((stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 50.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 50.0))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_1d > -60.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (df["ROC_9_1h"] < 10.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1h & 4h overbought
-            & ((df["ROC_9_1h"] < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 1h P&D, 1h down move
             & ((df["change_pct_1h"] > -10.0) | (df["change_pct_1h"].shift(12) < 10.0) | (rsi_3_1h > 50.0))
             # 4h P&D, 4h high
@@ -22970,7 +22900,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h green with top wick
             & ((df["change_pct_4h"] < 50.0) | (df["change_pct_4h"] < 50.0))
             # 1d green with top wick, 15m still high
-            & ((df["change_pct_1d"] < 10.0) | (df["top_wick_pct_1d"] < 8.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["change_pct_1d"] < 10.0) | (df["top_wick_pct_1d"] < 8.0) | (aroonu_14_15m < 50.0))
             # 1d green, 4h down move, 4h still high
             & ((df["change_pct_1d"] < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 50.0))
             # 1d green with top wick, 4h down move
@@ -22978,15 +22908,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 4h still high
             & ((df["top_wick_pct_1d"] < 50.0) | (aroonu_14_4h < 50.0))
             # big drop in last 4 days, 1d down move
-            & ((df["close"] > (df["high_max_24_4h"] * 0.20)) | (df["RSI_3_1d"] > 20.0))
+            & ((close > (df["high_max_24_4h"] * 0.20)) | (rsi_3_1d > 20.0))
             # big drop in the last 20 days, 4h down move
-            & ((df["close"] > (df["high_max_20_1d"] * 0.15)) | (rsi_3_4h > 20.0))
+            & ((close > (df["high_max_20_1d"] * 0.15)) | (rsi_3_4h > 20.0))
             # big drop in the last 20 days, 1d down move
-            & ((df["close"] > (df["high_max_20_1d"] * 0.05)) | (df["RSI_3_1d"] > 20.0))
+            & ((close > (df["high_max_20_1d"] * 0.05)) | (rsi_3_1d > 20.0))
             # big drop in the last 20 days, 1h still high
-            & ((df["close"] > (df["high_max_20_1d"] * 0.05)) | (stochrsi_k_1h < 45.0))
+            & ((close > (df["high_max_20_1d"] * 0.05)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 20 days, 4h high
-            & ((df["close"] > (df["high_max_20_1d"] * 0.05)) | (stochrsi_k_4h < 70.0))
+            & ((close > (df["high_max_20_1d"] * 0.05)) | (stochrsi_k_4h < 70.0))
           )
 
           # Logic
@@ -22997,7 +22927,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.030))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
-            & (df["close"] < df["SMA_9"])
+            & (close < df["SMA_9"])
           )
 
         # Condition #163 - Scalp mode (Long).
@@ -23006,25 +22936,25 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
           long_entry_logic.append(df["protections_long_global"] == True)
 
-          long_entry_logic.append((df["RSI_3"] > 10.0) & (rsi_3_15m > 10.0) & (rsi_3_1h > 20.0))
+          long_entry_logic.append((rsi_3 > 10.0) & (rsi_3_15m > 10.0) & (rsi_3_1h > 20.0))
 
           long_entry_logic.append(
             # 5m & 15m & 4h down mnove, 4h high
-            ((df["RSI_3"] > 15.0) | (rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            ((rsi_3 > 15.0) | (rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 5m & 15m & 1d down move, 1h high
-            & ((df["RSI_3"] > 15.0) | (rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3 > 15.0) | (rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 5m & 1h down move, 15m still high, 4h high
-            & ((df["RSI_3"] > 20.0) | (rsi_3_1h > 40.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 > 20.0) | (rsi_3_1h > 40.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_4h < 100.0))
             # 5m & 1h & 15m down move, 1h still not low enough
-            & ((df["RSI_3"] > 15.0) | (rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 30.0))
             # 15m & 4h down move, 4h high
-            & ((df["RSI_3"] > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3 > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 5m & 4h down move, 15m high
-            & ((df["RSI_3"] > 15.0) | (rsi_3_4h > 45.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3 > 15.0) | (rsi_3_4h > 45.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 12.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h & 1d down move
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
             # 15m & 1h down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h & 4h down move, 1d overbought
@@ -23038,11 +22968,11 @@ class NostalgiaForInfinityX7(IStrategy):
               | (aroonu_14_4h < 80.0)
             )
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (df["RSI_14_4h"] < 85.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_14_4h < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 40.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
@@ -23052,55 +22982,55 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (rsi_3_4h > 65.0) | (df["MFI_14_4h"] < 85.0))
             # 15m & 1h & 1d down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (rsi_3_1d > 40.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 85.0))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
               (rsi_3_15m > 15.0)
               | (rsi_3_1h > 40.0)
-              | (df["AROONU_14_15m"] < 30.0)
+              | (aroonu_14_15m < 30.0)
               | (aroonu_14_1h < 80.0)
               | (aroonu_14_4h < 80.0)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (df["RSI_14_4h"] < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h & 1d up move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (df["RSI_3_1d"] < 80.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (df["CMF_20_1d"] > -0.2))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 10.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h & 4h still high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 50.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 15.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 100.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 20.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 50.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (df["RSI_3_1d"] > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 60.0) | (stochrsi_k_1d < 80.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_15m"] < 75.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 75.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h high, 1d overbought
@@ -23108,17 +23038,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] < 50.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 30.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 150.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high, 1d overbought
@@ -23127,10 +23057,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 15m down move, 4h high
             & (
-              (rsi_3_15m > 15.0)
-              | (df["RSI_14_4h"] < 70.0)
-              | (stochrsi_k_4h < 90.0)
-              | (df["EMA_9"] < (df["EMA_26"] * 0.972))
+              (rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h < 90.0) | (df["EMA_9"] < (df["EMA_26"] * 0.972))
             )
             # 15m down move, 4h high and downtrend
             & ((rsi_3_15m > 15.0) | (df["CMF_20_4h"] > -0.2) | (aroonu_14_4h < 80.0))
@@ -23145,31 +23072,31 @@ class NostalgiaForInfinityX7(IStrategy):
               (rsi_3_15m > 20.0)
               | (rsi_3_1h > 35.0)
               | (df["CMF_20_1h"] > -0.10)
-              | (df["AROONU_14_15m"] < 40.0)
+              | (aroonu_14_15m < 40.0)
               | (aroonu_14_1h < 85.0)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (df["RSI_14_4h"] < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | (df["AROONU_14_15m"] < 60.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 100.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 20.0) | (df["RSI_3_1d"] > 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (df["RSI_14_4h"] < 75.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (rsi_14_4h < 75.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h downtrend, 4h overbought
             & ((rsi_3_15m > 20.0) | (df["CMF_20_4h"] > -0.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h & 4h high, 1f overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 85.0) | (df["RSI_14_4h"] < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 85.0) | (rsi_14_4h < 70.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 25.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
@@ -23178,8 +23105,8 @@ class NostalgiaForInfinityX7(IStrategy):
               | (rsi_3_1h > 45.0)
               | (df["RSI_14_15m"] < 30.0)
               | (df["RSI_14_1h"] < 50.0)
-              | (df["RSI_14_4h"] < 70.0)
-              | (df["AROONU_14_15m"] < 20.0)
+              | (rsi_14_4h < 70.0)
+              | (aroonu_14_15m < 20.0)
               | (aroonu_14_1h < 60.0)
               | (aroonu_14_4h < 100.0)
             )
@@ -23188,21 +23115,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 65.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 65.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 25.0) | (df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 15m downtrend, 4h still high
             & ((rsi_3_1h > 25.0) | (df["CMF_20_15m"] > -0.4) | (aroonu_14_4h < 50.0))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
             # 1h down move, 15m still high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
@@ -23216,11 +23143,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 40.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 30.0) | (df["RSI_3_1d"] > 30.0) | (df["AROONU_14_1d"] < 40.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 40.0))
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_4h < 95.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 95.0))
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high
             & ((rsi_3_1h > 30.0) | (df["MFI_14_1h"] < 80.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h still high, 1d overbought
@@ -23234,23 +23161,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (df["RSI_14_1h"] < 50.0) | (df["RSI_14_4h"] < 70.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (df["RSI_14_1h"] < 50.0) | (rsi_14_4h < 70.0))
             # 1h down move, 15m still not low enough, 1h high
-            & ((rsi_3_1h > 35.0) | (df["AROONU_14_15m"] < 30.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 25.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 40.0) | (df["RSI_3_1d"] > 55.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_1h > 40.0) | (rsi_3_1d > 55.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h & 4h high
@@ -23258,35 +23185,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (df["ROC_9_15m"] > -10.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_15m > -10.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 45.0) | (df["RSI_3_1d"] > 50.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1h & 4h high
             & ((rsi_3_1h > 50.0) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 50.0) | (df["AROONU_14_15m"] < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h down move, 15m & 1h high, 1d downtrend
-            & ((rsi_3_1h > 60.0) | (df["AROONU_14_15m"] < 65.0) | (stochrsi_k_1h < 80.0) | (df["CMF_20_1d"] > -0.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (df["CMF_20_1d"] > -0.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 3.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_15m < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (df["RSI_3_1d"] > 50.0) | (df["AROONU_14_1d"] < 90.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m still not low enough, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 30.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (df["CMF_20_4h"] > -0.30))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (df["AROONU_14_15m"] < 30.0) | (stochrsi_k_1h < 25.0))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 4h down move, 1h still high, 4h downtrend
@@ -23296,19 +23223,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 20.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 20.0))
             # 4h & 1d down move, 1h & 4h low
-            & ((rsi_3_4h > 25.0) | (df["RSI_3_1d"] > 25.0) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.4))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.4))
             # 4h down move, 4h still high 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 25.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 80.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (df["AROONU_14_15m"] < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h high, 1d downtrend
@@ -23318,61 +23245,61 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 45.0) | (df["AROONU_14_1d"] < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (df["RSI_14_4h"] < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 55.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 100.0))
             # 4h & 1d down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 60.0) | (df["RSI_3_1d"] > 60.0) | (aroonu_14_4h < 75.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_4h < 75.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 70.0) | (aroonu_14_4h < 90.0) | (df["AROONU_14_1d"] < 100.0))
+            & ((rsi_3_4h > 70.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 1d down move, 4h high
-            & ((df["RSI_3_1d"] > 3.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1d > 3.0) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1h high
-            & ((df["RSI_3_1d"] > 5.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 80.0))
             # 1d down move, 15m & 1h still high
-            & ((df["RSI_3_1d"] > 10.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1d > 10.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
             # 1d down move, 1h & 4h high
-            & ((df["RSI_3_1d"] > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h & 4h still high
-            & ((df["RSI_3_1d"] > 10.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 40.0))
             # 1d down move, 1h high & overbought
-            & ((df["RSI_3_1d"] > 20.0) | (stochrsi_k_1h < 80.0) | (df["ROC_9_1h"] < 20.0))
+            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
             # 1d down move, 1d high & overbought
-            & ((df["RSI_3_1d"] > 40.0) | (df["AROONU_14_1d"] < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 1d down move, 4h high & overbought
-            & ((df["RSI_3_1d"] > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1d down move, 1h high, 1d overbought
-            & ((df["RSI_3_1d"] > 60.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 80.0))
             # 1d down move, 15m still high, 1d overbought
-            & ((df["RSI_3_1d"] > 65.0) | (df["AROONU_14_15m"] < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1d > 65.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 100.0))
             # 1d down move, 4h & 1d high
-            & ((df["RSI_3_1d"] > 65.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 65.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 5m still high, 1h down move, 15m still high, 1h high
-            & ((df["RSI_3"] < 40.0) | (rsi_3_1h > 30.0) | (df["AROONU_14_15m"] < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3 < 40.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 90.0))
             # 5m still high, 15m high
-            & ((df["RSI_3"] < 45.0) | (df["AROONU_14_15m"] < 70.0))
+            & ((rsi_3 < 45.0) | (aroonu_14_15m < 70.0))
             # 5m still high, 1h down move, 4h high
-            & ((df["RSI_3"] < 50.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 < 50.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high
             & ((df["RSI_14_15m"] > 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h & 1d high
-            & ((df["RSI_14_15m"] > 30.0) | (stochrsi_k_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0))
+            & ((df["RSI_14_15m"] > 30.0) | (stochrsi_k_4h < 90.0) | (stochrsi_k_1d < 70.0))
             # 1h downtrend, 4h high, 1d downtrend
             & ((df["CMF_20_1h"] > -0.2) | (stochrsi_k_4h < 90.0) | (df["CMF_20_1d"] > -0.25))
             # 15m & 1h high, 1d overbought
-            & ((df["AROONU_14_15m"] < 60.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 85.0) | (df["AROONU_14_1d"] < 85.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1d still high, 4h & 1d downtrend
-            & ((df["AROONU_14_1d"] < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h top wick, 15m & 1h down move
             & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_15m > 15.0) | (rsi_3_1h > 40.0))
             # 4h top wick, 1h down move, 1h high
@@ -23384,7 +23311,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, 1d downtrend
             & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.1))
             # 1d P&D, 15m high
-            & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 40.0) | (df["AROONU_14_15m"] < 50.0))
+            & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 40.0) | (aroonu_14_15m < 50.0))
             # 1d P&D, 1h high
             & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 40.0) | (stochrsi_k_1h < 70.0))
             # 1d red with top wick, 1h high
@@ -23400,15 +23327,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 1h down move
             & ((df["top_wick_pct_1d"] < 50.0) | (rsi_3_1h > 30.0))
             # big drop in the last 12 days, 1h down move, 1h high
-            & ((df["close"] > (df["high_max_12_1d"] * 0.35)) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((close > (df["high_max_12_1d"] * 0.35)) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
             # big drop in the last 20 days, 1h down move, 1h high
-            & ((df["close"] > (df["high_max_20_1d"] * 0.30)) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 75.0))
+            & ((close > (df["high_max_20_1d"] * 0.30)) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 75.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & (
-              (df["close"] > (df["high_max_20_1d"] * 0.20))
-              | (df["STOCHRSIk_14_14_3_3_1d"] < 70.0)
-              | (roc_9_1d > -15.0)
-            )
+            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -23418,7 +23341,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (df["AROOND_14"] > 75.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (df["EMA_9"] < (df["EMA_26"] * 0.982))
-            & (df["close"] < df["SMA_9"])
+            & (close < df["SMA_9"])
           )
 
         ###############################################################################################
@@ -23474,34 +23397,32 @@ class NostalgiaForInfinityX7(IStrategy):
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
-          short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
+          short_entry_logic.append(rsi_3_1d >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
-          short_entry_logic.append(df["RSI_14_4h"] > 20.0)
+          short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 5m up move, 4h still not high enough
-          short_entry_logic.append((df["RSI_3"] < 97.0) | (aroonu_14_4h > 60.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (aroonu_14_4h > 60.0))
           # 5m up move, 4h still low
-          short_entry_logic.append((df["RSI_3"] < 97.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (stochrsi_k_4h > 50.0))
           # 5m & 15m strong up move
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_15m < 95.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0))
           # 5m & 1h up move, 1d uptrend
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 90.0) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 90.0) | (roc_9_1d < 100.0))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (df["AROOND_14_15m"] < 25.0) | (df["AROOND_14_1h"] < 25.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (df["AROOND_14_15m"] < 25.0) | (df["AROOND_14_1h"] < 25.0))
           # 4m up move, 1h & 4h still low
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0))
           # 4m & 1h up move, 1h still low
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 80.0) | (aroonu_14_4h > 20.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 80.0) | (aroonu_14_4h > 20.0))
           # 5m up move, 15m & 1h uptrend
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30))
+          short_entry_logic.append((rsi_3 < 90.0) | (df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30))
           # 5m up move, 15m stil low
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["AROONU_14_15m"] > 50.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (aroonu_14_15m > 50.0))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append(
-            (df["RSI_3"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (stochrsi_k_1h > 75.0)
-          )
+          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 75.0))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
           # 15m & 1h up move, 4h still going up
@@ -23517,11 +23438,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1d lost, 1h low
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_14_1d"] > 40.0) | (aroonu_14_1h > 40.0))
           # 15m up move, 15m & 4h uptrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["AROONU_14_15m"] < 90.0) | (aroonu_14_4h < 90.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (aroonu_14_15m < 90.0) | (aroonu_14_4h < 90.0))
           # 15m up move, 15m stil not high enough, 1h low
-          short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (stochrsi_k_1h > 10.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 10.0))
           # 15m up move, 1h still not high enough, 4h low
           short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 70.0) | (aroonu_14_4h > 20.0))
           # 15m up move, 1h & 4h still not high enough
@@ -23541,7 +23460,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1d uptrend
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (roc_9_1d < 40.0))
           # 15m & 1h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_15m > 60.0))
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 80.0))
           # 15m & 4h up move, 1h still not high enough
@@ -23549,7 +23468,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 4h not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (df["AROOND_14_4h"] < 50.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 30.0))
           # 15m & 4h up move, 1h low
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_1h > 20.0))
           # 15m & 4h up move, 4h low
@@ -23561,11 +23480,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | (stochrsi_k_4h > 70.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
           # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 20.0))
           # 15m & 1h up move, 1d still low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 60.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1d > 60.0))
           # 15m & 1h up move, 1h low
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 70.0) | (stochrsi_k_1h > 30.0))
           # 15m & 1h up move, 4h low
@@ -23573,7 +23492,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
           # 15m & 4h up move, 15m low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (stochrsi_k_15m > 50.0))
           # 15m down move, 15m still not high enough, 4h low
           short_entry_logic.append((rsi_3_15m < 85.0) | (df["RSI_14_15m"] > 70.0) | (stochrsi_k_4h > 40.0))
           # 15m up move, 4h overbought
@@ -23581,15 +23500,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 60.0))
           # 15m & 4h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h < 80.0) | (df["AROONU_14_15m"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h < 80.0) | (aroonu_14_15m > 50.0))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_1h > 20.0))
           # 15m & 1h up move, 1h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 30.0))
           # 15m up move, 15m still not high enough, 1h still low
-          short_entry_logic.append(
-            (rsi_3_15m < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 90.0) | (stochrsi_k_1h > 50.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 90.0) | (stochrsi_k_1h > 50.0))
           # 1h & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 70.0))
           # 1h up move, 4h low
@@ -23601,57 +23518,55 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 4h uptrend
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (roc_9_4h < 40.0))
           # 1h & 1d strong up move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_1d"] < 95.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_1d < 95.0))
           # 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 50.0) | (df["ROC_9_1h"] < 30.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 50.0) | (roc_9_1h < 30.0))
           # 1h & 4h strong up move
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 95.0) | (rsi_3_4h < 95.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0) | (df["ROC_9_1h"] < 20.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1d > 50.0) | (roc_9_1h < 20.0))
           # 1h strong up move, 15m still move higher
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h & 4h up move, 1h still low
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 50.0))
           # 1h & 4h up move, 1d still not high enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1d > 70.0))
           # 1h up move, 4h low, 1d overbought
           short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_4h > 20.0) | (roc_9_1d < 50.0))
           # 1h up move, 1h still low, 1d uptrend
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 60.0) | (roc_9_1d < 50.0))
           # 1h up move, 1h still not high enough, 1d low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_1d > 30.0))
           # 1h up move, 4h low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 20.0) | (df["ROC_9_1h"] < 10.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 20.0) | (roc_9_1h < 10.0))
           # 1h up move, 4h low, 1h overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 40.0) | (df["ROC_9_1h"] < 30.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 40.0) | (roc_9_1h < 30.0))
           # 1h up move, 15m & 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_15m"] < 15.0) | (df["ROC_9_1h"] < 15.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 15.0) | (roc_9_1h < 15.0))
           # 1h up move, 15m & 4h still low
-          short_entry_logic.append((rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (df["AROOND_14_15m"] < 50.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 90.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (stochrsi_k_15m > 90.0))
           # 1h up move, 15m still not high enough, 1h still low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_15m > 80.0) | (stochrsi_k_1h > 50.0))
           # 1h up move, 1h still low
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 60.0))
           # 4h & 1d strong up move
-          short_entry_logic.append((rsi_3_4h < 95.0) | (df["RSI_3_1d"] < 95.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (rsi_3_1d < 95.0))
           # 4h up move, 15m still low, 1h not high enough
-          short_entry_logic.append(
-            (rsi_3_4h < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["AROOND_14_1h"] < 25.0)
-          )
+          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 50.0) | (df["AROOND_14_1h"] < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
-          short_entry_logic.append((rsi_3_4h < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 70.0) | (roc_9_4h < 60.0))
           # 4h up move, 15m uptrend
-          short_entry_logic.append((rsi_3_4h < 95.0) | (df["ROC_9_15m"] < 20.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_15m < 20.0))
           # 4h up move, 1h uptrend
-          short_entry_logic.append((rsi_3_4h < 95.0) | (df["ROC_9_1h"] < 20.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_1h < 20.0))
           # 4h up move, 1h & 4h overbought
-          short_entry_logic.append((rsi_3_4h < 95.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
           # 4h up move, 1h still low
           short_entry_logic.append((rsi_3_4h < 90.0) | (aroonu_14_1h > 40.0))
           # 4h up move, 1d still low, 4h uptrend
@@ -23661,61 +23576,59 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1h low
           short_entry_logic.append((rsi_3_4h < 70.0) | (aroonu_14_1h > 25.0))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (df["AROONU_14_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_4h < 70.0) | (aroonu_14_1d > 20.0))
           # 4h up move, 1h low
           short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1h > 20.0))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
           # 1d up move, 1h & 4h still not low enough
-          short_entry_logic.append((df["RSI_3_1d"] < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 50.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((df["RSI_14_4h"] > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 15m & 1h uptrend, 4h still low
           short_entry_logic.append((df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
-          short_entry_logic.append((df["AROONU_14_15m"] < 100.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1h > 20.0))
           # 1h & 4h uptrend
           short_entry_logic.append((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
           # 1h uptrend, 4h uptrend
           short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
           # 4h uptrend, 1d uptrend
-          short_entry_logic.append((aroonu_14_4h < 100.0) | (df["AROONU_14_1d"] < 100.0))
+          short_entry_logic.append((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
           # 4h uptrend, 15m uptrend
-          short_entry_logic.append((aroonu_14_4h < 100.0) | (df["ROC_9_15m"] < 10.0))
+          short_entry_logic.append((aroonu_14_4h < 100.0) | (roc_9_15m < 10.0))
           # 4h uptrend, 1h uptrend
-          short_entry_logic.append((aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+          short_entry_logic.append((aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
           # 1d uptrend, 15m uptrend
-          short_entry_logic.append((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_15m"] < 20.0))
+          short_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_15m < 20.0))
           # 1d uptrend, 1h uptrend
-          short_entry_logic.append((df["AROONU_14_1d"] < 100.0) | (df["ROC_9_1h"] < 20.0))
+          short_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_1h < 20.0))
           # 15m still not high enough, 1h & 4h overbought
-          short_entry_logic.append(
-            (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_4h < 60.0)
-          )
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((df["ROC_9_1h"] < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((df["ROC_9_1h"] < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 1h & 4h & 1d uptrend
-          short_entry_logic.append((df["ROC_9_1h"] < 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
           # 5m green, 15m still not high enough
           short_entry_logic.append((df["change_pct"] < 5.0) | (df["AROOND_14_15m"] < 50.0))
           # 5m green, 15m still not high enough
-          short_entry_logic.append((df["change_pct"] < 5.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 90.0))
+          short_entry_logic.append((df["change_pct"] < 5.0) | (stochrsi_k_15m > 90.0))
           # pump in the last half hour, 1h low
-          short_entry_logic.append((df["close"] < (df["close_min_6"] * 1.20)) | (aroonu_14_1h > 30.0))
+          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (aroonu_14_1h > 30.0))
           # pump in the last half hour, 15m still low
-          short_entry_logic.append((df["close"] < (df["close_min_6"] * 1.20)) | (df["STOCHRSIk_14_14_3_3_15m"] > 40.0))
+          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (stochrsi_k_15m > 40.0))
           # pump in the last half hour, 1d uptrend
-          short_entry_logic.append((df["close"] < (df["close_min_6"] * 1.20)) | (roc_9_1d < 20.0))
+          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (roc_9_1d < 20.0))
           # big pump in the last 4 hours, 15m still low
-          short_entry_logic.append((df["close"] < (df["close_min_48"] * 1.50)) | (df["AROONU_14_15m"] > 50.0))
+          short_entry_logic.append((close < (df["close_min_48"] * 1.50)) | (aroonu_14_15m > 50.0))
 
           # Logic
           short_entry_logic.append(df["EMA_12"] > df["EMA_26"])
           short_entry_logic.append((df["EMA_12"] - df["EMA_26"]) > (df["open"] * 0.030))
           short_entry_logic.append((df["EMA_12"].shift() - df["EMA_26"].shift()) > (df["open"] / 100.0))
-          short_entry_logic.append(df["close"] > (df["BBU_20_2.0"] * 1.004))
+          short_entry_logic.append(close > (df["BBU_20_2.0"] * 1.004))
 
         # Condition #502 - Normal mode (Short).
         if short_entry_condition_index == 502:
@@ -23724,23 +23637,23 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["protections_short_global"] == True)
 
           # 5m & 15m & 1h & 4h up move
-          short_entry_logic.append((df["RSI_3"] < 97.0) | (rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 80.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 80.0))
           # 5m & 4h up move
-          short_entry_logic.append((df["RSI_3"] < 97.0) | (rsi_3_4h < 95.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (rsi_3_4h < 95.0))
           # 5m up move, 4h still not high enough
-          short_entry_logic.append((df["RSI_3"] < 97.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (stochrsi_k_4h > 80.0))
           # 5m & 15m strong up move
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_15m < 95.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0))
           # 5m & 15m up move, 4h low
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_15m < 90.0) | (aroonu_14_4h > 30.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 90.0) | (aroonu_14_4h > 30.0))
           # 5m & 1h & 4h up move
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 90.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 90.0))
           # 5m & 1h up move, 15m still not high enough
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_15m > 70.0))
           # 5m up move, 15m still low
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_15m > 50.0))
           # 5m up move, 4h low
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (aroonu_14_4h > 20.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (aroonu_14_4h > 20.0))
           # 15m & 1h down move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 97.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 80.0))
           # 15m up move, 1h still low
@@ -23756,9 +23669,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h up move
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 90.0))
           # 15m & 1h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (stochrsi_k_15m > 80.0))
           # 15m & 1h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 40.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (stochrsi_k_1d > 40.0))
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 80.0))
           # 15m & 1h up move, 4h stil low
@@ -23766,9 +23679,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (df["RSI_14_1d"] > 40.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 30.0))
           # 15m up move, 1h still low, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_1h > 50.0) | (df["AROONU_14_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_1h > 50.0) | (aroonu_14_1d > 30.0))
           # 15m up move, 1h high
           short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_1h < 100.0))
           # 15m up move, 1h still low
@@ -23780,7 +23693,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0))
           # 15m & 4h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h < 75.0) | (df["AROONU_14_15m"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h < 75.0) | (aroonu_14_15m > 50.0))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 80.0) | (aroonu_14_1h > 10.0))
           # 15m up move, 1h low, 1d uptrend
@@ -23788,9 +23701,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h low
           short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_4h > 40.0))
           # 15m up move, 1h uptrend
-          short_entry_logic.append((rsi_3_15m < 75.0) | (df["ROC_9_1h"] < 40.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (roc_9_1h < 40.0))
           # 1h & 1d strong up move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_1d"] < 95.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_1d < 95.0))
           # 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1h > 70.0))
           # 1h up move, 4h still low, 1h moving higher
@@ -23802,21 +23715,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, relative stable before the hour
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["close_min_12"] > (df["close_min_48"] * 1.10)))
           # 1h up move, 15m uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROONU_14_15m"] < 100.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_15m < 100.0))
           # 1h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1d > 10.0))
           # 1h up move, 1h & 4h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_1h"] < 30.0) | (roc_9_4h < 30.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_1h < 30.0) | (roc_9_4h < 30.0))
           # 1h up move, 4h uptrend
           short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_4h < 20.0))
           # 1h up move, 4h still low
           short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_4h > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (stochrsi_k_1d > 30.0))
           # 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 70.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 80.0) | (df["RSI_14_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_14_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 20.0))
           # 1h up move, 4h low
@@ -23824,11 +23737,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still low
           short_entry_logic.append((rsi_3_1h < 75.0) | (stochrsi_k_1h > 50.0))
           # 1h up move, 4h low
-          short_entry_logic.append((rsi_3_1h < 70.0) | (df["RSI_14_4h"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (rsi_14_4h > 40.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_4h > 40.0))
           # 1h up move, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 70.0) | (df["ROC_9_1h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (roc_9_1h < 40.0))
           # 1h up move, 1h low
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 20.0))
           # 4h up move, 1d still low
@@ -23838,11 +23751,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_4h > 80.0))
           # 4h up move, 15m still not high enough, 4h moving higher
-          short_entry_logic.append(
-            (rsi_3_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (df["CCI_20_change_pct_4h"] < 0.0)
-          )
+          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 80.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 4h up move, 15m still low
-          short_entry_logic.append((rsi_3_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0))
+          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 50.0))
           # 4h up move, 1h still low
           short_entry_logic.append((rsi_3_4h < 90.0) | (aroonu_14_1h > 40.0))
           # 4h up move, 4h still not high enough
@@ -23858,25 +23769,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 4h low
           short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_4h > 40.0))
           # 1d up move, 1h still not high enough
-          short_entry_logic.append((df["RSI_3_1d"] < 95.0) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_1d < 95.0) | (stochrsi_k_1h > 90.0))
           # 1d up move, 1h still low
-          short_entry_logic.append((df["RSI_3_1d"] < 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 50.0))
           # 1d up move, 4h still low
-          short_entry_logic.append((df["RSI_3_1d"] < 80.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_1d < 80.0) | (stochrsi_k_4h > 40.0))
           # 15m low, 1h still low
-          short_entry_logic.append((df["AROONU_14_15m"] > 20.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((aroonu_14_15m > 20.0) | (stochrsi_k_1h > 50.0))
           # 15m low, 4h low
-          short_entry_logic.append((df["AROONU_14_15m"] > 20.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((aroonu_14_15m > 20.0) | (stochrsi_k_4h > 20.0))
           # 15m still low, 1h low
-          short_entry_logic.append((df["AROONU_14_15m"] > 50.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((aroonu_14_15m > 50.0) | (stochrsi_k_1h > 30.0))
           # 15m still not high enough, 4h low
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (aroonu_14_4h > 10.0))
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (aroonu_14_4h > 10.0))
           # 1h & 4h low
           short_entry_logic.append((aroonu_14_1h > 20.0) | (aroonu_14_4h > 20.0))
           # 1h & 4h low
           short_entry_logic.append((aroonu_14_1h > 20.0) | (stochrsi_k_4h > 20.0))
           # 1h low, 1d low
-          short_entry_logic.append((aroonu_14_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((aroonu_14_1h > 30.0) | (stochrsi_k_1d > 30.0))
           # 4h still not high enough, 4h & 1d uptrend
           short_entry_logic.append((aroonu_14_4h > 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 200.0))
           # 1h & 4h low
@@ -23885,18 +23796,18 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((df["change_pct_1d"] < 30.0) | (df["RSI_14_1d"] > 65.0))
           # rise in the last hour, relatively stable before the hour
           short_entry_logic.append(
-            (df["close"] < (df["close_min_12"] * 1.10)) | (df["close_min_12"] > (df["close_min_48"] * 1.10))
+            (close < (df["close_min_12"] * 1.10)) | (df["close_min_12"] > (df["close_min_48"] * 1.10))
           )
           # big pump in the last 6 days, 4h still not high enough
-          short_entry_logic.append((df["close"] < (df["low_min_6_1d"] * 4.0)) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((close < (df["low_min_6_1d"] * 4.0)) | (stochrsi_k_4h > 80.0))
           # big pump in the last 20 days, 1h up move
-          short_entry_logic.append((df["close"] < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h < 90.0))
+          short_entry_logic.append((close < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h < 90.0))
 
           # Logic
           short_entry_logic.append(df["AROOND_14"] < 25.0)
           short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
-          short_entry_logic.append(df["close"] > (df["EMA_20"] * 1.060))
-          short_entry_logic.append(df["close"] > (df["BBU_20_2.0"] * 0.995))
+          short_entry_logic.append(close > (df["EMA_20"] * 1.060))
+          short_entry_logic.append(close > (df["BBU_20_2.0"] * 0.995))
           short_entry_logic.append(df["AROOND_14_15m"] < 25.0)
 
         # Condition #503 - Normal mode (Short).
@@ -23906,28 +23817,28 @@ class NostalgiaForInfinityX7(IStrategy):
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
-          short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
+          short_entry_logic.append(rsi_3_1d >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
-          short_entry_logic.append(df["RSI_14_4h"] > 20.0)
+          short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 5m strong down move
-          short_entry_logic.append((df["RSI_3"] < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
           # 5m down move, 4h still high
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["MFI_14"] > 10.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (df["MFI_14"] > 10.0) | (stochrsi_k_4h > 30.0))
           # 5m & 1h down move, 1h still high
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0))
           # 5m down move, 4h downtrend, 1h still high
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 30.0))
           # 5m & 4h strong down move, 4h still not low enough
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0))
           # 5m down move, 1h high, 1d overbought
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["ROC_9_1h"] < 15.0) | (roc_9_1d > -40.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (roc_9_1h < 15.0) | (roc_9_1d > -40.0))
           # 5m down move, 1h & 4h high
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h > 30.0))
           # 5m down move, 1h high, 4h downtrend
-          short_entry_logic.append((df["RSI_3"] < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h < 10.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h < 10.0))
           # 5m & 1h down move, 4h down
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 85.0) | (df["CMF_20_4h"] > -0.2))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 85.0) | (df["CMF_20_4h"] > -0.2))
           # 5m down move, 1h high
           short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (stochrsi_k_1h > 30.0))
           # 5m down move, 1h high
@@ -23945,7 +23856,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_4h < 80.0) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 50.0) | (df["RSI_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 50.0) | (rsi_14_4h > 50.0))
           # 15m & 1h & 4h down move
           short_entry_logic.append(
             (rsi_3_15m < 90.0) | (df["RSI_3_change_pct_1h"] > -60.0) | (df["RSI_3_change_pct_4h"] > -40.0)
@@ -23953,7 +23864,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1d downtrend, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (roc_9_1d > -25.0) | (stochrsi_k_1h > 30.0))
           # 15m & 1d down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["RSI_3_1d"] < 90.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1d < 90.0) | (stochrsi_k_1h > 30.0))
           # 15m & 4h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 15m still not low enough, 4h down move
@@ -23968,12 +23879,12 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (roc_9_1d > -70.0))
           # 15m down move, 15m not low enough, 1h overbought
           short_entry_logic.append(
-            (df["RSI_14_change_pct_15m"] > -40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 90.0) | (df["RSI_14_1h"] > 30.0)
+            (df["RSI_14_change_pct_15m"] > -40.0) | (stochrsi_k_15m > 90.0) | (df["RSI_14_1h"] > 30.0)
           )
           # 15m strong down move, 1h still high
-          short_entry_logic.append((df["ROC_9_15m"] < 15.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 50.0))
           # 15m downtrend, 1h & 4h still high
-          short_entry_logic.append((df["ROC_9_15m"] < 10.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((roc_9_15m < 10.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 50.0))
           # 15m & 1h & 4h down move
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 15m strong down move
@@ -23991,9 +23902,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still not low enough, 1d overbought
           short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (df["RSI_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
           # 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
           # 1h down move, 4h still high, 1d downtrend
@@ -24011,9 +23922,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h still high, 4h overbought
           short_entry_logic.append((df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_1h"] < 50.0) | (roc_9_4h > -40.0))
           # 15m still high, 1h down move, 1d downtrend
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
           # 1h & 4h still high, 1d strong down move
-          short_entry_logic.append((stochrsi_k_1h > 50.0) | (df["UO_7_14_28_4h"] > 55.0) | (df["RSI_3_1d"] < 90.0))
+          short_entry_logic.append((stochrsi_k_1h > 50.0) | (df["UO_7_14_28_4h"] > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
           short_entry_logic.append((df["AROOND_14_1h"] < 25.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
           # 4h moving down, 1d P&D
@@ -24036,7 +23947,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 10.0) | (df["AROOND_14_4h"] < 25.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_1d > -40.0)
+            (df["change_pct_4h"] < 10.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
           )
           # 4h red, 4h still high, 1d downtrend
           short_entry_logic.append((df["change_pct_4h"] < 10.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 40.0))
@@ -24054,7 +23965,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
           short_entry_logic.append(df["RSI_4"] > 54.0)
           short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["close"] > df["SMA_16"] * 1.058)
+          short_entry_logic.append(close > df["SMA_16"] * 1.058)
 
         # Condition #504 - Normal mode (Short).
         if short_entry_condition_index == 504:
@@ -24063,9 +23974,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
-          short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
+          short_entry_logic.append(rsi_3_1d >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
-          short_entry_logic.append(df["RSI_14_4h"] > 20.0)
+          short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
@@ -24088,13 +23999,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h strong downtrend
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
-          short_entry_logic.append((df["ROC_9_15m"] > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
 
           # Logic
           short_entry_logic.append(df["AROOND_14"] < 25.0)
           short_entry_logic.append(df["AROOND_14_15m"] < 25.0)
-          short_entry_logic.append(df["close"] > (df["EMA_9"] * 1.058))
-          short_entry_logic.append(df["close"] > (df["EMA_20"] * 1.040))
+          short_entry_logic.append(close > (df["EMA_9"] * 1.058))
+          short_entry_logic.append(close > (df["EMA_20"] * 1.040))
 
         # Condition #541 - Quick mode (Short).
         if short_entry_condition_index == 541:
@@ -24102,13 +24013,11 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
           # 5m & 15m down move, 4h still high
-          short_entry_logic.append(
-            (df["RSI_3"] < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (df["RSI_14_4h"] > 50.0)
-          )
+          short_entry_logic.append((rsi_3 < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (rsi_14_4h > 50.0))
           # 5m & 15m & 1h down move
-          short_entry_logic.append((df["RSI_3"] < 95.0) | (rsi_3_15m < 95.0) | (rsi_3_1h < 95.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0) | (rsi_3_1h < 95.0))
           # 5m strong down move
-          short_entry_logic.append((df["RSI_3"] < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
           # 15m & 1h strong down move & downtrend
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
           # 15m strong down move, 4h high
@@ -24132,13 +24041,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h downtrend, 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["ROC_9_1h"] < 20.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (roc_9_1h < 20.0) | (stochrsi_k_4h > 50.0))
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 30.0))
           # 15m down move, 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 85.0) | (df["RSI_3_change_pct_1h"] < 30.0) | (stochrsi_k_4h > 10.0))
           # 1m down move, 1h still dropping, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["CCI_20_change_pct_1h"] < 0.0) | (df["RSI_14_4h"] > 20.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (df["CCI_20_change_pct_1h"] < 0.0) | (rsi_14_4h > 20.0))
           # 15m down move, 1h high
           short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h > 10.0))
           # 1h strong down move, 4h high
@@ -24146,7 +24055,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h downtrend, 4h not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["CMF_20_4h"] > -0.25) | (stochrsi_k_4h > 70.0))
           # 1h down move, 4h high, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_14_4h"] > 40.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_14_4h > 40.0) | (roc_9_1d > -50.0))
           # 1h down move, 4h strong down move
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_4h"] < 40.0))
           # 1h & 4h down move, 4h still going down
@@ -24155,14 +24064,14 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 70.0))
           # 1h down move, 4h down move, 4h P&D
           short_entry_logic.append(
-            (rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 70.0) | (df["RSI_14_4h"].shift(48) > 30.0)
+            (rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 70.0) | (rsi_14_4h.shift(48) > 30.0)
           )
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
             (rsi_3_1h < 90.0)
             | (df["RSI_3_change_pct_4h"] < 50.0)
             | (df["AROOND_14_4h"] < 25.0)
-            | (df["STOCHRSIk_14_14_3_3_1d"] > 60.0)
+            | (stochrsi_k_1d > 60.0)
           )
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0) | (df["ROC_2_1d"] > -50.0))
@@ -24175,21 +24084,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((df["RSI_3_change_pct_1h"] < 65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
           # 15m strong down move, 1h still high
-          short_entry_logic.append((df["ROC_9_15m"] < 15.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 30.0))
           # 15m downtrend, 4h down move, 4h stil high
-          short_entry_logic.append((df["ROC_9_15m"] < 15.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((roc_9_15m < 15.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
           # 1h downtrend, 4h overbought
-          short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (df["RSI_14_4h"] > 20.0) | (roc_9_4h > -25.0))
+          short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (rsi_14_4h > 20.0) | (roc_9_4h > -25.0))
           # 1h P&D, 4h still high
-          short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (df["ROC_9_1h"] > -5.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h > 30.0))
           # 1h downtrend, 4h down move, 1d downtrend
-          short_entry_logic.append((df["ROC_9_1h"] < 40.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
-          short_entry_logic.append((roc_9_4h > -200.0) | (df["RSI_14_4h"] > 20.0))
+          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
           # 4h down move, 1d P&D
           short_entry_logic.append((roc_9_4h < 20.0) | (df["ROC_2_1d"] < 20.0) | (roc_9_1d > -50.0))
           # 1h P&D, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_1h"] < 2.0) | (df["change_pct_1h"].shift(12) > 2.0) | (df["RSI_14_4h"] > 20.0)
+            (df["change_pct_1h"] < 2.0) | (df["change_pct_1h"].shift(12) > 2.0) | (rsi_14_4h > 20.0)
           )
           # 1h P&D, 1d overbought
           short_entry_logic.append(
@@ -24200,10 +24109,10 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["change_pct_1h"] < 10.0) | (df["change_pct_4h"] < 10.0) | (df["MFI_14_1h"] > 50.0)
           )
           # 1h red, 1h still not low enough, 1d down move
-          short_entry_logic.append((df["change_pct_1h"] < 15.0) | (df["MFI_14_1h"] > 50.0) | (df["RSI_3_1d"] < 90.0))
+          short_entry_logic.append((df["change_pct_1h"] < 15.0) | (df["MFI_14_1h"] > 50.0) | (rsi_3_1d < 90.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (df["RSI_14_4h"].shift(48) > 20.0)
+            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
           )
           # 1d P&D, 1d overbought
           short_entry_logic.append(
@@ -24227,9 +24136,9 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["protections_short_global"] == True)
 
           # 5m & 15m up move, 15m stil low
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_15m < 80.0) | (df["AROONU_14_15m"] > 60.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_15m < 80.0) | (aroonu_14_15m > 60.0))
           # 15m & 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 1h still moving higher
@@ -24237,37 +24146,37 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 4h still moving higher
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0))
           # 15m & 1d up move, 4h uptrend
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["RSI_3_1d"] < 80.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1d < 80.0) | (roc_9_4h < 20.0))
           # 15m up move, 15m & 4h high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["AROONU_14_15m"] < 100.0) | (aroonu_14_4h < 100.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0))
           # 15m up move, 15m still not high enough, 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (roc_9_1d < 80.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_15m > 80.0) | (roc_9_1d < 80.0))
           # 15m & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 90.0) | (stochrsi_k_15m > 70.0))
           # 15m & 4h up move, 1d uptrend
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (roc_9_1d < 50.0))
           # 15m & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 80.0) | (df["RSI_14_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 80.0) | (rsi_14_4h > 60.0))
           # 15m up move, 15m still not high enough, 4h still low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_4h < 50.0))
           # 15m & 1h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (df["AROONU_14_15m"] > 40.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_15m > 40.0))
           # 15m & 1h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 40.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (stochrsi_k_15m > 40.0))
           # # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 60.0) | (aroonu_14_4h > 40.0))
           # 1h & 1d up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 97.0) | (df["RSI_3_1d"] < 95.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_15m > 80.0))
           # 1h & 4h up move, 1d uptrend
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (roc_9_1d < 100.0))
           # 1h & 4h up move, 1d still low
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (df["RSI_14_1d"] > 50.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_4h"] > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 95.0) | (aroonu_14_4h > 10.0))
           # 1h & 4h up move, 1h still moving higher
@@ -24275,89 +24184,85 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_4h > 80.0))
           # 1h & 1d up move, 15m still low
-          short_entry_logic.append(
-            (rsi_3_1h < 90.0) | (df["RSI_3_1d"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_1d < 90.0) | (stochrsi_k_15m > 60.0))
           # 1h up move, 15m high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROONU_14_15m"] < 100.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_15m < 100.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 30.0))
           # 1h up move, 4h still low, 1h still moving higher
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
           # 1h up move, 15m uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_15m"] < 30.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 30.0))
           # 1h up move, 15m & 4h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["ROC_9_15m"] < 20.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 20.0) | (roc_9_4h < 20.0))
           # 1h & 4h up move, 4h still moving higher
           short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (df["CCI_20_change_pct_4h"] < -0.0))
           # 1h up move, 15m low
-          short_entry_logic.append((rsi_3_1h < 85.0) | (df["AROONU_14_15m"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_15m > 40.0))
           # 1h up move, 4h still not high enough, 1d low
           short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_4h > 80.0) | (df["RSI_14_1d"] > 40.0))
           # 1h & 4h up move, 4h still low
           short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (aroonu_14_4h > 50.0))
           # 1h & 4h up move, 1d still low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (df["AROONU_14_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (aroonu_14_1d > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 30.0))
           # 1h up move, 1d still low, 1d uptrend
-          short_entry_logic.append((rsi_3_1h < 80.0) | (df["AROONU_14_1d"] > 50.0) | (roc_9_1d < 30.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (aroonu_14_1d > 50.0) | (roc_9_1d < 30.0))
           # 1h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1d > 20.0))
           # 1h up move, 4h & 1d uptrend
           short_entry_logic.append((rsi_3_1h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h up move, 1d low
           short_entry_logic.append((rsi_3_4h < 95.0) | (df["RSI_14_1d"] > 40.0))
           # 4h down move, 15m still not high enough, 1d low
-          short_entry_logic.append(
-            (rsi_3_4h < 95.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (df["AROOND_14_1d"] < 75.0)
-          )
+          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
           # 4h up move, 1h & 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 95.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
           # 4h up move, 15m low
-          short_entry_logic.append((rsi_3_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 45.0))
+          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 45.0))
           # 4h up move, 4h & 1d uptrend
           short_entry_logic.append((rsi_3_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_4h < 85.0) | (df["AROONU_14_15m"] > 60.0))
+          short_entry_logic.append((rsi_3_4h < 85.0) | (aroonu_14_15m > 60.0))
           # 4h up move, 15m low
-          short_entry_logic.append((rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 30.0))
+          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_15m > 30.0))
           # 4h up move, 4h uptrend
           short_entry_logic.append((rsi_3_4h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
           # 4h up move, 15m still low, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (aroonu_14_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h > 80.0))
           # 4h up move, 15m still low, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 75.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 80.0))
           # 1d up move, 4h low
-          short_entry_logic.append((df["RSI_3_1d"] < 85.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h > 40.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((df["RSI_14_4h"] > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 15m & 1h high, 4h uptrend
-          short_entry_logic.append((df["AROONU_14_15m"] < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
           # 15m & 4h high, 1h uptrend
-          short_entry_logic.append((df["AROONU_14_15m"] < 100.0) | (aroonu_14_4h < 100.0) | (df["ROC_9_1h"] < 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
           # 15m high, 1d low
-          short_entry_logic.append((df["AROONU_14_15m"] < 100.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1d > 20.0))
           # 15m high & uptrend
-          short_entry_logic.append((df["AROONU_14_15m"] < 100.0) | (df["ROC_9_15m"] < 30.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_15m < 30.0))
           # 15m high, 1h & 4h uptrend
-          short_entry_logic.append((df["AROONU_14_15m"] < 100.0) | (df["ROC_9_1h"] < 20.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
           # 1h high, 15m uptrend
-          short_entry_logic.append((aroonu_14_1h < 100.0) | (df["ROC_9_15m"] < 20.0))
+          short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_15m < 20.0))
           # 15m & 4h still not high enough
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 70.0))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((df["ROC_9_1h"] < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((df["ROC_9_1h"] < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 1d bot wick, 4h still not high enough
           short_entry_logic.append((df["bot_wick_pct_1d"] < 30.0) | (stochrsi_k_4h > 80.0))
           # rise in the last 12 hours, relatively stable before the 12 hours
           short_entry_logic.append(
-            (df["close"] < (df["low_min_12_1h"] * 1.30)) | (df["low_min_12_1h"] > (df["low_min_24_1h"] * 1.10))
+            (close < (df["low_min_12_1h"] * 1.30)) | (df["low_min_12_1h"] > (df["low_min_24_1h"] * 1.10))
           )
           # big pump in the last 30 days, 4h up move
-          short_entry_logic.append((df["close"] < (df["low_min_30_1d"] * 4.0)) | (rsi_3_4h < 85.0))
+          short_entry_logic.append((close < (df["low_min_30_1d"] * 4.0)) | (rsi_3_4h < 85.0))
 
           # Logic
           short_entry_logic.append(df["WILLR_14"] > -50.0)
@@ -24367,7 +24272,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["WILLR_84_1h"] > -30.0)
           short_entry_logic.append(stochrsi_k_1h > 80.0)
           short_entry_logic.append(df["BBB_20_2.0_1h"] > 20.0)
-          short_entry_logic.append(df["close_min_48"] <= (df["close"] * 0.90))
+          short_entry_logic.append(df["close_min_48"] <= (close * 0.90))
 
         # Condition #543 - Rapid mode (Short).
         if short_entry_condition_index == 543:
@@ -24375,10 +24280,10 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
-          short_entry_logic.append(df["RSI_14_4h"] > 20.0)
+          short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 5m strong down move
-          short_entry_logic.append((df["RSI_3"] < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
           # 15m down move, 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 60.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 1h down move, 4h still not low enough
@@ -24406,15 +24311,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 55.0))
           # 15m down move, 15m still not low enough, 1h still high
-          short_entry_logic.append(
-            (rsi_3_15m < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_1h > 30.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 30.0))
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 75.0) | (stochrsi_k_1h > 30.0))
           # 15m down move, 15m still not low enoug, 1h high
           short_entry_logic.append((rsi_3_15m < 85.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 10.0))
           # 15m down move, 1h downtrend, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["ROC_9_1h"] < 5.0) | (roc_9_4h > -35.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still high
@@ -24422,20 +24325,20 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 70.0))
           # 1h down move, 1h still not low enough, 4h still not low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (df["RSI_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
           # 1h down move, 1h not low enough, 1h still high
           short_entry_logic.append((rsi_3_1h < 85.0) | (df["AROOND_14_1h"] < 50.0) | (stochrsi_k_4h > 50.0))
           # 4h down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_4h < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h > 50.0) | (roc_9_1d < 50.0))
           # 4h & 1d down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h < 90.0) | (df["RSI_3_1d"] < 90.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((rsi_3_4h < 90.0) | (rsi_3_1d < 90.0) | (roc_9_1d < 60.0))
           # 4h overbought, 1h still high, 1d downtrend
           short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h > 70.0) | (roc_9_1d < 50.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (df["RSI_14_4h"].shift(48) > 20.0)
+            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
           )
           # 4h red, 4h moving down, 4h still high, 1d downtrend
           short_entry_logic.append(
@@ -24452,8 +24355,8 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["EMA_26"] < df["EMA_12"])
           short_entry_logic.append((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.024))
           short_entry_logic.append((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
-          short_entry_logic.append(df["close"] < (df["EMA_20"] * 0.958))
-          short_entry_logic.append(df["close"] < (df["BBL_20_2.0"] * 0.992))
+          short_entry_logic.append(close < (df["EMA_20"] * 0.958))
+          short_entry_logic.append(close < (df["BBL_20_2.0"] * 0.992))
 
         # # Condition #620 - Grind mode (Short).
         # if short_entry_condition_index == 620:
@@ -24483,18 +24386,18 @@ class NostalgiaForInfinityX7(IStrategy):
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
-          short_entry_logic.append(df["RSI_3_1d"] >= 20.0)
+          short_entry_logic.append(rsi_3_1d >= 20.0)
           short_entry_logic.append(df["RSI_14_1h"] > 20.0)
-          short_entry_logic.append(df["RSI_14_4h"] > 20.0)
+          short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 5m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 30.0))
           # 5m down move, 1h high, 4h still not low enough
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
           # 15m down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 1d still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1d > 70.0))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 70.0))
           # 15m down move, 1h high, 4h still high
@@ -24504,9 +24407,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h still not low enough, 4h still high
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 60.0))
           # 1h & 4h & 1d down move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (df["RSI_3_1d"] < 80.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0))
           # 1h & 4h down move, 15m not low enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 75.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_15m > 75.0))
           # 1h down move, 1h still not low enough, 4h still high
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 1h still not low enough
@@ -24520,15 +24423,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 70.0))
           # 4h down move, 15m still high, 1h still not low enough
-          short_entry_logic.append((rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 75.0))
           # 4h down move, 15m & 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 15.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h < 15.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 80.0))
 
           # Logic
           short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
-          short_entry_logic.append(df["RSI_3"] > 70.0)
+          short_entry_logic.append(rsi_3 > 70.0)
           short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["close"] > df["SMA_16"] * 1.044)
+          short_entry_logic.append(close > df["SMA_16"] * 1.044)
 
         # Condition #642 - Top Coins mode (Short).
         if short_entry_condition_index == 642:
@@ -24538,37 +24441,31 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
           # 5m & 1h & 4h down move
-          short_entry_logic.append((df["RSI_3"] < 90.0) | (rsi_3_1h < 95.0) | (rsi_3_4h < 90.0))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 95.0) | (rsi_3_4h < 90.0))
           # 5m down move, 15m & 4h still high
-          short_entry_logic.append(
-            (df["RSI_3"] < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (stochrsi_k_4h > 60.0)
-          )
+          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
           # 5m down move, 15m still high, 1h high
-          short_entry_logic.append((df["RSI_3"] < 85.0) | (df["AROOND_14_15m"] < 50.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3 < 85.0) | (df["AROOND_14_15m"] < 50.0) | (stochrsi_k_1h > 20.0))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 90.0))
           # 15m & 1h down move, 1d still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 70.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1d > 70.0))
           # 15m strong down move, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_4h > 20.0))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_1h > 80.0))
           # 15m down move, 15m stil high, 1h still not low enough
-          short_entry_logic.append(
-            (rsi_3_15m < 90.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_1h > 80.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 80.0))
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 60.0) | (stochrsi_k_4h > 60.0))
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 15m still not low enough, 4h high
-          short_entry_logic.append(
-            (rsi_3_15m < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 80.0) | (stochrsi_k_4h > 20.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_15m > 80.0) | (stochrsi_k_4h > 20.0))
           # 15m down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
           # 15m & 4h down move, 1d still high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 75.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 75.0) | (stochrsi_k_1d > 50.0))
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0))
           # 15m & 1h down move, 4h still not low enough
@@ -24582,15 +24479,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
           # 15m down move, 4h high, 1d stil high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 50.0))
           # 15m & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 70.0))
           # 15m & 4h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h < 80.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 15m still high 4h still high
-          short_entry_logic.append(
-            (rsi_3_15m < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (stochrsi_k_4h > 50.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 10.0))
           # 1h & 4h down move, 1h still not low enough
@@ -24604,15 +24499,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 85.0))
           # 1h & 4h down move, 1d still high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 50.0))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 85.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 75.0))
           # 1h & 4h down move, 15m still high
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (stochrsi_k_15m > 50.0))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 75.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 75.0))
           # 1h & 4h down move, 1h still high
@@ -24620,50 +24515,40 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 4h still high
           short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 50.0))
           # 4h down move, 15m still high, 1h still not low enough
-          short_entry_logic.append((rsi_3_4h < 85.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 80.0))
           # 4h down move, 15m still high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 75.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 75.0))
           # 4h down move, 1h still not low enough, 1d still high
-          short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h > 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_1d > 50.0))
           # 15m & 1h still high, 4h high
-          short_entry_logic.append(
-            (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0)
-          )
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0))
           # 15m still high, 1h & 1d high
-          short_entry_logic.append(
-            (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (stochrsi_k_1h > 30.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 30.0)
-          )
+          short_entry_logic.append((stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 30.0) | (stochrsi_k_1d > 30.0))
           # 15m & 4h high
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 20.0))
           # 15m high, 1h & 4h still not low enough
-          short_entry_logic.append(
-            (df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (stochrsi_k_1h > 75.0) | (stochrsi_k_4h > 75.0)
-          )
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 75.0) | (stochrsi_k_4h > 75.0))
           # 15m & 4h high
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 30.0))
           # 1h & 4h still high, 1d high
-          short_entry_logic.append(
-            (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0)
-          )
+          short_entry_logic.append((stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0) | (stochrsi_k_1d > 50.0))
           # 1h & 4h high
           short_entry_logic.append((stochrsi_k_1h > 30.0) | (stochrsi_k_4h > 10.0))
           # 1h & 4h high
           short_entry_logic.append((stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 20.0))
           # 4h & 1d high
-          short_entry_logic.append((stochrsi_k_4h > 20.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 20.0))
           # 1d red, 1d high
-          short_entry_logic.append((df["change_pct_1d"] < 5.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((df["change_pct_1d"] < 5.0) | (stochrsi_k_1d > 20.0))
           # 1d P&D, 1d high
           short_entry_logic.append(
-            (df["change_pct_1d"] < 10.0)
-            | (df["change_pct_1d"].shift(288) > -10.0)
-            | (df["STOCHRSIk_14_14_3_3_1d"] > 50.0)
+            (df["change_pct_1d"] < 10.0) | (df["change_pct_1d"].shift(288) > -10.0) | (stochrsi_k_1d > 50.0)
           )
 
           # Logic
           short_entry_logic.append(df["RSI_4"] > 54.0)
           short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
-          short_entry_logic.append(df["close"] > df["SMA_16"] * 1.042)
+          short_entry_logic.append(close > df["SMA_16"] * 1.042)
 
         # Condition #661 - Scalp mode (Short).
         if short_entry_condition_index == 661:
@@ -24675,9 +24560,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m still high
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 50.0))
           # 15m down move, 15m & 4h still high
-          short_entry_logic.append(
-            (rsi_3_15m < 70.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_4h > 50.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 15m & 1h down move, 1h high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (df["AROOND_14_1h"] < 70.0))
           # 15m & 1h down move, 1h still high
@@ -24685,36 +24568,28 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_4h"] < 80.0))
           # 15m & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m > 50.0))
           # 15m & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 30.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (df["AROOND_14_15m"] < 50.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append(
-            (rsi_3_15m < 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_1h > 50.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 60.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 4h still high, 1d overbought
           short_entry_logic.append((rsi_3_15m < 60.0) | (df["AROOND_14_4h"] < 50.0) | (roc_9_1d > -100.0))
           # 15m down move, 15m high, 4h still high
           short_entry_logic.append((rsi_3_15m < 55.0) | (df["AROOND_14_15m"] > 30.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append(
-            (rsi_3_15m < 55.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 55.0) | (stochrsi_k_1h > 60.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h > 60.0))
           # 15m down move, 15m still not low enough, 4h high
-          short_entry_logic.append(
-            (rsi_3_15m < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (stochrsi_k_4h > 10.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append(
-            (rsi_3_1h < 75.0) | (df["AROOND_14_4h"] < 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0)
-          )
-          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 60.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (df["AROOND_14_4h"] < 50.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 60.0) | (stochrsi_k_1d > 10.0))
           # 1h & 4h down move, 4h high
           short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 50.0))
           # 1h down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 70.0))
           # 1h down move, 1h high
@@ -24732,27 +24607,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m high, 1h still high
           short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_15m"] < 70.0) | (stochrsi_k_1h > 60.0))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append(
-            (rsi_3_1h < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 40.0) | (df["AROOND_14_1h"] < 60.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (df["AROOND_14_1h"] < 60.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append(
-            (rsi_3_1h < 50.0) | (df["AROOND_14_1h"] < 70.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_1h"] < 70.0) | (stochrsi_k_1d > 20.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 10.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 10.0))
           # 1h down move, 5m up move, 1h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["RSI_3"] > 40.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h > 50.0))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append(
-            (rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (df["AROOND_14_1h"] < 70.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (df["AROOND_14_1h"] < 70.0))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 70.0) | (stochrsi_k_1h > 40.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 40.0))
           # 1h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 1h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_1h"] < 90.0))
           # 1h down move, 1h still high, 4h high
@@ -24764,7 +24633,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 30.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["RSI_14_4h"] > 30.0) | (df["RSI_14_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (df["RSI_14_1d"] > 20.0))
           # 4h down move, 15m high
           short_entry_logic.append((rsi_3_4h < 80.0) | (df["AROOND_14_15m"] < 80.0))
           # 4h down move, 1h high
@@ -24774,7 +24643,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (df["AROOND_14_15m"] < 80.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h still high, 4h still moving down
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h > 50.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 4h down move, 1h high, 4h still high
@@ -24782,13 +24651,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still high
           short_entry_logic.append((rsi_3_4h < 50.0) | (df["AROOND_14_15m"] < 70.0) | (stochrsi_k_4h > 60.0))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 60.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 15m & 4h still high
-          short_entry_logic.append(
-            (rsi_3_4h < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (df["AROOND_14_4h"] < 50.0)
-          )
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 50.0) | (df["AROOND_14_4h"] < 50.0))
           # 4h down move, 15m high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 50.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 70.0))
           # 4h down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h > 50.0) | (df["AROOND_14_4h"] < 70.0))
           # 4h down move, 15m & 4h high
@@ -24796,39 +24663,39 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still high
           short_entry_logic.append((rsi_3_4h < 40.0) | (df["AROOND_14_15m"] < 80.0) | (df["AROOND_14_4h"] < 40.0))
           # 4h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 50.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 30.0))
           # 4h down move, 15m & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
           # 4h down move, 1h & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h > 30.0) | (df["AROOND_14_4h"] < 70.0))
           # 4h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h > 50.0) | (df["STOCHRSIk_14_14_3_3_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 20.0))
           # 15m high, 4h high
           short_entry_logic.append((df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_4h"] < 85.0))
           # 15m high, 4h still high
           short_entry_logic.append((df["AROOND_14_15m"] < 80.0) | (stochrsi_k_4h > 50.0))
           # 15m high, 1h still high
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 60.0))
           # 15m & 4h high
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 30.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (df["AROOND_14_4h"] < 70.0))
           # 15m high, 1h still not low enough
-          short_entry_logic.append((df["STOCHRSIk_14_14_3_3_15m"] > 20.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 20.0) | (stochrsi_k_1h > 70.0))
 
           # Logic
           short_entry_logic.append(df["RSI_14"] > 50.0)
           short_entry_logic.append(df["AROOND_14_15m"] < 90.0)
-          short_entry_logic.append(df["STOCHRSIk_14_14_3_3_15m"] > 10.0)
+          short_entry_logic.append(stochrsi_k_15m > 10.0)
           if isinstance(df["SMA_200"].iloc[-1], np.float64):
             short_entry_logic.append(df["SMA_21"].shift(1) > df["SMA_200"].shift(1))
             short_entry_logic.append(df["SMA_21"] < df["SMA_200"])
           else:
             short_entry_logic.append(pd.Series([False]))
           if isinstance(df["EMA_200_1h"].iloc[-1], np.float64):
-            short_entry_logic.append(df["close"] < df["EMA_200_1h"])
+            short_entry_logic.append(close < df["EMA_200_1h"])
           else:
             short_entry_logic.append(pd.Series([False]))
           if isinstance(df["EMA_200_4h"].iloc[-1], np.float64):
-            short_entry_logic.append(df["close"] < df["EMA_200_4h"])
+            short_entry_logic.append(close < df["EMA_200_4h"])
           else:
             short_entry_logic.append(pd.Series([False]))
           short_entry_logic.append(df["BBB_20_2.0_1h"] > 4.0)


### PR DESCRIPTION
## Summary
- Stores high-traffic populate_entry_trend() Series references once.
- Reuses those Series across the existing entry condition matrix.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same entry trend conditions, thresholds, tag generation, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
