### PR TITLE
Reuse X7 entry CMF series reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12655,6 +12655,10 @@ class NostalgiaForInfinityX7(IStrategy):
     close = df["close"]
     roc_9_15m = df["ROC_9_15m"]
     rsi_14_4h = df["RSI_14_4h"]
+    cmf_20_15m = df["CMF_20_15m"]
+    cmf_20_1h = df["CMF_20_1h"]
+    cmf_20_4h = df["CMF_20_4h"]
+    cmf_20_1d = df["CMF_20_1d"]
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
@@ -12737,7 +12741,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 1h downtrend, 1h high
-            & ((rsi_3_15m > 1.0) | (df["CMF_20_1h"] > -0.1) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 1.0) | (cmf_20_1h > -0.1) | (aroonu_14_1h < 70.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 1h still high
@@ -12769,7 +12773,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (df["CMF_20_15m"] > -0.40) | (roc_9_15m > -20.0))
+            & ((rsi_3_15m > 3.0) | (cmf_20_15m > -0.40) | (roc_9_15m > -20.0))
             # 15m down move, 15m still high, 15m downtrend
             & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 40.0) | (roc_9_15m > -20.0))
             # 15m down move, 1h & 4h high
@@ -12841,7 +12845,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
             # 15m down move & downtrend, 4h high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.3) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high & overbought
@@ -12895,7 +12899,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.3))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.3))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still not low enough
@@ -12919,7 +12923,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_14_4h < 75.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h overbought
@@ -12969,7 +12973,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 40.0) | (df["CMF_20_1h"] > -0.25) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h > 40.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 15m downtrend
@@ -13031,7 +13035,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((df["RSI_3_change_pct_1h"] > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m & 1h & 4h downtrend
-            & ((df["CMF_20_15m"] > -0.3) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.3))
+            & ((cmf_20_15m > -0.3) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.3))
             # 15m high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_1d < 80.0))
             # 1h still high, 1h & 4h downtrend
@@ -13067,23 +13071,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h down move, 15m still high
             & ((df["ROC_9"] > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 4h down move, 15m downtrend, 1h high
-            & ((df["ROC_9"] > -15.0) | (rsi_3_4h > 45.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_1h < 60.0))
+            & ((df["ROC_9"] > -15.0) | (rsi_3_4h > 45.0) | (cmf_20_15m > -0.3) | (aroonu_14_1h < 60.0))
             # 1h downtrend, 4h high & overbought
             & ((roc_9_1h > -25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
             & ((roc_9_1h < 20.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
             # 1d P&D, 1d downtrend
-            & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.0))
+            & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (cmf_20_1d > -0.0))
             # 1d green with top wick, 1h down move
             & ((df["change_pct_1d"] < 20.0) | (df["top_wick_pct_1d"] < 15.0) | (rsi_3_1h > 20.0))
             # 1d green with top wick, 4h high
             & ((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 25.0) | (aroonu_14_4h < 80.0))
             # 1d green, 1h down move, 1d downtrend
-            & ((df["change_pct_1d"] < 40.0) | (rsi_3_1h > 25.0) | (df["CMF_20_1d"] > -0.2))
+            & ((df["change_pct_1d"] < 40.0) | (rsi_3_1h > 25.0) | (cmf_20_1d > -0.2))
             # 1d green with top wick, 4h overbought
             & ((df["change_pct_1d"] < 50.0) | (df["top_wick_pct_1d"] < 30.0) | (roc_9_4h < 80.0))
             # big drop in the last hour, 15m downtrend
-            & ((close > (df["close_max_12"] * 0.65)) | (df["CMF_20_15m"] > -0.5))
+            & ((close > (df["close_max_12"] * 0.65)) | (cmf_20_15m > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
             & ((close > (df["high_max_6_1h"] * 0.60)) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0))
             # big drop in the last 24 hours,  1h still high
@@ -13130,7 +13134,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1d down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (df["CMF_20_1d"] > -0.25))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high
@@ -13160,7 +13164,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 1h still not low enough
@@ -13174,7 +13178,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
@@ -13202,7 +13206,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (rsi_14_4h < 30.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (df["CMF_20_4h"] > -0.35))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (cmf_20_4h > -0.35))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d downtrend
@@ -13218,7 +13222,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h still high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (df["CMF_20_15m"] > -0.35))
+            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d downtrend
@@ -13260,7 +13264,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m downtrend, 4h still not low enough
-            & ((rsi_3_15m > 5.0) | (df["CMF_20_15m"] > -0.30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m stil high, 1h still high
@@ -13332,7 +13336,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d high
@@ -13348,7 +13352,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 4h high
@@ -13454,7 +13458,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 1.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -10.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
@@ -13480,7 +13484,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h % 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (cmf_20_4h > -0.30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 15m high
@@ -13574,7 +13578,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (cmf_20_4h > -0.50))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -13678,7 +13682,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high. 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 4h downtrend
@@ -13738,7 +13742,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
@@ -13873,7 +13877,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 15m high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 4h downtrend. 15m high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_4h"] > -0.30) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.30) | (aroonu_14_15m < 60.0))
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 15m high, 4h downtrend
@@ -14007,7 +14011,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -40.0))
             # 15m down move, 15m high, 15m downtrend
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (cmf_20_15m > -0.30))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 70.0))
             # 15m down move, 1h high, 1d overbought
