### PR TITLE
Reuse X7 grind v2 adjust candle reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -40047,18 +40047,23 @@ class NostalgiaForInfinityX7(IStrategy):
       )
     )
     is_long_buyback_entry = self.long_buyback_entry_v2(last_candle, previous_candle, slice_profit, True)
+    last_rsi_3 = last_candle["RSI_3"]
+    last_rsi_3_15m = last_candle["RSI_3_15m"]
+    last_rsi_3_1h = last_candle["RSI_3_1h"]
+    last_aroonu_14 = last_candle["AROONU_14"]
+    last_aroonu_14_15m = last_candle["AROONU_14_15m"]
     is_long_grind_entry = (
       self.long_grind_entry_v2(last_candle, previous_candle, slice_profit, True)
       or (
         (is_derisk_1_found or is_derisk_2_found or is_derisk_3_found)
         and (num_open_grinds_and_buybacks == 0)
         and (
-          (last_candle["RSI_3"] > 10.0)
-          and (last_candle["RSI_3_15m"] > 20.0)
-          and (last_candle["RSI_3_1h"] > 20.0)
-          and (last_candle["RSI_3_1h"] > 20.0)
-          and (last_candle["AROONU_14"] < 50.0)
-          and (last_candle["AROONU_14_15m"] < 50.0)
+          (last_rsi_3 > 10.0)
+          and (last_rsi_3_15m > 20.0)
+          and (last_rsi_3_1h > 20.0)
+          and (last_rsi_3_1h > 20.0)
+          and (last_aroonu_14 < 50.0)
+          and (last_aroonu_14_15m < 50.0)
         )
       )
       or (
@@ -40069,12 +40074,12 @@ class NostalgiaForInfinityX7(IStrategy):
           or (not trade_is_short and current_rate < trade.liquidation_price * 1.10)
         )
         and (slice_profit < -0.03)
-        and (last_candle["RSI_3"] > 10.0)
-        and (last_candle["RSI_3_15m"] > 20.0)
+        and (last_rsi_3 > 10.0)
+        and (last_rsi_3_15m > 20.0)
         # and (last_candle["RSI_3_1h"] > 20.0)
         # and (last_candle["RSI_3_1h"] > 20.0)
-        and (last_candle["AROONU_14"] < 50.0)
-        and (last_candle["AROONU_14_15m"] < 50.0)
+        and (last_aroonu_14 < 50.0)
+        and (last_aroonu_14_15m < 50.0)
       )
     )
 
@@ -63362,18 +63367,23 @@ class NostalgiaForInfinityX7(IStrategy):
       )
     )
     is_short_buyback_entry = self.short_buyback_entry_v2(last_candle, previous_candle, slice_profit, True)
+    last_rsi_3 = last_candle["RSI_3"]
+    last_rsi_3_15m = last_candle["RSI_3_15m"]
+    last_rsi_3_1h = last_candle["RSI_3_1h"]
+    last_aroond_14 = last_candle["AROOND_14"]
+    last_aroond_14_15m = last_candle["AROOND_14_15m"]
     is_short_grind_entry = (
       self.short_grind_entry_v2(last_candle, previous_candle, slice_profit, True)
       or (
         (is_derisk_1_found or is_derisk_2_found or is_derisk_3_found)
         and (num_open_grinds_and_buybacks == 0)
         and (
-          (last_candle["RSI_3"] < 90.0)
-          and (last_candle["RSI_3_15m"] < 80.0)
-          and (last_candle["RSI_3_1h"] < 80.0)
-          and (last_candle["RSI_3_1h"] < 80.0)
-          and (last_candle["AROOND_14"] < 50.0)
-          and (last_candle["AROOND_14_15m"] < 50.0)
+          (last_rsi_3 < 90.0)
+          and (last_rsi_3_15m < 80.0)
+          and (last_rsi_3_1h < 80.0)
+          and (last_rsi_3_1h < 80.0)
+          and (last_aroond_14 < 50.0)
+          and (last_aroond_14_15m < 50.0)
         )
       )
       or (
@@ -63384,12 +63394,12 @@ class NostalgiaForInfinityX7(IStrategy):
           or (not trade_is_short and current_rate < trade.liquidation_price * 1.10)
         )
         and (slice_profit > 0.03)
-        and (last_candle["RSI_3"] < 90.0)
-        and (last_candle["RSI_3_15m"] < 80.0)
+        and (last_rsi_3 < 90.0)
+        and (last_rsi_3_15m < 80.0)
         # and (last_candle["RSI_3_1h"] < 80.0)
         # and (last_candle["RSI_3_1h"] < 80.0)
-        and (last_candle["AROOND_14"] < 50.0)
-        and (last_candle["AROOND_14_15m"] < 50.0)
+        and (last_aroond_14 < 50.0)
+        and (last_aroond_14_15m < 50.0)
       )
     )
 


### PR DESCRIPTION
## Summary
- Reuse repeated RSI/Aroon candle values in the long and short grind v2 adjust entry checks.
- Keep the existing v2 grind-entry calls, condition order, thresholds, liquidation guard, and return behavior unchanged.
- Leave v3 grind-entry code untouched.

## Safety
- This touches active adjust-position runtime paths, so I kept the change to local Series read reuse only.
- No indicator math, candle selection, order classification, profit arithmetic, stake sizing, or signal logic was changed.
- Reviewed the diff around `long_grind_adjust_trade_position_v2()` and `short_grind_adjust_trade_position_v2()` after the edit.

## Backtest scope
- Full backtesting is not expected to add signal/regression coverage here because the patch only stores existing `last_candle[...]` values in local variables before the same boolean checks.
- The active-path risk is instead covered with targeted diff review plus the undefined-local/preflight checks below.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
  - includes changed-file scope, merge-tree, AST undefined-local scan, `ruff format --check`, `ruff check`, and `py_compile`
- local checks pass; GitHub checks pending