### PR TITLE
Reuse X7 exit target lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -24894,10 +24894,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -24963,7 +24964,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
@@ -25015,7 +25016,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -48054,10 +48055,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -48123,7 +48125,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
@@ -48175,7 +48177,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -48327,10 +48329,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -48395,7 +48398,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
@@ -48440,7 +48443,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -48627,10 +48630,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -48696,7 +48700,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
@@ -48748,7 +48752,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -48926,10 +48930,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -48994,7 +48999,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
@@ -49039,7 +49044,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -49170,10 +49175,11 @@ class NostalgiaForInfinityX7(IStrategy):
       )
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -49238,7 +49244,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
@@ -49283,7 +49289,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.03:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -49511,10 +49517,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -49580,7 +49587,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
@@ -49632,7 +49639,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -49813,10 +49820,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -49882,7 +49890,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if sell and signal_name is not None:
       previous_profit = None
       previous_sell_reason = ""
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
         previous_sell_reason = target_data["sell_reason"]
@@ -49934,7 +49942,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):
@@ -50112,10 +50120,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
+    profit_target_get = cache_data.get if cache_data is not None else None
 
     # Profit Target Signal
     # Check if pair exist on target_profit_cache
-    target_data = cache_data.get(pair) if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
     if target_data is not None:
       previous_rate = target_data["rate"]
       previous_profit = target_data["profit"]
@@ -50180,7 +50189,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Add the pair to the list, if a sell triggered and conditions met
     if sell and signal_name is not None:
       previous_profit = None
-      target_data = cache_data.get(pair) if cache_data is not None else None
+      target_data = profit_target_get(pair) if profit_target_get is not None else None
       if target_data is not None:
         previous_profit = target_data["profit"]
       if signal_name in [
@@ -50225,7 +50234,7 @@ class NostalgiaForInfinityX7(IStrategy):
     else:
       if profit_init_ratio >= 0.005:
         previous_profit = None
-        target_data = cache_data.get(pair) if cache_data is not None else None
+        target_data = profit_target_get(pair) if profit_target_get is not None else None
         if target_data is not None:
           previous_profit = target_data["profit"]
         if (previous_profit is None) or (previous_profit < profit_init_ratio):


### PR DESCRIPTION
## Summary
- Reuses the `target_profit_cache` getter in X7 exit target wrappers instead of repeating the same `cache_data.get(pair)` lookup pattern.
- Branch is based on latest upstream `main`.

## Safety
- This keeps the existing target-profit cache object, pair key, target data checks, mark/update flow, and return values unchanged.
- Indicators, candle selection, order classification, profit arithmetic, thresholds, condition order, and target-profit values are unchanged.
- Touched functions: `long_exit_normal()`, `short_exit_normal()`, `short_exit_pump()`, `short_exit_quick()`, `short_exit_rebuy()`, `short_exit_high_profit()`, `short_exit_rapid()`, `short_exit_top_coins()`, and `short_exit_scalp()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this lookup-reuse patch because it only reuses the same cache getter inside the same call; trading conditions, target-profit values, and exits remain unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in the validator for `last_*` / `previous_*` / `current_*` locals
- `git merge-tree` conflict simulation against `origin/main` included in the validator
- Targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