@@ -14101,7 +14105,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 35.0) | (df["CMF_20_1h"] > -0.30) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 35.0) | (cmf_20_1h > -0.30) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h high, 1d overbought
@@ -14129,7 +14133,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (df["CMF_20_1d"] > -0.20))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.20))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 1h down move, 15m high, 4h overbought
@@ -14263,7 +14267,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 1d downtrend, 1d overbought
-            & ((rsi_3_4h > 30.0) | (df["CMF_20_1d"] > -0.30) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 30.0) | (cmf_20_1d > -0.30) | (roc_9_1d < 40.0))
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 1h high, 1d downtrend
@@ -14584,7 +14588,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (cmf_20_15m > -0.40))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
             # 1h down move, 1h high, 4h high
@@ -14602,7 +14606,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (df["CMF_20_1h"] > -0.40))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (cmf_20_1h > -0.40))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d overbought
@@ -14878,7 +14882,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m high, 4h downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -14918,7 +14922,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | (aroonu_14_4h < 70.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d downtrend
@@ -15004,7 +15008,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 15m downtrend, 1d high
-            & ((rsi_3_4h > 10.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h > 10.0) | (cmf_20_15m > -0.30) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
             # 4h down move, 15m high
@@ -15030,7 +15034,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high. 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 1h high, 4h downtrend
@@ -15050,9 +15054,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 4h downtrend
             & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h > -30.0))
             # 15m & 1h & 4h downtrend
-            & ((df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30) | (df["CMF_20_4h"] > -0.30))
+            & ((cmf_20_15m > -0.30) | (cmf_20_1h > -0.30) | (cmf_20_4h > -0.30))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m not low enough, 1h & 4h downtrend
             & ((aroonu_14_15m < 20.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 15m high, 1h high & overbought
@@ -15215,7 +15219,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0))
             # 15m & 1h & 4h down move, 15m downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
@@ -15281,7 +15285,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 4h still high
@@ -15299,9 +15303,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 20.0))
             # 15m down move, 15m downtrend, 4h still high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.40) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | (stochrsi_k_4h < 50.0))
             # 15m down move, 1h downtrend, 4h still high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_1h"] > -0.30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_1h > -0.30) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
@@ -15321,7 +15325,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
@@ -15441,7 +15445,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15 down move, 1h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 10.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 70.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 70.0) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
             # 15m & 1h down move, 1h still high
@@ -15575,7 +15579,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 4h overbought
@@ -15715,7 +15719,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d high
@@ -15771,7 +15775,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
             # 1d down move, 4h downtrend, 4h high
