### PR TITLE
Reuse X7 long dec candle reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -28531,30 +28531,53 @@ class NostalgiaForInfinityX7(IStrategy):
     last_stochrsi_k_1h = last_candle["STOCHRSIk_14_14_3_3_1h"]
     last_stochrsi_k_1d = last_candle["STOCHRSIk_14_14_3_3_1d"]
     last_roc_9_4h = last_candle["ROC_9_4h"]
+    last_aroonu_14_1d = last_candle["AROONU_14_1d"]
+    last_cmf_20_1h = last_candle["CMF_20_1h"]
+    last_cmf_20_4h = last_candle["CMF_20_4h"]
+    last_ema_12_1h = last_candle["EMA_12_1h"]
+    last_ema_12_4h = last_candle["EMA_12_4h"]
+    last_change_pct_4h = last_candle["change_pct_4h"]
+    last_roc_2_1d = last_candle["ROC_2_1d"]
+    last_roc_2_1h = last_candle["ROC_2_1h"]
+    last_roc_2_4h = last_candle["ROC_2_4h"]
+    last_rsi_14_1d = last_candle["RSI_14_1d"]
+    last_rsi_14_1h = last_candle["RSI_14_1h"]
+    last_aroonu_14_15m = last_candle["AROONU_14_15m"]
+    last_cci_20_change_pct_1h = last_candle["CCI_20_change_pct_1h"]
+    last_kst_1h = last_candle["KST_10_15_20_30_10_10_10_15_1h"]
+    last_kst_4h = last_candle["KST_10_15_20_30_10_10_10_15_4h"]
+    last_ksts_9_1h = last_candle["KSTs_9_1h"]
+    last_ksts_9_4h = last_candle["KSTs_9_4h"]
+    last_roc_9_15m = last_candle["ROC_9_15m"]
+    last_stochrsi_k_change_pct_4h = last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"]
+    last_stoch_k_4h = last_candle["STOCHk_14_3_3_4h"]
+    last_change_pct_1h = last_candle["change_pct_1h"]
+    last_close = last_candle["close"]
+    last_high_max_30_1d = last_candle["high_max_30_1d"]
     if 0.01 > current_profit >= 0.001:
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_2"
       elif (
         (last_willr_14 > -1.0)
         and (last_stochrsi_k > 99.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
@@ -28562,8 +28585,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 78.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
       elif (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -28586,8 +28609,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_stochrsi_k > 99.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -28595,7 +28618,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_3 > 99.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
@@ -28610,7 +28633,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -28633,7 +28656,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
@@ -28645,9 +28668,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_17"
-      elif (
-        (last_rsi_3 > 95.0) and (last_rsi_14 > 75.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 > 75.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
         (last_rsi_3 > 99.0)
@@ -28663,7 +28684,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -28716,27 +28737,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_31"
-      elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_0_34"
       elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_0_35"
@@ -28758,9 +28769,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_37"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_0_38"
-      elif (
-        (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
         (last_rsi_3 > 98.0)
@@ -28804,9 +28813,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_44"
       elif (last_rsi_3 > 96.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_0_45"
-      elif (
-        (last_rsi_3 > 98.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 98.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_0_46"
       elif (
         (last_rsi_3 > 98.0)
@@ -28946,15 +28953,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
-        (last_rsi_3 > 97.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -29018,7 +29022,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -8.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
@@ -29050,7 +29054,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -29068,7 +29072,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -2.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
@@ -29131,7 +29135,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
@@ -29165,7 +29169,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
@@ -29323,7 +29327,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -29340,9 +29344,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_0_130"
       elif (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -29357,7 +29361,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -29366,26 +29370,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_1_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 68.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_2"
       elif (
         (last_willr_14 > -8.0)
         and (last_stochrsi_k > 99.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_1_3"
       elif (
@@ -29393,8 +29397,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_4"
       elif (last_willr_14 > -2.0) and (last_rsi_14 > 72.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -29417,8 +29421,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -2.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -29426,7 +29430,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -2.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_9"
@@ -29441,7 +29445,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -29464,7 +29468,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_1_16"
@@ -29476,9 +29480,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_17"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_1_18"
       elif (
         (last_rsi_3 > 95.0)
@@ -29494,7 +29496,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -29547,27 +29549,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_31"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_1_32"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -2.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_1_34"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_1_35"
@@ -29589,9 +29581,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_37"
       elif (last_rsi_3 > 85.0) and (last_willr_14 > -15.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_1_38"
-      elif (
-        (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_1_39"
       elif (
         (last_rsi_3 > 85.0)
@@ -29635,9 +29625,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_44"
       elif (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_1_45"
-      elif (
-        (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_1_46"
       elif (
         (last_rsi_3 > 86.0)
@@ -29777,15 +29765,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
-        (last_rsi_3 > 96.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_1_69"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -29849,7 +29834,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_81"
       elif (
@@ -29881,7 +29866,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -29899,7 +29884,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_1_88"
       elif (
@@ -29962,7 +29947,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_1_95"
       elif (
@@ -29996,7 +29981,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
@@ -30154,7 +30139,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -30171,9 +30156,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_129"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_1_130"
       elif (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -30188,7 +30173,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_132"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -30197,26 +30182,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_2_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 66.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_2"
       elif (
         (last_willr_14 > -10.0)
         and (last_stochrsi_k > 99.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_2_3"
       elif (
@@ -30224,8 +30209,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_4"
       elif (last_willr_14 > -4.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -30248,8 +30233,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -4.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -30257,7 +30242,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -4.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_9"
@@ -30272,7 +30257,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -30295,7 +30280,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_2_16"
@@ -30307,9 +30292,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_17"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_2_18"
       elif (
         (last_rsi_3 > 90.0)
@@ -30325,7 +30308,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -4.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -30378,27 +30361,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_31"
-      elif (
-        (last_rsi_3 > 85.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_2_32"
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -4.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_2_34"
       elif (last_rsi_3 > 86.0) and (last_willr_14 > -7.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_2_35"
@@ -30420,9 +30393,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_37"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -20.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_2_38"
-      elif (
-        (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_2_39"
       elif (
         (last_rsi_3 > 80.0)
@@ -30466,9 +30437,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_44"
       elif (last_rsi_3 > 92.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_2_45"
-      elif (
-        (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_2_46"
       elif (
         (last_rsi_3 > 84.0)
@@ -30608,15 +30577,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_2_69"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -30680,7 +30646,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -12.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_81"
       elif (
@@ -30712,7 +30678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -30730,7 +30696,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -22.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_2_88"
       elif (
@@ -30793,7 +30759,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_2_95"
       elif (
@@ -30827,7 +30793,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
@@ -30985,7 +30951,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -31002,9 +30968,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_129"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_2_130"
       elif (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -31019,7 +30985,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_132"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -31028,26 +30994,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_3_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 64.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
         (last_willr_14 > -20.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
@@ -31055,8 +31021,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_4"
       elif (last_willr_14 > -6.0) and (last_rsi_14 > 68.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -31079,8 +31045,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -6.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -31088,7 +31054,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -6.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
@@ -31103,7 +31069,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -31126,7 +31092,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
@@ -31138,9 +31104,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_17"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
         (last_rsi_3 > 88.0)
@@ -31156,7 +31120,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -6.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -31209,27 +31173,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_31"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -6.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_3_34"
       elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_3_35"
@@ -31251,9 +31205,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_37"
       elif (last_rsi_3 > 75.0) and (last_willr_14 > -25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_3_38"
-      elif (
-        (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
         (last_rsi_3 > 75.0)
@@ -31297,9 +31249,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_44"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_3_45"
-      elif (
-        (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_3_46"
       elif (
         (last_rsi_3 > 82.0)
@@ -31439,15 +31389,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
-        (last_rsi_3 > 94.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 94.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_3_69"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -31511,7 +31458,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -14.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
@@ -31543,7 +31490,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -31561,7 +31508,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -24.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_3_88"
       elif (
@@ -31624,7 +31571,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
@@ -31658,7 +31605,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
@@ -31816,7 +31763,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -31833,9 +31780,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_3_130"
       elif (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -31850,7 +31797,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -31859,26 +31806,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_4_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 62.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_2"
       elif (
         (last_willr_14 > -20.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_4_3"
       elif (
@@ -31886,8 +31833,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_4"
       elif (last_willr_14 > -8.0) and (last_rsi_14 > 66.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -31910,8 +31857,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -8.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -31919,7 +31866,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -7.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_9"
@@ -31934,7 +31881,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -31957,7 +31904,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_4_16"
@@ -31969,9 +31916,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_17"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_4_18"
       elif (
         (last_rsi_3 > 86.0)
@@ -31987,7 +31932,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -8.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -32040,27 +31985,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_31"
-      elif (
-        (last_rsi_3 > 75.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_4_32"
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -8.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_4_34"
       elif (last_rsi_3 > 82.0) and (last_willr_14 > -9.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_4_35"
@@ -32082,9 +32017,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_37"
       elif (last_rsi_3 > 70.0) and (last_willr_14 > -30.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_4_38"
-      elif (
-        (last_rsi_3 > 92.0) and (last_willr_14 > -8.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -8.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_4_39"
       elif (
         (last_rsi_3 > 70.0)
@@ -32128,9 +32061,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_44"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -12.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_4_45"
-      elif (
-        (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_4_46"
       elif (
         (last_rsi_3 > 80.0)
@@ -32270,15 +32201,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
-        (last_rsi_3 > 93.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_4_69"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -32342,7 +32270,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -16.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_81"
       elif (
@@ -32374,7 +32302,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -32392,7 +32320,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -26.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_4_88"
       elif (
@@ -32455,7 +32383,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
@@ -32489,7 +32417,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
@@ -32647,7 +32575,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -32664,9 +32592,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_129"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_4_130"
       elif (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -32681,7 +32609,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_132"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -32690,26 +32618,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_5_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 60.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
         (last_willr_14 > -20.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
@@ -32717,8 +32645,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_4"
       elif (last_willr_14 > -10.0) and (last_rsi_14 > 64.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -32741,8 +32669,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -10.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -32750,7 +32678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -8.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_9"
@@ -32765,7 +32693,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -32788,7 +32716,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_5_16"
@@ -32800,9 +32728,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_17"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
         (last_rsi_3 > 84.0)
@@ -32818,7 +32744,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -10.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -32871,27 +32797,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_31"
-      elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -10.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_5_34"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_5_35"
@@ -32913,9 +32829,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_37"
       elif (last_rsi_3 > 65.0) and (last_willr_14 > -35.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_5_38"
-      elif (
-        (last_rsi_3 > 91.0) and (last_willr_14 > -9.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 91.0) and (last_willr_14 > -9.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
         (last_rsi_3 > 65.0)
@@ -32959,9 +32873,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_44"
       elif (last_rsi_3 > 86.0) and (last_willr_14 > -14.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_5_45"
-      elif (
-        (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_5_46"
       elif (
         (last_rsi_3 > 78.0)
@@ -33101,15 +33013,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
-        (last_rsi_3 > 92.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 92.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -33173,7 +33082,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -18.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
@@ -33205,7 +33114,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -33223,7 +33132,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -28.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_5_88"
       elif (
@@ -33286,7 +33195,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_5_95"
       elif (
@@ -33320,7 +33229,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
@@ -33478,7 +33387,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -33495,9 +33404,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_5_130"
       elif (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -33512,7 +33421,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -33521,26 +33430,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_6_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 62.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_2"
       elif (
         (last_willr_14 > -15.0)
         and (last_stochrsi_k > 98.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
@@ -33548,8 +33457,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 68.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_4"
       elif (last_willr_14 > -8.0) and (last_rsi_14 > 66.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -33572,8 +33481,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -8.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -33581,7 +33490,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -7.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_9"
@@ -33596,7 +33505,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -33619,7 +33528,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
@@ -33631,9 +33540,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_17"
-      elif (
-        (last_rsi_3 > 80.0) and (last_rsi_14 > 65.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14 > 65.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
         (last_rsi_3 > 86.0)
@@ -33649,7 +33556,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -8.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -33702,27 +33609,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_31"
-      elif (
-        (last_rsi_3 > 75.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -8.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_6_34"
       elif (last_rsi_3 > 82.0) and (last_willr_14 > -9.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_6_35"
@@ -33744,9 +33641,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_37"
       elif (last_rsi_3 > 70.0) and (last_willr_14 > -30.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_6_38"
-      elif (
-        (last_rsi_3 > 92.0) and (last_willr_14 > -8.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -8.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
         (last_rsi_3 > 70.0)
@@ -33790,9 +33685,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_44"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -12.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_6_45"
-      elif (
-        (last_rsi_3 > 75.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 75.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_6_46"
       elif (
         (last_rsi_3 > 80.0)
@@ -33932,15 +33825,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
-        (last_rsi_3 > 93.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -34004,7 +33894,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -16.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
@@ -34036,7 +33926,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -34054,7 +33944,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -26.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_6_88"
       elif (
@@ -34117,7 +34007,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
@@ -34151,7 +34041,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
@@ -34309,7 +34199,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -34326,9 +34216,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_6_130"
       elif (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -34343,7 +34233,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -34352,26 +34242,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_7_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 64.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_2"
       elif (
         (last_willr_14 > -10.0)
         and (last_stochrsi_k > 98.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_7_3"
       elif (
@@ -34379,8 +34269,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 70.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_4"
       elif (last_willr_14 > -6.0) and (last_rsi_14 > 68.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -34403,8 +34293,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -6.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -34412,7 +34302,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -6.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_9"
@@ -34427,7 +34317,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -34450,7 +34340,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_7_16"
@@ -34462,9 +34352,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_17"
-      elif (
-        (last_rsi_3 > 85.0) and (last_rsi_14 > 70.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_rsi_14 > 70.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_7_18"
       elif (
         (last_rsi_3 > 88.0)
@@ -34480,7 +34368,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -6.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -34533,27 +34421,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_31"
-      elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_7_32"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -6.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_7_34"
       elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_7_35"
@@ -34575,9 +34453,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_37"
       elif (last_rsi_3 > 75.0) and (last_willr_14 > -25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_7_38"
-      elif (
-        (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_7_39"
       elif (
         (last_rsi_3 > 75.0)
@@ -34621,9 +34497,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_44"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_7_45"
-      elif (
-        (last_rsi_3 > 80.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 80.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_7_46"
       elif (
         (last_rsi_3 > 82.0)
@@ -34763,15 +34637,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
-        (last_rsi_3 > 94.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 94.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_7_69"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -34835,7 +34706,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -14.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_81"
       elif (
@@ -34867,7 +34738,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -34885,7 +34756,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -24.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_7_88"
       elif (
@@ -34948,7 +34819,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
@@ -34982,7 +34853,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
@@ -35140,7 +35011,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -35157,9 +35028,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_129"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_7_130"
       elif (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -35174,7 +35045,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_132"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -35183,26 +35054,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_8_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 66.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_2"
       elif (
         (last_willr_14 > -8.0)
         and (last_stochrsi_k > 98.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_8_3"
       elif (
@@ -35210,8 +35081,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 72.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_4"
       elif (last_willr_14 > -4.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -35234,8 +35105,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -4.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -35243,7 +35114,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -5.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_9"
@@ -35258,7 +35129,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -35281,7 +35152,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_8_16"
@@ -35293,9 +35164,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_17"
-      elif (
-        (last_rsi_3 > 90.0) and (last_rsi_14 > 72.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14 > 72.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_8_18"
       elif (
         (last_rsi_3 > 90.0)
@@ -35311,7 +35180,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -4.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -35364,27 +35233,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_31"
-      elif (
-        (last_rsi_3 > 85.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_8_32"
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -4.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_8_34"
       elif (last_rsi_3 > 86.0) and (last_willr_14 > -7.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_8_35"
@@ -35406,9 +35265,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_37"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -20.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_8_38"
-      elif (
-        (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_8_39"
       elif (
         (last_rsi_3 > 80.0)
@@ -35452,9 +35309,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_44"
       elif (last_rsi_3 > 92.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_8_45"
-      elif (
-        (last_rsi_3 > 85.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 85.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_8_46"
       elif (
         (last_rsi_3 > 84.0)
@@ -35594,15 +35449,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 50.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_8_69"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -35666,7 +35518,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -12.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_81"
       elif (
@@ -35698,7 +35550,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -35716,7 +35568,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -22.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_8_88"
       elif (
@@ -35779,7 +35631,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_8_95"
       elif (
@@ -35813,7 +35665,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
@@ -35971,7 +35823,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -35988,9 +35840,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_129"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_8_130"
       elif (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -36005,7 +35857,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_132"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -36014,26 +35866,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_9_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 68.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_2"
       elif (
         (last_willr_14 > -6.0)
         and (last_stochrsi_k > 98.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_9_3"
       elif (
@@ -36041,8 +35893,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 74.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_4"
       elif (last_willr_14 > -2.0) and (last_rsi_14 > 72.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -36065,8 +35917,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -2.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -36074,7 +35926,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -4.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_9"
@@ -36089,7 +35941,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -36112,7 +35964,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_9_16"
@@ -36124,9 +35976,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_17"
-      elif (
-        (last_rsi_3 > 92.0) and (last_rsi_14 > 74.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_14 > 74.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_9_18"
       elif (
         (last_rsi_3 > 92.0)
@@ -36142,7 +35992,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -36195,27 +36045,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_31"
-      elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_9_32"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -2.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_9_34"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_9_35"
@@ -36237,9 +36077,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_37"
       elif (last_rsi_3 > 85.0) and (last_willr_14 > -15.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_9_38"
-      elif (
-        (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_9_39"
       elif (
         (last_rsi_3 > 85.0)
@@ -36283,9 +36121,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_44"
       elif (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_9_45"
-      elif (
-        (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_9_46"
       elif (
         (last_rsi_3 > 86.0)
@@ -36425,15 +36261,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
-        (last_rsi_3 > 96.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_9_69"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -36497,7 +36330,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_81"
       elif (
@@ -36529,7 +36362,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -36547,7 +36380,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_9_88"
       elif (
@@ -36610,7 +36443,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_9_95"
       elif (
@@ -36644,7 +36477,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
@@ -36802,7 +36635,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -36819,9 +36652,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_129"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_9_130"
       elif (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -36836,7 +36669,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_132"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -36845,26 +36678,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_10_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 70.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_2"
       elif (
         (last_willr_14 > -4.0)
         and (last_stochrsi_k > 98.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_10_3"
       elif (
@@ -36872,8 +36705,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 76.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_4"
       elif (last_willr_14 > -1.0) and (last_rsi_14 > 74.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -36896,8 +36729,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_stochrsi_k > 95.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -36905,7 +36738,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -3.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_9"
@@ -36920,7 +36753,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -36943,7 +36776,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_10_16"
@@ -36955,9 +36788,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_17"
-      elif (
-        (last_rsi_3 > 94.0) and (last_rsi_14 > 76.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_rsi_14 > 76.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_10_18"
       elif (
         (last_rsi_3 > 94.0)
@@ -36973,7 +36804,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -37026,27 +36857,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_31"
-      elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_10_32"
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_10_34"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -5.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_10_35"
@@ -37068,9 +36889,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_37"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_10_38"
-      elif (
-        (last_rsi_3 > 96.0) and (last_willr_14 > -4.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_willr_14 > -4.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_10_39"
       elif (
         (last_rsi_3 > 90.0)
@@ -37114,9 +36933,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_44"
       elif (last_rsi_3 > 96.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_10_45"
-      elif (
-        (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_10_46"
       elif (
         (last_rsi_3 > 88.0)
@@ -37256,15 +37073,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
-        (last_rsi_3 > 97.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_10_69"
       elif (last_rsi_3 > 68.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -37328,7 +37142,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -8.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_81"
       elif (
@@ -37360,7 +37174,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -37378,7 +37192,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -18.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_10_88"
       elif (
@@ -37441,7 +37255,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_10_95"
       elif (
@@ -37475,7 +37289,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
@@ -37633,7 +37447,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -37650,9 +37464,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_129"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_10_130"
       elif (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -37667,7 +37481,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_132"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -37676,26 +37490,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_11_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 74.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_2"
       elif (
         (last_willr_14 > -2.0)
         and (last_stochrsi_k > 99.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_11_3"
       elif (
@@ -37703,8 +37517,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 78.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_4"
       elif (last_willr_14 > -1.0) and (last_rsi_14 > 76.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -37727,8 +37541,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_stochrsi_k > 98.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -37736,7 +37550,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -2.0)
         and (last_rsi_3 > 95.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_9"
@@ -37751,7 +37565,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -37774,7 +37588,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_11_16"
@@ -37786,9 +37600,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_17"
-      elif (
-        (last_rsi_3 > 96.0) and (last_rsi_14 > 78.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 78.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_11_18"
       elif (
         (last_rsi_3 > 96.0)
@@ -37804,7 +37616,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -37857,27 +37669,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_31"
-      elif (
-        (last_rsi_3 > 98.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 98.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_11_32"
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_11_34"
       elif (last_rsi_3 > 92.0) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_11_35"
@@ -37899,9 +37701,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_37"
       elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_11_38"
-      elif (
-        (last_rsi_3 > 97.0) and (last_willr_14 > -3.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 97.0) and (last_willr_14 > -3.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_11_39"
       elif (
         (last_rsi_3 > 95.0)
@@ -37945,9 +37745,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_44"
       elif (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_11_45"
-      elif (
-        (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_11_46"
       elif (
         (last_rsi_3 > 90.0)
@@ -38087,15 +37885,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
-        (last_rsi_3 > 98.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 98.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_11_69"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 36.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -38159,7 +37954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -6.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_81"
       elif (
@@ -38191,7 +37986,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -38209,7 +38004,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -16.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_11_88"
       elif (
@@ -38272,7 +38067,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_11_95"
       elif (
@@ -38306,7 +38101,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
@@ -38464,7 +38259,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -38481,9 +38276,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_129"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_11_130"
       elif (last_rsi_14 < 34.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -38498,7 +38293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_132"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -38507,26 +38302,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] < last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] < last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
+        and (last_kst_1h < last_ksts_9_1h)
+        and (last_kst_4h < last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_12_1"
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (last_cmf_20_1h < -0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_2"
       elif (
         (last_willr_14 > -1.0)
         and (last_stochrsi_k > 99.0)
-        and (last_candle["CMF_20_1h"] < -0.0)
-        and (last_candle["CMF_20_4h"] < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] < -10.0))
+        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_4h < -0.0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_12_3"
       elif (
@@ -38534,8 +38329,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 80.0)
         and (last_stochrsi_k > 95.0)
         and (last_stochrsi_k_4h > 70.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] < last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] < last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_4"
       elif (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
@@ -38558,8 +38353,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_stochrsi_k > 99.0)
-        and (last_candle["CMF_20_1h"] < -0.1)
-        and (last_candle["CMF_20_4h"] < -0.1)
+        and (last_cmf_20_1h < -0.1)
+        and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -38567,7 +38362,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 > -1.0)
         and (last_rsi_3 > 99.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_9"
@@ -38582,7 +38377,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_rsi_14 < 45.0)
-        and (last_candle["ROC_9_15m"] < -10.0)
+        and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
@@ -38605,7 +38400,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_aroonu_14_4h > 25.0)
         and (last_roc_9_4h < -25.0)
-        and (last_candle["AROONU_14_1d"] > 50.0)
+        and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_12_16"
@@ -38617,9 +38412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_17"
-      elif (
-        (last_rsi_3 > 99.0) and (last_rsi_14 > 80.0) and (last_rsi_3_4h < 20.0) and (last_candle["ROC_2_1d"] < -50.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 80.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_12_18"
       elif (
         (last_rsi_3 > 99.0)
@@ -38635,7 +38428,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -38688,27 +38481,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_31"
-      elif (
-        (last_rsi_3 > 99.0)
-        and (last_rsi_3_1h < 15.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
-        and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3 > 99.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
         return True, f"exit_{mode_name}_d_12_32"
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
-        and (last_candle["ROC_2_1h"] < -10.0)
+        and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_33"
-      elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_3_15m < 30.0)
-        and (last_candle["RSI_14_1h"] > 80.0)
-        and (last_roc_9_1h > 40.0)
-      ):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_12_34"
       elif (last_rsi_3 > 94.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_12_35"
@@ -38730,9 +38513,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_37"
       elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_12_38"
-      elif (
-        (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_candle["CMF_20_4h"] < -0.0) and (last_rsi_3_4h < 10.0)
-      ):
+      elif (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_12_39"
       elif (
         (last_rsi_3 > 98.0)
@@ -38776,9 +38557,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_44"
       elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_12_45"
-      elif (
-        (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_candle["ROC_2_1d"] < -20.0)
-      ):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_12_46"
       elif (
         (last_rsi_3 > 98.0)
@@ -38918,15 +38697,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_candle["ROC_2_4h"] < -30.0)
+        and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
-        (last_rsi_3 > 99.0)
-        and (last_roc_9_4h > 20.0)
-        and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_4h"] < -5.0)
+        (last_rsi_3 > 99.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_12_69"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 34.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -38990,7 +38766,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -4.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] > 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_81"
       elif (
@@ -39022,7 +38798,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 99.0)
         and (last_rsi_14_4h > 80.0)
-        and (last_candle["ROC_2_1h"] < -5.0)
+        and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
         and (last_stochrsi_k_4h > 50.0)
       ):
@@ -39040,7 +38816,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -14.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 50.0)
-        and (last_candle["change_pct_1h"] < -2.0)
+        and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_12_88"
       elif (
@@ -39103,7 +38879,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 10.0)
-        and (isinstance(last_candle["AROONU_14_1d"], np.float64) and (last_candle["AROONU_14_1d"] > 75.0))
+        and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_12_95"
       elif (
@@ -39137,7 +38913,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] > 40.0)
+        and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
@@ -39295,7 +39071,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
         and (last_rsi_3_1d < 40.0)
-        and (last_candle["close"] < (last_candle["high_max_30_1d"] * 0.50))
+        and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
@@ -39312,9 +39088,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_129"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_candle["RSI_14_1h"] > 65.0)
+        and (last_rsi_14_1h > 65.0)
         and (last_stochrsi_k_1h > 80.0)
-        and (last_candle["CCI_20_change_pct_1h"] < -0.0)
+        and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_12_130"
       elif (last_rsi_14 < 32.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
@@ -39329,7 +39105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_132"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_candle["AROONU_14_15m"] > 75.0)
+        and (last_aroonu_14_15m > 75.0)
         and (last_aroonu_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):


### PR DESCRIPTION
## Summary
- Reuses concrete `last_candle[...]` values in `long_exit_dec()` instead of reading the same Series fields repeatedly.
- Branch is based on latest upstream `main`.

## Safety
- This only replaces repeated `last_candle[...]` reads with local variables inside the same function call.
- Indicators, candle selection, condition order, thresholds, profit arithmetic, order classification, and return values are unchanged.
- Touched function: `long_exit_dec()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this local-read reuse patch because it does not change trading conditions or calculated values; it only reuses already-read candle fields inside the same exit decision function.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in the validator for `last_*` / `previous_*` / `current_*` locals
- `git merge-tree` conflict simulation against `origin/main` included in the validator
- Targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
