### PR TITLE
Reuse X7 rebuy exit price reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -47582,9 +47582,11 @@ class NostalgiaForInfinityX7(IStrategy):
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
-    slice_profit_exit = (
-      ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
-    )
+    if count_of_exits > 0:
+      last_filled_exit_price = filled_exits[-1].safe_price
+      slice_profit_exit = (exit_rate - last_filled_exit_price) / last_filled_exit_price
+    else:
+      slice_profit_exit = 0.0
 
     current_stake_amount = trade_amount * current_rate
     stake_scale_leverage = trade_leverage if is_futures_mode else 1.0
@@ -70483,9 +70485,11 @@ class NostalgiaForInfinityX7(IStrategy):
     slice_amount = filled_entries[0].cost
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
-    slice_profit_exit = (
-      ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
-    )
+    if count_of_exits > 0:
+      last_filled_exit_price = filled_exits[-1].safe_price
+      slice_profit_exit = (exit_rate - last_filled_exit_price) / last_filled_exit_price
+    else:
+      slice_profit_exit = 0.0
 
     current_stake_amount = trade_amount * current_rate
     stake_scale_leverage = trade_leverage if is_futures_mode else 1.0


### PR DESCRIPTION
## Summary
- Store the latest rebuy exit price once in the long and short rebuy adjust helpers.
- Reuse that price for the existing `slice_profit_exit` calculation.

## Safety
- This touches active rebuy adjust helper paths, so the change is limited to local price reuse inside the existing `count_of_exits > 0` guard.
- The same `filled_exits[-1].safe_price` value is used for the same formula; no exit selection, order classification, profit arithmetic meaning, thresholds, condition order, stake formulas, or return values were changed.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting is not expected to add signal coverage here because this patch only reuses an already-read exit price inside the same call and keeps the empty-exit fallback at `0.0`.
- The active-path risk is covered with targeted diff review plus the validation below.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
  - includes changed-file scope, merge-tree conflict simulation, AST undefined-local scan, `ruff format --check`, `ruff check`, and `py_compile`
- targeted review of touched functions: `long_rebuy_adjust_trade_position`, `short_rebuy_adjust_trade_position`
- local checks pass; GitHub checks pending