-            & ((rsi_3_1d > 20.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1d > 20.0) | (cmf_20_4h > -0.25) | (aroonu_14_4h < 70.0))
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 4h & 1d high
@@ -15781,7 +15785,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 4h downtrend, 4h high & over
-            & ((df["CMF_20_4h"] > -0.10) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
+            & ((cmf_20_4h > -0.10) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
             # 15m still high, 4h high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 15m still high, 4h high, 1h overbought
@@ -15918,7 +15922,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (df["CMF_20_4h"] > -0.25))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (cmf_20_4h > -0.25))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
             # 15m down move, 4h & 1d overbought
@@ -16030,7 +16034,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 65.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m not low enough, 1h high, 1d overbought
             & ((aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
@@ -16060,7 +16064,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h overbought, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (df["CMF_20_4h"] > -0.30))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (cmf_20_4h > -0.30))
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 20.0))
             # 4h & 1d high, 4h overbought
@@ -16082,7 +16086,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h high, 4h overbought. 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0) | (df["CMF_20_1d"] > -0.25))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0) | (cmf_20_1d > -0.25))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h high & 4h & 1d overbought
@@ -16118,7 +16122,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h still high
@@ -16240,7 +16244,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
@@ -16328,7 +16332,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 15m & 1h downtrend
-            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.30) | (cmf_20_1h > -0.30))
             # 1h down move, 1h still high, 1h downtrend
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (roc_9_1h > -20.0))
             # 1h down move, 1h high
@@ -16350,7 +16354,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (cmf_20_1h > -0.30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
             # 1h & 1d down move, 1h still high
@@ -16402,9 +16406,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (df["CMF_20_1h"] > -0.40))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (cmf_20_1h > -0.40))
             # 1h down move, 1d downtrend, 4h high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1d > -0.30) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
@@ -16430,15 +16434,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h downtrend, 1h still high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1h > -0.30) | (stochrsi_k_1h < 40.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (df["CMF_20_1h"] > -0.25))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (cmf_20_1h > -0.25))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d overbought
@@ -16514,9 +16518,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 30.0) | (df["CMF_20_1h"] > -0.25) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1h > 30.0) | (cmf_20_1h > -0.25) | (stochrsi_k_1h < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 30.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 30.0) | (cmf_20_4h > -0.50) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
@@ -16654,13 +16658,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m downtrend, 4h & 1d high
-            & ((df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((cmf_20_15m > -0.30) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h high, 1h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h & 4h high, 1h downtrend
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (df["CMF_20_1h"] > -0.30))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (cmf_20_1h > -0.30))
             # 1h high, 4h high, 1h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
@@ -16896,7 +16900,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
@@ -16938,7 +16942,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -16986,7 +16990,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17016,7 +17020,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (cmf_20_4h > -0.40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h overbought
@@ -17062,7 +17066,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
             # 4h down move, 1h downtrend, 4h still high
-            & ((rsi_3_4h > 3.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h > 3.0) | (cmf_20_1h > -0.30) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d downtrend
@@ -17218,9 +17222,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h downtrend, 4h high
-            & ((df["CMF_20_1h"] > -0.40) | (df["CMF_20_4h"] > -0.40) | (aroonu_14_4h < 80.0))
+            & ((cmf_20_1h > -0.40) | (cmf_20_4h > -0.40) | (aroonu_14_4h < 80.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (aroonu_14_1d < 85.0))
+            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 15m & 1d high, 4h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d downtrend
@@ -17559,7 +17563,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
@@ -17713,7 +17717,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 4h downtrend, 1h & 4h high
-            & ((df["CMF_20_4h"] > -0.30) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((cmf_20_4h > -0.30) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m still high, 1h & 4h overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 15m & 1d high, 1d overbought
@@ -17910,7 +17914,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 4h still high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (cmf_20_15m > -0.40))
             # 1h down move, 4h still high, 4h downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -18022,7 +18026,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 60.0))
             # 4h downtrend, 4h high
-            & ((df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((cmf_20_4h > -0.50) | (aroonu_14_4h < 70.0))
             # 1h & 1d high, 4h downtrend
             & ((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h still high, 1h & 4h downtrend
@@ -18109,7 +18113,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 35.0))
           # 15m down move, 4h still high, 15m downtrend
-          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (df["CMF_20_15m"] > -0.35))
+          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
           # 15m & 1h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0))
           # 15m & 1h down move, 4h high
@@ -18530,7 +18534,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 4h high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.30))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (cmf_20_4h > -0.30))
           # 1h down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1h down move, 1h high, 1d overbought
@@ -18550,7 +18554,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d still high
           long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d low
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (df["CMF_20_1d"] > -0.2))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (cmf_20_1d > -0.2))
           # 4h & 1d down move, 1d still high
           long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d overbought
@@ -18659,7 +18663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_1d"] < 50.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (cmf_20_4h > -0.30))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
@@ -18677,7 +18681,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 40.0) | (rsi_14_4h < 40.0))
             # 15m down move, 15m downtrend. 4h high
