### PR TITLE
Reuse X7 short rebuy-v3 order references

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -72617,7 +72617,11 @@ class NostalgiaForInfinityX7(IStrategy):
     if count_of_entries == 0:
       return None
 
-    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
+    first_filled_order = filled_orders[0]
+    last_filled_order = filled_orders[-1]
+    last_filled_entry = filled_entries[-1]
+
+    has_order_tags = hasattr(first_filled_order, "ft_order_tag")
 
     if dp.runmode.value in ("live", "dry_run"):
       ticker = dp.ticker(trade_pair)
@@ -72637,8 +72641,8 @@ class NostalgiaForInfinityX7(IStrategy):
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     slice_amount = filled_entries[0].cost
-    slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
-    slice_profit_entry = (exit_rate - filled_entries[-1].safe_price) / filled_entries[-1].safe_price
+    slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
+    slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
       ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
     )
@@ -72661,7 +72665,7 @@ class NostalgiaForInfinityX7(IStrategy):
     current_grind_stake = 0.0
     current_grind_stake_profit = 0.0
     for order in reversed(filled_orders):
-      if (order.ft_order_side == "sell") and (order is not filled_orders[0]):
+      if (order.ft_order_side == "sell") and (order is not first_filled_order):
         sub_grind_count += 1
         total_amount += order.safe_filled
         total_cost += order.safe_filled * order.safe_price


### PR DESCRIPTION
## Summary
- Names the first/last filled-order references in short_rebuy_adjust_trade_position_v3().
- Reuses those references across the existing short rebuy-v3 checks.
- Independent on latest upstream main.

## Safety
- Behavior is preserved: same short rebuy-v3 adjust conditions, order references, stake sizing, indicators, candle selection, condition order, and return values.
- The patch only reuses already-available values inside the same call.
- No CMF/math formula changes are made.
- No v3 grind-entry code is touched.

## Backtest scope
- A full trading-output backtest was not required because this is exact local value reuse and does not change indicators, thresholds, candle selection, order classification, stake sizing, or profit arithmetic.

## Checks
- git diff --check
- ruff format --check NostalgiaForInfinityX7.py
- ruff check NostalgiaForInfinityX7.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py
- python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main
