### PR TITLE
Reuse X7 stake multiplier selection

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -2624,6 +2624,15 @@ class NostalgiaForInfinityX7(IStrategy):
     rapid_mode_stake_multiplier_spot = self.rapid_mode_stake_multiplier_spot
     regular_mode_stake_multiplier_futures = self.regular_mode_stake_multiplier_futures
     regular_mode_stake_multiplier_spot = self.regular_mode_stake_multiplier_spot
+    grind_mode_stake_multipliers = (
+      grind_mode_stake_multiplier_futures if is_futures_mode else grind_mode_stake_multiplier_spot
+    )
+    rapid_mode_stake_multipliers = (
+      rapid_mode_stake_multiplier_futures if is_futures_mode else rapid_mode_stake_multiplier_spot
+    )
+    regular_mode_stake_multipliers = (
+      regular_mode_stake_multiplier_futures if is_futures_mode else regular_mode_stake_multiplier_spot
+    )
 
     def scaled_stake(stake_multiplier: float) -> float:
       stake = proposed_stake * stake_multiplier
@@ -2643,32 +2652,23 @@ class NostalgiaForInfinityX7(IStrategy):
           and all(c in long_rapid_rebuy_grind_mode_tags for c in enter_tags)
         )
       ):
-        stake_multiplier = (
-          rapid_mode_stake_multiplier_futures[0] if is_futures_mode else rapid_mode_stake_multiplier_spot[0]
-        )
-        return scaled_stake(stake_multiplier)
+        return scaled_stake(rapid_mode_stake_multipliers[0])
       # Grind mode
       elif all(c in long_grind_mode_tags for c in enter_tags):
-        for item in grind_mode_stake_multiplier_futures if is_futures_mode else grind_mode_stake_multiplier_spot:
+        for item in grind_mode_stake_multipliers:
           stake = proposed_stake * item
           if stake > min_stake:
             return stake
       # Btc mode
       elif all(c in long_btc_mode_tags for c in enter_tags):
-        stake_multiplier = (
-          grind_mode_stake_multiplier_futures[0] if is_futures_mode else grind_mode_stake_multiplier_spot[0]
-        )
-        return proposed_stake * stake_multiplier
+        return proposed_stake * grind_mode_stake_multipliers[0]
       else:
         if system_name_use == system_v3_2_name:
           return scaled_stake(system_v3_2_stake_multiplier)
         elif system_name_use == system_v3_1_name:
           return scaled_stake(system_v3_1_stake_multiplier)
         else:
-          stake_multiplier = (
-            regular_mode_stake_multiplier_futures[0] if is_futures_mode else regular_mode_stake_multiplier_spot[0]
-          )
-          return scaled_stake(stake_multiplier)
+          return scaled_stake(regular_mode_stake_multipliers[0])
     else:
       # Rebuy mode
       if all(c in short_rebuy_mode_tags for c in enter_tags) or (
@@ -2678,7 +2678,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return scaled_stake(system_v3_rebuy_mode_stake_multiplier)
       # Grind mode
       elif all(c in short_grind_mode_tags for c in enter_tags):
-        for item in grind_mode_stake_multiplier_futures if is_futures_mode else grind_mode_stake_multiplier_spot:
+        for item in grind_mode_stake_multipliers:
           stake = proposed_stake * item
           if stake > min_stake:
             return stake
@@ -2690,20 +2690,14 @@ class NostalgiaForInfinityX7(IStrategy):
           and all(c in short_rapid_rebuy_grind_mode_tags for c in enter_tags)
         )
       ):
-        stake_multiplier = (
-          rapid_mode_stake_multiplier_futures[0] if is_futures_mode else rapid_mode_stake_multiplier_spot[0]
-        )
-        return scaled_stake(stake_multiplier)
+        return scaled_stake(rapid_mode_stake_multipliers[0])
       else:
         if system_name_use == system_v3_2_name:
           return scaled_stake(system_v3_2_stake_multiplier)
         elif system_name_use == system_v3_1_name:
           return scaled_stake(system_v3_1_stake_multiplier)
         else:
-          stake_multiplier = (
-            regular_mode_stake_multiplier_futures[0] if is_futures_mode else regular_mode_stake_multiplier_spot[0]
-          )
-          return scaled_stake(stake_multiplier)
+          return scaled_stake(regular_mode_stake_multipliers[0])
 
     return proposed_stake
 


### PR DESCRIPTION
## Summary
- Select the futures/spot stake multiplier lists once in `custom_stake_amount()`.
- Reuse those selected lists in the existing long/short rapid, grind, BTC, and regular stake paths.

## Safety
- This touches the active stake callback, so the change is limited to selector reuse only.
- The `[0]` accesses remain inside the same branches that used them before; the patch does not eagerly read first elements at function entry.
- No stake formulas, mode tag checks, thresholds, return order, or min-stake behavior were changed.

## Backtest scope
- Full backtesting is not expected to add signal coverage here because the patch keeps the same selected multiplier lists and the same branch-local stake calculations.
- The active-callback risk is covered with targeted diff review and local validation.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
  - includes changed-file scope, merge-tree, AST undefined-local scan, `ruff format --check`, `ruff check`, and `py_compile`
- local checks pass; GitHub checks pending