-            & ((rsi_3_15m > 3.0) | (df["CMF_20_15m"] > -0.50) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 3.0) | (cmf_20_15m > -0.50) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still not low enough
             & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0))
             # 15m down move, 4h high
@@ -18721,7 +18725,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high
@@ -18817,7 +18821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high, 1d overbought
@@ -18879,7 +18883,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 4h downtrend, 4h still high
-            & ((rsi_3_4h > 5.0) | (df["CMF_20_4h"] > -0.20) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h > 5.0) | (cmf_20_4h > -0.20) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d downtrend
@@ -18921,7 +18925,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 1h high, 4h high, 1h overbought
@@ -19036,7 +19040,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d overbought
@@ -19052,7 +19056,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m downtrend, 4h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.30) | (aroonu_14_4h < 50.0))
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d high
@@ -19172,7 +19176,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (cmf_20_4h > -0.50))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 15m still high, 1d overbought
@@ -19188,7 +19192,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (cmf_20_4h > -0.40))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 4h overbought
@@ -19232,7 +19236,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (roc_9_1d > -15.0))
             # 4h down move, 1h downtrend, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["CMF_20_1h"] > -0.40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 15.0) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -19254,7 +19258,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -19286,7 +19290,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (aroonu_14_1d < 85.0))
+            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
@@ -19330,7 +19334,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1d down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (df["CMF_20_1d"] > -0.25))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m down move, 1d high & overbought
@@ -19426,7 +19430,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m downtrend, 4h high
-            & ((rsi_3_15m > 30.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 30.0) | (cmf_20_15m > -0.30) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
@@ -19468,7 +19472,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 15.0) | (roc_9_1h > -40.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h down move, 15m still not low enough, 4h still high
             & ((rsi_3_1h > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
             # 1h down move, 1h still not low enough
@@ -19518,11 +19522,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d downtrend, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.20) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.20) | (aroonu_14_1h < 30.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.20) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.20) | (stochrsi_k_1h < 30.0))
             # 1h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.30))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19538,7 +19542,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down mov, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 1d high, 4h downtrend
@@ -19728,13 +19732,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h downtrend, 1h high
-            & ((df["CMF_20_1h"] > -0.20) | (aroonu_14_1h < 80.0))
+            & ((cmf_20_1h > -0.20) | (aroonu_14_1h < 80.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.30) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 60.0))
+            & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m still high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (roc_9_1h < 40.0))
             # 15m still high, 4h overbought
@@ -19981,7 +19985,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 20.0))
           # 1h & 4h down move, 1d low
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1d"] > -0.2))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (cmf_20_1d > -0.2))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 20.0))
           # 1h & 4h down move, 4h still not low enough
@@ -20344,7 +20348,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (df["CMF_20_4h"] > -0.40))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (cmf_20_4h > -0.40))
           # 1h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 4h still high
@@ -20704,9 +20708,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
           # 15m & 1h & 4h down move, 15m downtrend
-          long_entry_logic.append(
-            (rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (df["CMF_20_15m"] > -0.20)
-          )
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (cmf_20_15m > -0.20))
           # 15m & 1h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 20.0))
           # 15m & 1h down move, 1h high
