### PR TITLE
Reuse X7 stoploss exit fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -39367,6 +39367,8 @@ class NostalgiaForInfinityX7(IStrategy):
     is_futures_mode = self.is_futures_mode
     doom_stops_enable = self.doom_stops_enable
     trade_leverage = trade.leverage
+    stoploss_doom = f"exit_{mode_name}_stoploss_doom"
+    stoploss_u_e = f"exit_{mode_name}_stoploss_u_e"
 
     is_backtest = self.is_backtest_mode()
     trade_open_date = None if is_backtest else trade.open_date_utc.replace(tzinfo=None)
@@ -39389,7 +39391,7 @@ class NostalgiaForInfinityX7(IStrategy):
           / trade_leverage
         )
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
     elif is_system_v3_1:
       # Stoploss doom
       if doom_stops_enable and (
@@ -39404,7 +39406,7 @@ class NostalgiaForInfinityX7(IStrategy):
           / trade_leverage
         )
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
     elif is_system_v3:
       # Stoploss doom
       if doom_stops_enable and (
@@ -39417,7 +39419,7 @@ class NostalgiaForInfinityX7(IStrategy):
           / trade_leverage
         )
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
     else:
       # Stoploss doom
       if (
@@ -39432,11 +39434,14 @@ class NostalgiaForInfinityX7(IStrategy):
         # temporary
         and (is_backtest or trade_open_date >= datetime(2024, 9, 13))
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
 
     last_close = last_candle["close"]
     last_ema_200 = last_candle["EMA_200"]
     last_rsi_14 = last_candle["RSI_14"]
+    last_cmf_20 = last_candle["CMF_20"]
+    last_rsi_14_1h = last_candle["RSI_14_1h"]
+    previous_rsi_14 = previous_candle_1["RSI_14"]
 
     # Stoploss u_e
     if (
@@ -39449,15 +39454,15 @@ class NostalgiaForInfinityX7(IStrategy):
         )
       )
       and (last_close < last_ema_200)
-      and (last_candle["CMF_20"] < -0.0)
+      and (last_cmf_20 < -0.0)
       and (((last_ema_200 - last_close) / last_close) < 0.010)
-      and (last_rsi_14 > previous_candle_1["RSI_14"])
-      and (last_rsi_14 > (last_candle["RSI_14_1h"] + 24.0))
+      and (last_rsi_14 > previous_rsi_14)
+      and (last_rsi_14 > (last_rsi_14_1h + 24.0))
       # and (current_time - timedelta(minutes=720) > trade.open_date_utc)
       # temporary
       and (is_backtest or trade_open_date >= datetime(2025, 4, 3))
     ):
-      return True, f"exit_{mode_name}_stoploss_u_e"
+      return True, stoploss_u_e
 
     #  Here ends exit signal conditions for long_exit_stoploss
 
@@ -62681,6 +62686,8 @@ class NostalgiaForInfinityX7(IStrategy):
     is_futures_mode = self.is_futures_mode
     doom_stops_enable = self.doom_stops_enable
     trade_leverage = trade.leverage
+    stoploss_doom = f"exit_{mode_name}_stoploss_doom"
+    stoploss_u_e = f"exit_{mode_name}_stoploss_u_e"
 
     is_backtest = self.is_backtest_mode()
     trade_open_date = None if is_backtest else trade.open_date_utc.replace(tzinfo=None)
@@ -62703,7 +62710,7 @@ class NostalgiaForInfinityX7(IStrategy):
           / trade_leverage
         )
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
     elif is_system_v3_1:
       # Stoploss doom
       if doom_stops_enable and (
@@ -62718,7 +62725,7 @@ class NostalgiaForInfinityX7(IStrategy):
           / trade_leverage
         )
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
     elif is_system_v3:
       # Stoploss doom
       if doom_stops_enable and (
@@ -62731,7 +62738,7 @@ class NostalgiaForInfinityX7(IStrategy):
           / trade_leverage
         )
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
     else:
       # Stoploss doom
       if (
@@ -62746,11 +62753,14 @@ class NostalgiaForInfinityX7(IStrategy):
         # temporary
         and (is_backtest or trade_open_date >= datetime(2024, 9, 13))
       ):
-        return True, f"exit_{mode_name}_stoploss_doom"
+        return True, stoploss_doom
 
     last_close = last_candle["close"]
     last_ema_200 = last_candle["EMA_200"]
     last_rsi_14 = last_candle["RSI_14"]
+    last_cmf_20 = last_candle["CMF_20"]
+    last_rsi_14_1h = last_candle["RSI_14_1h"]
+    previous_rsi_14 = previous_candle_1["RSI_14"]
 
     # Stoploss u_e
     if (
@@ -62763,15 +62773,15 @@ class NostalgiaForInfinityX7(IStrategy):
         )
       )
       and (last_close > last_ema_200)
-      and (last_candle["CMF_20"] > 0.0)
+      and (last_cmf_20 > 0.0)
       and (((last_close - last_ema_200) / last_ema_200) < 0.010)
-      and (last_rsi_14 < previous_candle_1["RSI_14"])
-      and (last_rsi_14 < (last_candle["RSI_14_1h"] - 24.0))
+      and (last_rsi_14 < previous_rsi_14)
+      and (last_rsi_14 < (last_rsi_14_1h - 24.0))
       # and (current_time - timedelta(minutes=720) > trade.open_date_utc)
       # temporary
       and (is_backtest or trade_open_date >= datetime(2025, 4, 3))
     ):
-      return True, f"exit_{mode_name}_stoploss_u_e"
+      return True, stoploss_u_e
 
     #  Here ends exit signal conditions for short_exit_stoploss
 


### PR DESCRIPTION
## Summary
- Reuses stoploss signal labels and already-read candle fields in the long/short X7 stoploss exit checks.
- Branch is based on latest upstream `main`.

## Safety
- This only replaces repeated string formatting and repeated candle field reads with local variables inside the same function call.
- Stoploss thresholds, profit arithmetic, candle selection, entry-condition checks, condition order, and returned signal strings are unchanged.
- Touched functions: `long_exit_stoploss()` and `short_exit_stoploss()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this local-read/string-label reuse patch because it does not change trading conditions or calculated values; it only reuses values that were already read in the same stoploss functions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in the validator for `last_*` / `previous_*` / `current_*` locals
- `git merge-tree` conflict simulation against `origin/main` included in the validator
- Targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
