### PR TITLE
Reuse X7 no-derisk first order

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -46138,6 +46138,7 @@ class NostalgiaForInfinityX7(IStrategy):
     regular_mode_use_grind_stops = self.regular_mode_use_grind_stops
 
     last_filled_entry = filled_entries[-1]
+    first_filled_order = filled_orders[0]
     last_filled_order = filled_orders[-1]
 
     max_rebuy_sub_grinds = 0
@@ -46353,7 +46354,7 @@ class NostalgiaForInfinityX7(IStrategy):
     grind_6_buy_orders = []
     grind_6_distance_ratio = 0.0
     for order in reversed(filled_orders):
-      if (order.ft_order_side == "buy") and (order is not filled_orders[0]):
+      if (order.ft_order_side == "buy") and (order is not first_filled_order):
         order_tag = ""
         if has_order_tags:
           if order.ft_order_tag is not None:
@@ -46495,7 +46496,7 @@ class NostalgiaForInfinityX7(IStrategy):
         ]:
           rebuy_is_sell_found = True
         if not is_derisk:
-          start_amount = filled_orders[0].safe_filled
+          start_amount = first_filled_order.safe_filled
           current_amount = 0.0
           for order2 in filled_orders:
             if order2.ft_order_side == "buy":
@@ -69039,6 +69040,7 @@ class NostalgiaForInfinityX7(IStrategy):
     regular_mode_use_grind_stops = self.regular_mode_use_grind_stops
 
     last_filled_entry = filled_entries[-1]
+    first_filled_order = filled_orders[0]
     last_filled_order = filled_orders[-1]
 
     max_rebuy_sub_grinds = 0
@@ -69254,7 +69256,7 @@ class NostalgiaForInfinityX7(IStrategy):
     grind_6_buy_orders = []
     grind_6_distance_ratio = 0.0
     for order in reversed(filled_orders):
-      if (order.ft_order_side == "sell") and (order is not filled_orders[0]):
+      if (order.ft_order_side == "sell") and (order is not first_filled_order):
         order_tag = ""
         if has_order_tags:
           if order.ft_order_tag is not None:
@@ -69396,7 +69398,7 @@ class NostalgiaForInfinityX7(IStrategy):
         ]:
           rebuy_is_sell_found = True
         if not is_derisk:
-          start_amount = filled_orders[0].safe_filled
+          start_amount = first_filled_order.safe_filled
           current_amount = 0.0
           for order2 in filled_orders:
             if order2.ft_order_side == "sell":


### PR DESCRIPTION
## Summary
- Store the first filled order once in the long and short no-derisk adjust helpers.
- Reuse that order for the existing first-order exclusion and start-amount checks.

## Safety
- This touches active no-derisk adjust helper paths, so the change is limited to local order-object reuse.
- `filled_orders[0]` is still read at the same point as the existing filled-order setup; no order list filtering, order classification, profit arithmetic, stake formulas, condition order, or return values were changed.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting is not expected to add signal coverage here because this patch only reuses the same first filled order object inside the same call.
- The active-path risk is covered with targeted diff review plus the validation below.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
  - includes changed-file scope, merge-tree conflict simulation, AST undefined-local scan, `ruff format --check`, `ruff check`, and `py_compile`
- local checks pass; GitHub checks pending