@@ -20714,9 +20716,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
           # 15m & 1h down move, 15m & 1h downtrend
-          long_entry_logic.append(
-            (rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["CMF_20_1h"] > -0.40)
-          )
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 4h still high
@@ -20726,9 +20726,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
           # 15m & 4h down move, 1h & 4h downtrend
-          long_entry_logic.append(
-            (rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.20) | (df["CMF_20_4h"] > -0.20)
-          )
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 4h still high
@@ -20852,7 +20850,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d still not low enough, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_1d < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h downtrend, 1h still not low enough
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.25) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 10.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
@@ -21015,7 +21013,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 3.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 3.0) | (cmf_20_15m > -0.30))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
@@ -21035,7 +21033,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
             # 15m down move, 15m downtrend, 1d high
-            & ((rsi_3_15m > 5.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
@@ -21123,7 +21121,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
@@ -21185,7 +21183,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still high
@@ -21525,7 +21523,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
@@ -22093,7 +22091,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.20))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.20))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
@@ -22313,7 +22311,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1h high, 1d downtrend
@@ -22365,7 +22363,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d still high, 1d downtrend
@@ -22772,7 +22770,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down nove, 1h still high
@@ -22874,7 +22872,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high
             & ((rsi_3_1d > 20.0) | (rsi_14_4h < 80.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
             # 1h & 4h high, 1d overbought
@@ -22969,11 +22967,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 40.0))
             # 15m & 1h & 4h down move, 1h downtrend, 4h high
             & (
-              (rsi_3_15m > 15.0)
-              | (rsi_3_1h > 30.0)
-              | (rsi_3_4h > 55.0)
-              | (df["CMF_20_1h"] > -0.10)
-              | (aroonu_14_4h < 80.0)
+              (rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 55.0) | (cmf_20_1h > -0.10) | (aroonu_14_4h < 80.0)
             )
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 60.0))
@@ -23020,7 +23014,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h & 1d up move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (cmf_20_1d > -0.2))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h & 4h still high
@@ -23068,7 +23062,7 @@ class NostalgiaForInfinityX7(IStrategy):
               (rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h < 90.0) | (df["EMA_9"] < (df["EMA_26"] * 0.972))
             )
             # 15m down move, 4h high and downtrend
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_4h"] > -0.2) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.2) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h & 1d downtrend
@@ -23079,7 +23073,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (
               (rsi_3_15m > 20.0)
               | (rsi_3_1h > 35.0)
-              | (df["CMF_20_1h"] > -0.10)
+              | (cmf_20_1h > -0.10)
               | (aroonu_14_15m < 40.0)
               | (aroonu_14_1h < 85.0)
             )
@@ -23094,7 +23088,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (rsi_14_4h < 75.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h downtrend, 4h overbought
-            & ((rsi_3_15m > 20.0) | (df["CMF_20_4h"] > -0.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 20.0) | (cmf_20_4h > -0.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h & 4h high, 1f overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 85.0) | (rsi_14_4h < 70.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
@@ -23133,15 +23127,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 15m downtrend, 4h still high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_15m"] > -0.4) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_15m > -0.4) | (aroonu_14_4h < 50.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.25) | (aroonu_14_4h < 70.0))
             # 1h down move, 15m still high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still not low enough, 1d downtrend
@@ -23163,7 +23157,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
             # 1h down move, 1h highm 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
@@ -23211,7 +23205,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h down move, 15m & 1h high, 1d downtrend
-            & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (df["CMF_20_1d"] > -0.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m high
@@ -23219,13 +23213,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m still not low enough, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (cmf_20_4h > -0.30))
             # 4h down move, 15m & 1h still not low enough
             & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (df["CMF_20_4h"] > -0.3))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (cmf_20_4h > -0.3))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h high
@@ -23235,7 +23229,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 20.0))
             # 4h & 1d down move, 1h & 4h low
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.4))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.4))
             # 4h down move, 4h still high 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
