### PR TITLE
Reuse X7 populate pair label

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4376,6 +4376,7 @@ class NostalgiaForInfinityX7(IStrategy):
     tik = time.perf_counter()
     prepare_informative_merge = self.prepare_informative_merge
     base_timeframe = self.timeframe
+    metadata_pair = metadata["pair"]
 
     # =========================================================================
     # CONFIG
@@ -4405,7 +4406,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # ---------------------------------------------------------------------
 
       if btc_informative.empty:
-        log.warning(f"[{metadata['pair']}] BTC informative {btc_tf} EMPTY!")
+        log.warning(f"[{metadata_pair}] BTC informative {btc_tf} EMPTY!")
 
         continue
 
@@ -4415,10 +4416,10 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if debug:
         if not btc_informative.index.is_monotonic_increasing:
-          log.warning(f"[{metadata['pair']}] BTC {btc_tf} index NOT monotonic!")
+          log.warning(f"[{metadata_pair}] BTC {btc_tf} index NOT monotonic!")
 
         if btc_informative.index.has_duplicates:
-          log.warning(f"[{metadata['pair']}] BTC {btc_tf} index has DUPLICATES!")
+          log.warning(f"[{metadata_pair}] BTC {btc_tf} index has DUPLICATES!")
 
       # ---------------------------------------------------------------------
       # REMOVE UNUSED OHLCV BEFORE MERGE
@@ -4453,7 +4454,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if info_indicators.empty:
         if debug:
-          log.warning(f"[{metadata['pair']}] {info_tf} informative EMPTY!")
+          log.warning(f"[{metadata_pair}] {info_tf} informative EMPTY!")
 
         continue
 
@@ -4463,14 +4464,14 @@ class NostalgiaForInfinityX7(IStrategy):
 
       if debug:
         if not info_indicators.index.is_monotonic_increasing:
-          log.warning(f"[{metadata['pair']}] {info_tf} index NOT monotonic!")
+          log.warning(f"[{metadata_pair}] {info_tf} index NOT monotonic!")
 
         if info_indicators.index.has_duplicates:
-          log.warning(f"[{metadata['pair']}] {info_tf} index has DUPLICATES!")
+          log.warning(f"[{metadata_pair}] {info_tf} index has DUPLICATES!")
 
         nan_cols = info_indicators.columns[info_indicators.isna().all()].tolist()
         if nan_cols:
-          log.warning(f"[{metadata['pair']}] {info_tf} FULL NaN cols: {nan_cols}")
+          log.warning(f"[{metadata_pair}] {info_tf} FULL NaN cols: {nan_cols}")
 
       # ---------------------------------------------------------------------
       # KEEP ONLY REQUIRED OHLCV
@@ -4507,17 +4508,17 @@ class NostalgiaForInfinityX7(IStrategy):
     # =========================================================================
     if debug:
       if not df.index.is_monotonic_increasing:
-        log.warning(f"[{metadata['pair']}] FINAL DF index NOT monotonic!")
+        log.warning(f"[{metadata_pair}] FINAL DF index NOT monotonic!")
 
       if df.index.has_duplicates:
-        log.warning(f"[{metadata['pair']}] FINAL DF index has DUPLICATES!")
+        log.warning(f"[{metadata_pair}] FINAL DF index has DUPLICATES!")
 
       # ---------------------------------------------------------------------
       # FULL NaN COLUMNS
       # ---------------------------------------------------------------------
       full_nan_cols = df.columns[df.isna().all()].tolist()
       if full_nan_cols:
-        log.warning(f"[{metadata['pair']}] FINAL DF FULL NaN cols: {full_nan_cols}")
+        log.warning(f"[{metadata_pair}] FINAL DF FULL NaN cols: {full_nan_cols}")
 
       # ---------------------------------------------------------------------
       # RECENT NaN CHECK
@@ -4527,7 +4528,7 @@ class NostalgiaForInfinityX7(IStrategy):
       recent_nan_cols = [col for col in recent_df.columns if recent_df[col].isna().any()]
 
       if recent_nan_cols:
-        log.warning(f"[{metadata['pair']}] FINAL DF recent NaNs: {recent_nan_cols}")
+        log.warning(f"[{metadata_pair}] FINAL DF recent NaNs: {recent_nan_cols}")
 
     # =========================================================================
     # BASE TF INDICATORS LAST
@@ -12196,7 +12197,7 @@ class NostalgiaForInfinityX7(IStrategy):
     tok_after_protections = time.perf_counter()
     tok_total = time.perf_counter()
     log.debug(
-      f"[{metadata['pair']}] "
+      f"[{metadata_pair}] "
       f"populate_indicators pre-protections: "
       f"{tok_before_protections - tik:0.4f}s | "
       f"protections: "
@@ -12205,7 +12206,7 @@ class NostalgiaForInfinityX7(IStrategy):
       f"{tok_total - tik:0.4f}s"
     )
     tok = time.perf_counter()
-    log.debug("[%s] Populate indicators took a total of: %.4f seconds.", metadata["pair"], tok - tik)
+    log.debug("[%s] Populate indicators took a total of: %.4f seconds.", metadata_pair, tok - tik)
 
     return df
 


### PR DESCRIPTION
## Summary
- Store `metadata["pair"]` once in `populate_indicators()` and reuse it for warning/debug labels.
- Match the existing `metadata_pair` style already used by nearby indicator helpers.

## Safety
- Only log/debug label reads were changed.
- No indicator math, informative merge behavior, protections, candle selection, signal logic, or dataframe columns were changed.
- Touched function: `populate_indicators()`.

## Backtest scope
- Full backtesting is not expected to add signal coverage here because the patch only reuses the same metadata pair string for logging labels.
- The useful regression coverage is import/format/static validation plus targeted diff review.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
  - includes changed-file scope, merge-tree, AST undefined-local scan, `ruff format --check`, `ruff check`, and `py_compile`
- local checks pass; GitHub checks pending