### PR TITLE
Reuse X7 short dec candle reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -51816,30 +51816,54 @@ class NostalgiaForInfinityX7(IStrategy):
     last_stochrsi_k_1h = last_candle["STOCHRSIk_14_14_3_3_1h"]
     last_stochrsi_k_1d = last_candle["STOCHRSIk_14_14_3_3_1d"]
     last_roc_9_4h = last_candle["ROC_9_4h"]
+    last_aroond_14_1d = last_candle["AROOND_14_1d"]
+    last_cmf_20_1h = last_candle["CMF_20_1h"]
+    last_cmf_20_4h = last_candle["CMF_20_4h"]
+    last_ema_12_1h = last_candle["EMA_12_1h"]
+    last_ema_12_4h = last_candle["EMA_12_4h"]
+    last_change_pct_4h = last_candle["change_pct_4h"]
+    last_roc_2_1d = last_candle["ROC_2_1d"]
+    last_roc_2_1h = last_candle["ROC_2_1h"]
+    last_roc_2_4h = last_candle["ROC_2_4h"]
+    last_rsi_14_1d = last_candle["RSI_14_1d"]
+    last_rsi_14_1h = last_candle["RSI_14_1h"]
+    last_aroond_14_15m = last_candle["AROOND_14_15m"]
+    last_aroonu_14_1h = last_candle["AROONU_14_1h"]
+    last_cci_20_change_pct_1h = last_candle["CCI_20_change_pct_1h"]
+    last_kst_1h = last_candle["KST_10_15_20_30_10_10_10_15_1h"]
+    last_kst_4h = last_candle["KST_10_15_20_30_10_10_10_15_4h"]
+    last_ksts_9_1h = last_candle["KSTs_9_1h"]
+    last_ksts_9_4h = last_candle["KSTs_9_4h"]
+    last_roc_9_15m = last_candle["ROC_9_15m"]
+    last_stochrsi_k_change_pct_4h = last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"]
+    last_stoch_k_4h = last_candle["STOCHk_14_3_3_4h"]
+    last_change_pct_1h = last_candle["change_pct_1h"]
+    last_close = last_candle["close"]
+    last_low_min_30_1d = last_candle["low_min_30_1d"]
     if 0.01 > current_profit >= 0.001:
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
         (last_willr_14 <= -99.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_2"
       elif (
         (last_willr_14 <= -99.0)
         and (last_stochrsi_k < 1.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
@@ -51847,8 +51871,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 22.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
       elif (last_willr_14 <= -99.0) and (last_rsi_14 < 22.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -51871,8 +51895,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_stochrsi_k < 1.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -51880,7 +51904,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_3 < 1.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
@@ -51895,7 +51919,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -51918,7 +51942,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
@@ -51930,7 +51954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_0_17"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
         (last_rsi_3 < 1.0)
@@ -51946,7 +51970,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -51999,27 +52023,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_31"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_0_34"
       elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_0_35"
@@ -52041,9 +52055,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_37"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_0_38"
-      elif (
-        (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
         (last_rsi_3 < 2.0)
@@ -52087,9 +52099,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_44"
       elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_0_45"
-      elif (
-        (last_rsi_3 < 2.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_0_46"
       elif (
         (last_rsi_3 < 2.0)
@@ -52229,15 +52239,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
-        (last_rsi_3 < 3.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -52301,7 +52308,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
@@ -52333,7 +52340,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -52351,7 +52358,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -98.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
@@ -52414,7 +52421,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
@@ -52448,7 +52455,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
@@ -52572,12 +52579,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_115"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_0_116"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0):
         return True, f"exit_{mode_name}_d_0_117"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_0_118"
@@ -52609,7 +52611,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -52626,9 +52628,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_0_130"
       elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -52643,7 +52645,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -52652,26 +52654,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_1_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 32.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_2"
       elif (
         (last_willr_14 < -92.0)
         and (last_stochrsi_k < 1.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_3"
       elif (
@@ -52679,8 +52681,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_4"
       elif (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -52703,8 +52705,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -98.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -52712,7 +52714,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -98.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_9"
@@ -52727,7 +52729,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -52750,7 +52752,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_16"
@@ -52762,9 +52764,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_1_17"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_1_18"
       elif (
         (last_rsi_3 < 5.0)
@@ -52780,7 +52780,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -52833,27 +52833,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_31"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_1_32"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -98.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_1_34"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_1_35"
@@ -52875,9 +52865,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_37"
       elif (last_rsi_3 < 15.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_1_38"
-      elif (
-        (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_1_39"
       elif (
         (last_rsi_3 < 15.0)
@@ -52921,9 +52909,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_44"
       elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_1_45"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_1_46"
       elif (
         (last_rsi_3 < 14.0)
@@ -53063,15 +53049,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
-        (last_rsi_3 < 4.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 4.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_69"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -53135,7 +53118,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_81"
       elif (
@@ -53167,7 +53150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -53185,7 +53168,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_1_88"
       elif (
@@ -53248,7 +53231,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_1_95"
       elif (
@@ -53282,7 +53265,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
@@ -53407,10 +53390,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_1_116"
       elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 14.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_117"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -53443,7 +53423,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -53460,9 +53440,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_129"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_1_130"
       elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -53477,7 +53457,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_132"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -53486,26 +53466,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_2_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_2"
       elif (
         (last_willr_14 < -90.0)
         and (last_stochrsi_k < 1.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_3"
       elif (
@@ -53513,8 +53493,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_4"
       elif (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -53537,8 +53517,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -96.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -53546,7 +53526,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -96.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_9"
@@ -53561,7 +53541,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -53584,7 +53564,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_16"
@@ -53596,9 +53576,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_2_17"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_2_18"
       elif (
         (last_rsi_3 < 10.0)
@@ -53614,7 +53592,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -96.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -53667,27 +53645,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_31"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_2_32"
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -96.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_2_34"
       elif (last_rsi_3 < 14.0) and (last_willr_14 < -93.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_2_35"
@@ -53709,9 +53677,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_37"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_2_38"
-      elif (
-        (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_2_39"
       elif (
         (last_rsi_3 < 20.0)
@@ -53755,9 +53721,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_44"
       elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_2_45"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_2_46"
       elif (
         (last_rsi_3 < 16.0)
@@ -53897,15 +53861,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 5.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_69"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -53969,7 +53930,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_81"
       elif (
@@ -54001,7 +53962,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -54019,7 +53980,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -78.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_2_88"
       elif (
@@ -54082,7 +54043,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_2_95"
       elif (
@@ -54116,7 +54077,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
@@ -54241,10 +54202,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_2_116"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 16.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_117"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -54277,7 +54235,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -54294,9 +54252,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_129"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_2_130"
       elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -54311,7 +54269,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_132"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -54320,26 +54278,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_3_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 36.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
         (last_willr_14 < -80.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
@@ -54347,8 +54305,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_4"
       elif (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -54371,8 +54329,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -94.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -54380,7 +54338,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -94.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
@@ -54395,7 +54353,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -54418,7 +54376,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
@@ -54430,9 +54388,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_3_17"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
         (last_rsi_3 < 12.0)
@@ -54448,7 +54404,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -94.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -54501,27 +54457,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_31"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_3_34"
       elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_3_35"
@@ -54543,9 +54489,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_37"
       elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_3_38"
-      elif (
-        (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
         (last_rsi_3 < 25.0)
@@ -54589,9 +54533,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_44"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_3_45"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_3_46"
       elif (
         (last_rsi_3 < 18.0)
@@ -54731,15 +54673,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 6.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_69"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -54803,7 +54742,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
@@ -54835,7 +54774,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -54853,7 +54792,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -76.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_3_88"
       elif (
@@ -54916,7 +54855,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
@@ -54950,7 +54889,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
@@ -55075,10 +55014,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_3_116"
       elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 18.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_117"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -55111,7 +55047,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -55128,9 +55064,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_3_130"
       elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -55145,7 +55081,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -55154,26 +55090,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_4_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_2"
       elif (
         (last_willr_14 < -80.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_3"
       elif (
@@ -55181,8 +55117,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_4"
       elif (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -55205,8 +55141,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -92.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -55214,7 +55150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -93.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_9"
@@ -55229,7 +55165,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -55252,7 +55188,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_16"
@@ -55264,9 +55200,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_4_17"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_4_18"
       elif (
         (last_rsi_3 < 14.0)
@@ -55282,7 +55216,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -92.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -55335,27 +55269,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_31"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_4_32"
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -92.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_4_34"
       elif (last_rsi_3 < 18.0) and (last_willr_14 < -91.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_4_35"
@@ -55377,9 +55301,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_37"
       elif (last_rsi_3 < 30.0) and (last_willr_14 < -70.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_4_38"
-      elif (
-        (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_4_39"
       elif (
         (last_rsi_3 < 30.0)
@@ -55423,9 +55345,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_44"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_4_45"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_4_46"
       elif (
         (last_rsi_3 < 20.0)
@@ -55565,15 +55485,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
-        (last_rsi_3 < 7.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 7.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_69"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -55637,7 +55554,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_81"
       elif (
@@ -55669,7 +55586,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -55687,7 +55604,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -74.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_4_88"
       elif (
@@ -55750,7 +55667,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
@@ -55784,7 +55701,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
@@ -55909,10 +55826,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_4_116"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 20.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_117"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -55945,7 +55859,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -55962,9 +55876,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_129"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_4_130"
       elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -55979,7 +55893,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_132"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -55988,26 +55902,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_5_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 40.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
         (last_willr_14 < -80.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
@@ -56015,8 +55929,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_4"
       elif (last_willr_14 < -90.0) and (last_rsi_14 < 36.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -56039,8 +55953,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -90.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -56048,7 +55962,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -92.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_9"
@@ -56063,7 +55977,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -56086,7 +56000,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_5_16"
@@ -56098,9 +56012,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_5_17"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
         (last_rsi_3 < 16.0)
@@ -56116,7 +56028,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -90.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -56169,27 +56081,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_31"
-      elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -90.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_5_34"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_5_35"
@@ -56211,9 +56113,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_37"
       elif (last_rsi_3 < 35.0) and (last_willr_14 < -65.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_38"
-      elif (
-        (last_rsi_3 < 9.0) and (last_willr_14 < -91.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 9.0) and (last_willr_14 < -91.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
         (last_rsi_3 < 35.0)
@@ -56257,9 +56157,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_44"
       elif (last_rsi_3 < 14.0) and (last_willr_14 < -86.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_5_45"
-      elif (
-        (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_5_46"
       elif (
         (last_rsi_3 < 22.0)
@@ -56399,15 +56297,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
-        (last_rsi_3 < 8.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 8.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -56471,7 +56366,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -82.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
@@ -56503,7 +56398,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -56521,7 +56416,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -72.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_5_88"
       elif (
@@ -56584,7 +56479,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_5_95"
       elif (
@@ -56618,7 +56513,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
@@ -56743,10 +56638,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_5_116"
       elif (
-        (last_rsi_3 < 22.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 22.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_117"
       elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -56779,7 +56671,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -56796,9 +56688,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_5_130"
       elif (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -56813,7 +56705,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -56822,26 +56714,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_6_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 38.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_2"
       elif (
         (last_willr_14 < -85.0)
         and (last_stochrsi_k < 2.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
@@ -56849,8 +56741,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 32.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_4"
       elif (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -56873,8 +56765,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -92.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -56882,7 +56774,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -93.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_9"
@@ -56897,7 +56789,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -56920,7 +56812,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
@@ -56932,9 +56824,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_6_17"
-      elif (
-        (last_rsi_3 < 20.0) and (last_rsi_14 < 35.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14 < 35.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
         (last_rsi_3 < 14.0)
@@ -56950,7 +56840,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -92.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -57003,27 +56893,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_31"
-      elif (
-        (last_rsi_3 < 25.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -92.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_6_34"
       elif (last_rsi_3 < 18.0) and (last_willr_14 < -91.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_6_35"
@@ -57045,9 +56925,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_37"
       elif (last_rsi_3 < 30.0) and (last_willr_14 < -70.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_38"
-      elif (
-        (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
         (last_rsi_3 < 30.0)
@@ -57091,9 +56969,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_44"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_6_45"
-      elif (
-        (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_6_46"
       elif (
         (last_rsi_3 < 20.0)
@@ -57233,15 +57109,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
-        (last_rsi_3 < 7.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 7.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -57305,7 +57178,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -84.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
@@ -57337,7 +57210,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -57355,7 +57228,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -74.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_6_88"
       elif (
@@ -57418,7 +57291,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
@@ -57452,7 +57325,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
@@ -57577,10 +57450,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_6_116"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 20.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_117"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -57613,7 +57483,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -57630,9 +57500,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_6_130"
       elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -57647,7 +57517,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -57656,26 +57526,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_7_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 36.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_2"
       elif (
         (last_willr_14 < -90.0)
         and (last_stochrsi_k < 2.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_3"
       elif (
@@ -57683,8 +57553,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 30.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_4"
       elif (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -57707,8 +57577,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -94.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -57716,7 +57586,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -94.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_9"
@@ -57731,7 +57601,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -57754,7 +57624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_16"
@@ -57766,9 +57636,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_7_17"
-      elif (
-        (last_rsi_3 < 15.0) and (last_rsi_14 < 30.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_rsi_14 < 30.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_7_18"
       elif (
         (last_rsi_3 < 12.0)
@@ -57784,7 +57652,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -94.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -57837,27 +57705,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_31"
-      elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_7_32"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_7_34"
       elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_7_35"
@@ -57879,9 +57737,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_37"
       elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_7_38"
-      elif (
-        (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_7_39"
       elif (
         (last_rsi_3 < 25.0)
@@ -57925,9 +57781,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_44"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_7_45"
-      elif (
-        (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_7_46"
       elif (
         (last_rsi_3 < 18.0)
@@ -58067,15 +57921,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
-        (last_rsi_3 < 6.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 6.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_69"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -58139,7 +57990,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -86.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_81"
       elif (
@@ -58171,7 +58022,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -58189,7 +58040,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -76.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_7_88"
       elif (
@@ -58252,7 +58103,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
@@ -58286,7 +58137,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
@@ -58411,10 +58262,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_7_116"
       elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 18.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_117"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -58447,7 +58295,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -58464,9 +58312,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_129"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_7_130"
       elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -58481,7 +58329,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_132"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -58490,26 +58338,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_8_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 34.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_2"
       elif (
         (last_willr_14 < -92.0)
         and (last_stochrsi_k < 2.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_3"
       elif (
@@ -58517,8 +58365,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 28.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_4"
       elif (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -58541,8 +58389,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -96.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -58550,7 +58398,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -95.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_9"
@@ -58565,7 +58413,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -58588,7 +58436,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_16"
@@ -58600,9 +58448,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_8_17"
-      elif (
-        (last_rsi_3 < 10.0) and (last_rsi_14 < 28.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 28.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_8_18"
       elif (
         (last_rsi_3 < 10.0)
@@ -58618,7 +58464,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -96.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -58671,27 +58517,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_31"
-      elif (
-        (last_rsi_3 < 15.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_8_32"
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -96.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_8_34"
       elif (last_rsi_3 < 14.0) and (last_willr_14 < -93.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_8_35"
@@ -58713,9 +58549,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_37"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_8_38"
-      elif (
-        (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_8_39"
       elif (
         (last_rsi_3 < 20.0)
@@ -58759,9 +58593,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_44"
       elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_8_45"
-      elif (
-        (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_8_46"
       elif (
         (last_rsi_3 < 16.0)
@@ -58901,15 +58733,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 50.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 5.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_69"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -58973,7 +58802,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -88.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_81"
       elif (
@@ -59005,7 +58834,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -59023,7 +58852,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -78.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_8_88"
       elif (
@@ -59086,7 +58915,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_8_95"
       elif (
@@ -59120,7 +58949,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
@@ -59245,10 +59074,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_8_116"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 16.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_117"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -59281,7 +59107,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -59298,9 +59124,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_129"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_8_130"
       elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -59315,7 +59141,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_132"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -59324,26 +59150,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_9_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 32.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_2"
       elif (
         (last_willr_14 < -94.0)
         and (last_stochrsi_k < 2.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_3"
       elif (
@@ -59351,8 +59177,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 26.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_4"
       elif (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -59375,8 +59201,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -98.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -59384,7 +59210,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -96.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_9"
@@ -59399,7 +59225,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -59422,7 +59248,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_16"
@@ -59434,7 +59260,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_9_17"
-      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 26.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 26.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_9_18"
       elif (
         (last_rsi_3 < 8.0)
@@ -59450,7 +59276,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -59503,27 +59329,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_31"
-      elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_9_32"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -98.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_9_34"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_9_35"
@@ -59545,9 +59361,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_37"
       elif (last_rsi_3 < 15.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_9_38"
-      elif (
-        (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_9_39"
       elif (
         (last_rsi_3 < 15.0)
@@ -59591,9 +59405,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_44"
       elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_9_45"
-      elif (
-        (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_9_46"
       elif (
         (last_rsi_3 < 14.0)
@@ -59733,15 +59545,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
-        (last_rsi_3 < 4.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 4.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_69"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -59805,7 +59614,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_81"
       elif (
@@ -59837,7 +59646,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -59855,7 +59664,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_9_88"
       elif (
@@ -59918,7 +59727,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_9_95"
       elif (
@@ -59952,7 +59761,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
@@ -60077,10 +59886,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_9_116"
       elif (
-        (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 14.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_117"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -60113,7 +59919,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -60130,9 +59936,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_129"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_9_130"
       elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -60147,7 +59953,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_132"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -60156,26 +59962,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_10_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 30.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_2"
       elif (
         (last_willr_14 < -96.0)
         and (last_stochrsi_k < 2.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_3"
       elif (
@@ -60183,8 +59989,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 24.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_4"
       elif (last_willr_14 < -99.0) and (last_rsi_14 < 26.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -60207,8 +60013,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_stochrsi_k < 5.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -60216,7 +60022,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -97.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_9"
@@ -60231,7 +60037,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -60254,7 +60060,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_16"
@@ -60266,7 +60072,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_10_17"
-      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 24.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 24.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_10_18"
       elif (
         (last_rsi_3 < 6.0)
@@ -60282,7 +60088,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -60335,27 +60141,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_31"
-      elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_10_32"
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_10_34"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -95.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_10_35"
@@ -60377,9 +60173,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_37"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_10_38"
-      elif (
-        (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_10_39"
       elif (
         (last_rsi_3 < 10.0)
@@ -60423,9 +60217,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_44"
       elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_10_45"
-      elif (
-        (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_10_46"
       elif (
         (last_rsi_3 < 12.0)
@@ -60565,15 +60357,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
-        (last_rsi_3 < 3.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_69"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -60637,7 +60426,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -92.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_81"
       elif (
@@ -60669,7 +60458,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -60687,7 +60476,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -82.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_10_88"
       elif (
@@ -60750,7 +60539,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_10_95"
       elif (
@@ -60784,7 +60573,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
@@ -60909,10 +60698,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_10_116"
       elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 12.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_117"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -60945,7 +60731,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -60962,9 +60748,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_129"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_10_130"
       elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -60979,7 +60765,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_132"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -60988,26 +60774,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_11_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 26.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_2"
       elif (
         (last_willr_14 < -98.0)
         and (last_stochrsi_k < 1.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_3"
       elif (
@@ -61015,8 +60801,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 22.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_4"
       elif (last_willr_14 < -99.0) and (last_rsi_14 < 24.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -61039,8 +60825,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_stochrsi_k < 2.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -61048,7 +60834,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -98.0)
         and (last_rsi_3 < 5.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_9"
@@ -61063,7 +60849,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -61086,7 +60872,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_16"
@@ -61098,7 +60884,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_11_17"
-      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 22.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 22.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_11_18"
       elif (
         (last_rsi_3 < 4.0)
@@ -61114,7 +60900,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -61167,27 +60953,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_31"
-      elif (
-        (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_11_32"
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_11_34"
       elif (last_rsi_3 < 8.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_11_35"
@@ -61209,9 +60985,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_37"
       elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_11_38"
-      elif (
-        (last_rsi_3 < 3.0) and (last_willr_14 < -97.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 3.0) and (last_willr_14 < -97.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_11_39"
       elif (
         (last_rsi_3 < 5.0)
@@ -61255,9 +61029,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_44"
       elif (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_11_45"
-      elif (
-        (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_11_46"
       elif (
         (last_rsi_3 < 10.0)
@@ -61397,15 +61169,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 2.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_69"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -61469,7 +61238,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -94.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_81"
       elif (
@@ -61501,7 +61270,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -61519,7 +61288,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -84.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_11_88"
       elif (
@@ -61582,7 +61351,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_11_95"
       elif (
@@ -61616,7 +61385,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
@@ -61741,10 +61510,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_11_116"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
+        (last_rsi_3 < 10.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_117"
       elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
@@ -61777,7 +61543,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -61794,9 +61560,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_129"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_11_130"
       elif (last_rsi_14 > 66.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -61811,7 +61577,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_132"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -61820,26 +61586,26 @@ class NostalgiaForInfinityX7(IStrategy):
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
-        and (last_candle["KST_10_15_20_30_10_10_10_15_1h"] > last_candle["KSTs_9_1h"])
-        and (last_candle["KST_10_15_20_30_10_10_10_15_4h"] > last_candle["KSTs_9_4h"])
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
+        and (last_kst_1h > last_ksts_9_1h)
+        and (last_kst_4h > last_ksts_9_4h)
       ):
         return True, f"exit_{mode_name}_d_12_1"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (last_cmf_20_1h > 0.0)
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_2"
       elif (
         (last_willr_14 < -99.0)
         and (last_stochrsi_k < 1.0)
-        and (last_candle["CMF_20_1h"] > 0.0)
-        and (last_candle["CMF_20_4h"] > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_candle["STOCHRSIk_14_14_3_3_change_pct_4h"] > 10.0))
+        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_4h > 0.0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_3"
       elif (
@@ -61847,8 +61613,8 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 20.0)
         and (last_stochrsi_k < 5.0)
         and (last_stochrsi_k_4h < 30.0)
-        and (isinstance(last_ema_200_1h, np.float64) and (last_candle["EMA_12_1h"] > last_ema_200_1h))
-        and (isinstance(last_ema_200_4h, np.float64) and (last_candle["EMA_12_4h"] > last_ema_200_4h))
+        and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
+        and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_4"
       elif (last_willr_14 < -99.0) and (last_rsi_14 < 22.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
@@ -61871,8 +61637,8 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_stochrsi_k < 1.0)
-        and (last_candle["CMF_20_1h"] > 0.1)
-        and (last_candle["CMF_20_4h"] > 0.1)
+        and (last_cmf_20_1h > 0.1)
+        and (last_cmf_20_4h > 0.1)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -61880,7 +61646,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_3 < 1.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_9"
@@ -61895,7 +61661,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14 > 55.0)
-        and (last_candle["ROC_9_15m"] > 10.0)
+        and (last_roc_9_15m > 10.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
@@ -61918,7 +61684,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_aroond_14_4h > 25.0)
         and (last_roc_9_4h > 25.0)
-        and (last_candle["AROOND_14_1d"] > 50.0)
+        and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_16"
@@ -61930,7 +61696,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_12_17"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_rsi_3_4h > 80.0) and (last_candle["ROC_2_1d"] > 50.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_12_18"
       elif (
         (last_rsi_3 < 1.0)
@@ -61946,7 +61712,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -61999,27 +61765,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_31"
-      elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_3_1h > 85.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
-        and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_12_32"
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
-        and (last_candle["ROC_2_1h"] > 10.0)
+        and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_33"
-      elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_3_15m > 70.0)
-        and (last_candle["RSI_14_1h"] < 20.0)
-        and (last_roc_9_1h < -40.0)
-      ):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_12_34"
       elif (last_rsi_3 < 6.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_12_35"
@@ -62041,9 +61797,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_37"
       elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_12_38"
-      elif (
-        (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_candle["CMF_20_4h"] > 0.0) and (last_rsi_3_4h > 90.0)
-      ):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_12_39"
       elif (
         (last_rsi_3 < 2.0)
@@ -62087,9 +61841,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_44"
       elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_12_45"
-      elif (
-        (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_candle["ROC_2_1d"] > 20.0)
-      ):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_12_46"
       elif (
         (last_rsi_3 < 2.0)
@@ -62229,15 +61981,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_candle["ROC_2_4h"] > 30.0)
+        and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_roc_9_4h < -20.0)
-        and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_4h"] > 5.0)
+        (last_rsi_3 < 1.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_69"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 66.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -62301,7 +62050,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -96.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
-        and (isinstance(last_candle["RSI_14_1d"], np.float64) and (last_candle["RSI_14_1d"] < 50.0))
+        and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_81"
       elif (
@@ -62333,7 +62082,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 1.0)
         and (last_rsi_14_4h < 20.0)
-        and (last_candle["ROC_2_1h"] > 5.0)
+        and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
         and (last_stochrsi_k_4h < 50.0)
       ):
@@ -62351,7 +62100,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -86.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 50.0)
-        and (last_candle["change_pct_1h"] > 2.0)
+        and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_12_88"
       elif (
@@ -62414,7 +62163,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h < 90.0)
-        and (isinstance(last_candle["AROOND_14_1d"], np.float64) and (last_candle["AROOND_14_1d"] > 75.0))
+        and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_12_95"
       elif (
@@ -62448,7 +62197,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_candle["STOCHk_14_3_3_4h"] < 60.0)
+        and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
@@ -62572,12 +62321,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_115"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
         return True, f"exit_{mode_name}_d_12_116"
-      elif (
-        (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_candle["AROONU_14_1h"] < 20.0)
-        and (last_aroonu_14_4h < 20.0)
-      ):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0):
         return True, f"exit_{mode_name}_d_12_117"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_12_118"
@@ -62609,7 +62353,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
         and (last_rsi_3_1d > 60.0)
-        and (last_candle["close"] > (last_candle["low_min_30_1d"] * 2.0))
+        and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
@@ -62626,9 +62370,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_129"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_candle["RSI_14_1h"] < 35.0)
+        and (last_rsi_14_1h < 35.0)
         and (last_stochrsi_k_1h < 20.0)
-        and (last_candle["CCI_20_change_pct_1h"] > 0.0)
+        and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_12_130"
       elif (last_rsi_14 > 68.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
@@ -62643,7 +62387,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_132"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_candle["AROOND_14_15m"] > 75.0)
+        and (last_aroond_14_15m > 75.0)
         and (last_aroond_14_1h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):


### PR DESCRIPTION
## Summary
- Reuses concrete `last_candle[...]` values in `short_exit_dec()` instead of reading the same Series fields repeatedly.
- Branch is based on latest upstream `main`.

## Safety
- This only replaces repeated `last_candle[...]` reads with local variables inside the same function call.
- Indicators, candle selection, condition order, thresholds, profit arithmetic, order classification, and return values are unchanged.
- Touched function: `short_exit_dec()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this local-read reuse patch because it does not change trading conditions or calculated values; it only reuses already-read candle fields inside the same exit decision function.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in the validator for `last_*` / `previous_*` / `current_*` locals
- `git merge-tree` conflict simulation against `origin/main` included in the validator
- Targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