@@ -23297,7 +23291,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((df["RSI_14_15m"] > 30.0) | (stochrsi_k_4h < 90.0) | (stochrsi_k_1d < 70.0))
             # 1h downtrend, 4h high, 1d downtrend
-            & ((df["CMF_20_1h"] > -0.2) | (stochrsi_k_4h < 90.0) | (df["CMF_20_1d"] > -0.25))
+            & ((cmf_20_1h > -0.2) | (stochrsi_k_4h < 90.0) | (cmf_20_1d > -0.25))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
@@ -23317,7 +23311,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, 1h high
             & ((df["change_pct_1d"] > -15.0) | (df["change_pct_1d"].shift(288) < 15.0) | (stochrsi_k_1h < 80.0))
             # 1d P&D, 1d downtrend
-            & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.1))
+            & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (cmf_20_1d > -0.1))
             # 1d P&D, 15m high
             & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 40.0) | (aroonu_14_15m < 50.0))
             # 1d P&D, 1h high
@@ -23327,7 +23321,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green, 4m down move, 4h high
             & ((df["change_pct_1d"] < 25.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
             # 1d green with top wick, 1d low
-            & ((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 10.0) | (df["CMF_20_1d"] > -0.2))
+            & ((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 10.0) | (cmf_20_1d > -0.2))
             # 1d top wick, 1h still high
             & ((df["top_wick_pct_1d"] < 25.0) | (aroonu_14_1h < 50.0))
             # 1d top wick, 4h still high
@@ -23426,7 +23420,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 80.0) | (aroonu_14_4h > 20.0))
           # 5m up move, 15m & 1h uptrend
-          short_entry_logic.append((rsi_3 < 90.0) | (df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30))
+          short_entry_logic.append((rsi_3 < 90.0) | (cmf_20_15m < 0.30) | (cmf_20_1h < 0.30))
           # 5m up move, 15m stil low
           short_entry_logic.append((rsi_3 < 90.0) | (aroonu_14_15m > 50.0))
           # 5m up move, 15m & 1h still not high enough
@@ -23594,7 +23588,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 15m & 1h uptrend, 4h still low
-          short_entry_logic.append((df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
           short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1h > 20.0))
           # 1h & 4h uptrend
@@ -23846,7 +23840,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h high, 4h downtrend
           short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h < 10.0))
           # 5m & 1h down move, 4h down
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 85.0) | (df["CMF_20_4h"] > -0.2))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 85.0) | (cmf_20_4h > -0.2))
           # 5m down move, 1h high
           short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (stochrsi_k_1h > 30.0))
           # 5m down move, 1h high
@@ -24061,7 +24055,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h strong down move, 4h high
           short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h downtrend, 4h not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["CMF_20_4h"] > -0.25) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (cmf_20_4h > -0.25) | (stochrsi_k_4h > 70.0))
           # 1h down move, 4h high, 1d overbought
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_14_4h > 40.0) | (roc_9_1d > -50.0))
           # 1h down move, 4h strong down move
@@ -24297,7 +24291,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 40.0) | (stochrsi_k_4h > 30.0))
           # 5m down move, 1h down, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["CMF_20_1h"] < 0.2) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (cmf_20_1h < 0.2) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["AROOND_14_1h"] < 25.0) | (stochrsi_k_4h > 10.0))
           # 15m down move, 1h still high


### PR DESCRIPTION
## Summary
- Reuses the `CMF_20_15m`, `CMF_20_1h`, `CMF_20_4h`, and `CMF_20_1d` Series inside `populate_entry_trend`.
- Keeps the branch independent on latest upstream `main`.

## Safety
- This only aliases Series fields that were already read from the same dataframe inside the same call.
- Indicator formulas, candle selection, thresholds, condition order, order classification, profit arithmetic, stake sizing, and return values are unchanged.
- Touched function: `populate_entry_trend`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read dataframe Series in the same condition ladder. The entry conditions still evaluate the same columns, thresholds, and boolean order.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in validator: passed
- `git merge-tree` conflict simulation against `origin/main`: no conflict markers
- targeted `git diff` review for `populate_entry_trend` CMF replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
