### PR TITLE
Reduce X7 entry AROON series reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12641,6 +12641,11 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_4h = df["RSI_3_4h"]
     roc_9_1d = df["ROC_9_1d"]
     aroonu_14_4h = df["AROONU_14_4h"]
+    aroond_14_15m = df["AROOND_14_15m"]
+    aroond_14_4h = df["AROOND_14_4h"]
+    aroond_14_1h = df["AROOND_14_1h"]
+    aroond_14 = df["AROOND_14"]
+    aroonu_14 = df["AROONU_14"]
     roc_9_4h = df["ROC_9_4h"]
     aroonu_14_1h = df["AROONU_14_1h"]
     stochrsi_k_4h = df["STOCHRSIk_14_14_3_3_4h"]
@@ -13804,7 +13809,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             # (df["RSI_3"] > 5.0)
-            (df["AROONU_14"] < 30.0)
+            (aroonu_14 < 30.0)
             & (df["STOCHRSIk_14_14_3_3"] < 30.0)
             # & (rsi_3_15m > 5.0)
             & (aroonu_14_15m < 50.0)
@@ -14481,7 +14486,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_20"] < df["RSI_20"].shift(1))
             & (df["RSI_4"] < 45.0)
             & (df["RSI_14"] > 30.0)
-            & (df["AROONU_14"] < 20.0)
+            & (aroonu_14 < 20.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (close < df["SMA_16"] * 0.965)
             & (close < df["SMA_16_1h"] * 0.985)
@@ -14769,7 +14774,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["AROONU_14"] < 25.0)
+            (aroonu_14 < 25.0)
             & (aroonu_14_15m < 25.0)
             & (close < (df["EMA_9"] * 0.946))
             & (close < (df["EMA_20"] * 0.960))
@@ -15114,7 +15119,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 50.0)
-            & (df["AROONU_14"] < 25.0)
+            & (aroonu_14 < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.020))
@@ -15870,7 +15875,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["RSI_20"] < df["RSI_20"].shift(1))
             & (rsi_3 < 46.0)
-            & (df["AROONU_14"] < 25.0)
+            & (aroonu_14 < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (aroonu_14_15m < 50.0)
             & (close < df["SMA_16"] * 0.960)
@@ -16097,7 +16102,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["AROONU_14"] < 25.0)
+            (aroonu_14 < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (aroonu_14_15m < 50.0)
             & (close < df["EMA_16"] * 0.960)
@@ -16721,8 +16726,8 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 > 5.0)
             & (df["RSI_14"] < 36.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["AROOND_14"] > 75.0)
+            & (aroonu_14 < 25.0)
+            & (aroond_14 > 75.0)
             & (df["EMA_9"] < (df["EMA_26"] * 0.960))
           )
 
@@ -17772,7 +17777,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["RSI_14"] < 40.0)
             & (df["MFI_14"] < 40.0)
-            & (df["AROONU_14"] < 25.0)
+            & (aroonu_14 < 25.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.024))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
@@ -18961,7 +18966,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 50.0)
-            & (df["AROONU_14"] < 25.0)
+            & (aroonu_14 < 25.0)
             & (df["STOCHRSIk_14_14_3_3"] < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.030))
@@ -19310,7 +19315,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 40.0)
-            & (df["AROONU_14"] < 30.0)
+            & (aroonu_14 < 30.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (stochrsi_k_15m < 70.0)
             & (df["WILLR_84_1h"] < -70.0)
@@ -19813,7 +19818,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 > 0.0)
             & (rsi_3 < 50.0)
-            & (df["AROONU_14"] < 25.0)
+            & (aroonu_14 < 25.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.022))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
@@ -20126,7 +20131,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(rsi_3 > 3.0)
           long_entry_logic.append(df["RSI_14"] < 36.0)
-          long_entry_logic.append(df["AROONU_14"] < 25.0)
+          long_entry_logic.append(aroonu_14 < 25.0)
           long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
           long_entry_logic.append(close < (df["SMA_16"] * 0.946))
           long_entry_logic.append(aroonu_14_15m < 50.0)
@@ -20674,7 +20679,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["RSI_4"] < 45.0)
           long_entry_logic.append(df["RSI_14"] > 35.0)
           long_entry_logic.append(df["RSI_20"] < df["RSI_20"].shift(1))
-          long_entry_logic.append(df["AROONU_14"] < 25.0)
+          long_entry_logic.append(aroonu_14 < 25.0)
           long_entry_logic.append(close < df["SMA_16"] * 0.960)
 
         # Condition #104 - Rapid mode (Long).
@@ -20916,7 +20921,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(rsi_3 < 40.0)
-          long_entry_logic.append(df["AROONU_14"] < 25.0)
+          long_entry_logic.append(aroonu_14 < 25.0)
           long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
           long_entry_logic.append(aroonu_14_15m < 25.0)
           long_entry_logic.append(stochrsi_k_15m < 30.0)
@@ -20946,7 +20951,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (df["WILLR_14"] < -80.0)
-            & (df["AROONU_14"] < 25.0)
+            & (aroonu_14 < 25.0)
             & (close < (df["EMA_20"] * 0.978))
           )
 
@@ -21386,7 +21391,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["RSI_20"] < df["RSI_20"].shift(1))
             & (rsi_3 < 30.0)
-            & (df["AROONU_14"] < 25.0)
+            & (aroonu_14 < 25.0)
             & (close < df["SMA_16"] * 0.960)
           )
 
@@ -22929,8 +22934,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["AROONU_14"] < 25.0)
-            & (df["AROOND_14"] > 75.0)
+            (aroonu_14 < 25.0)
+            & (aroond_14 > 75.0)
             & (df["STOCHRSIk_14_14_3_3"] < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.030))
@@ -23345,8 +23350,8 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (df["RSI_14"] < 30.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["AROOND_14"] > 75.0)
+            & (aroonu_14 < 25.0)
+            & (aroond_14 > 75.0)
             & (df["STOCHRSIk_14_14_3_3"] < 20.0)
             & (df["EMA_9"] < (df["EMA_26"] * 0.982))
             & (close < df["SMA_9"])
@@ -23418,7 +23423,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h up move, 1d uptrend
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 90.0) | (roc_9_1d < 100.0))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((rsi_3 < 95.0) | (df["AROOND_14_15m"] < 25.0) | (df["AROOND_14_1h"] < 25.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
           # 4m up move, 1h & 4h still low
           short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0))
           # 4m & 1h up move, 1h still low
@@ -23462,7 +23467,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 70.0))
           # 15m & 1h up move, 1h not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (df["AROOND_14_1h"] < 50.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (aroond_14_1h < 50.0))
           # 15m & 1h up move, 1d stil not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (df["RSI_14_1h"] > 80.0))
           # 15m & 1h up move, 1d uptrend
@@ -23474,7 +23479,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 90.0))
           # 15m & 4h up move, 4h not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (aroond_14_4h < 50.0))
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 30.0))
           # 15m & 4h up move, 1h low
@@ -23556,7 +23561,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 15m & 4h still low
           short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (aroond_14_15m < 50.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (stochrsi_k_15m > 90.0))
           # 1h up move, 15m still not high enough, 1h still low
@@ -23566,7 +23571,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d strong up move
           short_entry_logic.append((rsi_3_4h < 95.0) | (rsi_3_1d < 95.0))
           # 4h up move, 15m still low, 1h not high enough
-          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 50.0) | (df["AROOND_14_1h"] < 25.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 50.0) | (aroond_14_1h < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
           short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 70.0) | (roc_9_4h < 60.0))
           # 4h up move, 15m uptrend
@@ -23620,7 +23625,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d uptrend
           short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
           # 5m green, 15m still not high enough
-          short_entry_logic.append((df["change_pct"] < 5.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((df["change_pct"] < 5.0) | (aroond_14_15m < 50.0))
           # 5m green, 15m still not high enough
           short_entry_logic.append((df["change_pct"] < 5.0) | (stochrsi_k_15m > 90.0))
           # pump in the last half hour, 1h low
@@ -23812,11 +23817,11 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((close < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h < 90.0))
 
           # Logic
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
+          short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
           short_entry_logic.append(close > (df["EMA_20"] * 1.060))
           short_entry_logic.append(close > (df["BBU_20_2.0"] * 0.995))
-          short_entry_logic.append(df["AROOND_14_15m"] < 25.0)
+          short_entry_logic.append(aroond_14_15m < 25.0)
 
         # Condition #503 - Normal mode (Short).
         if short_entry_condition_index == 503:
@@ -23855,7 +23860,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 15m still not low enough, 1h & 4h still not low enough
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 75.0) | (df["MFI_14_4h"] > 50.0)
+            (rsi_3_15m < 95.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 75.0) | (df["MFI_14_4h"] > 50.0)
           )
           # 5m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0))
@@ -23876,9 +23881,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 15m still not low enough, 4h down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["AROOND_14_15m"] < 50.0) | (rsi_3_4h < 85.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (aroond_14_15m < 50.0) | (rsi_3_4h < 85.0))
           # 15m down move, 1h still high, 1d strong downtrend
-          short_entry_logic.append((rsi_3_15m < 80.0) | (df["AROOND_14_1h"] < 25.0) | (df["MFI_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_1h < 25.0) | (df["MFI_14_1d"] < 90.0))
           # 15m down move, 1h still high, 1d downtrend
           short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0) | (roc_9_1d < 50.0))
           # 15m down move, 4h still high, 1d downtrend
@@ -23896,11 +23901,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 15m strong down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["MFI_14_15m"] < 85.0) | (df["AROOND_14_15m"] < 25.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (df["MFI_14_15m"] < 85.0) | (aroond_14_15m < 25.0))
           # 14m down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 80.0) | (df["AROOND_14_15m"] < 50.0) | (df["UO_7_14_28_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m < 50.0) | (df["UO_7_14_28_4h"] > 50.0))
           # 15m down move, 1h stil high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["AROOND_14_1h"] < 25.0) | (roc_9_1d > -80.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (aroond_14_1h < 25.0) | (roc_9_1d > -80.0))
           # 15m down move, 1h high, 1d overbought
           short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | (roc_9_1d > -50.0))
           # 1h & 4h down move, 4h still high
@@ -23908,7 +23913,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h < 10.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1d > -120.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
           # 1h down move, 4h still high
@@ -23921,20 +23926,20 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_4h < 90.0) | (df["ROC_2_1d"] < 20.0) | (stochrsi_k_1h > 50.0))
           # 15m still high, 1h down move, 4h high
           short_entry_logic.append(
-            (df["AROOND_14_15m"] < 50.0) | (df["RSI_3_change_pct_1h"] < 50.0) | (stochrsi_k_4h > 30.0)
+            (aroond_14_15m < 50.0) | (df["RSI_3_change_pct_1h"] < 50.0) | (stochrsi_k_4h > 30.0)
           )
           # 15m still high, 1h & 4h down move, 4h still high
           short_entry_logic.append(
-            (df["AROOND_14_15m"] < 50.0) | (rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (stochrsi_k_4h > 80.0)
+            (aroond_14_15m < 50.0) | (rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (stochrsi_k_4h > 80.0)
           )
           # 15m & 1h still high, 4h overbought
-          short_entry_logic.append((df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_1h"] < 50.0) | (roc_9_4h > -40.0))
+          short_entry_logic.append((aroond_14_15m < 50.0) | (aroond_14_1h < 50.0) | (roc_9_4h > -40.0))
           # 15m still high, 1h down move, 1d downtrend
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
           # 1h & 4h still high, 1d strong down move
           short_entry_logic.append((stochrsi_k_1h > 50.0) | (df["UO_7_14_28_4h"] > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
-          short_entry_logic.append((df["AROOND_14_1h"] < 25.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
           # 4h moving down, 1d P&D
           short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | (roc_9_1d > -50.0))
           # 1d strong downtrend, 4h still high
@@ -23955,7 +23960,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 10.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
+            (df["change_pct_4h"] < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
           )
           # 4h red, 4h still high, 1d downtrend
           short_entry_logic.append((df["change_pct_4h"] < 10.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 40.0))
@@ -23965,14 +23970,14 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1d P&D, 4h still high
           short_entry_logic.append(
-            (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (df["AROOND_14_4h"] < 50.0)
+            (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (aroond_14_4h < 50.0)
           )
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
 
           # Logic
           short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
           short_entry_logic.append(df["RSI_4"] > 54.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
+          short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(close > df["SMA_16"] * 1.058)
 
         # Condition #504 - Normal mode (Short).
@@ -24003,15 +24008,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 75.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 75.0) | (aroond_14_4h < 50.0))
           # 15m down move, 1h strong downtrend
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
           short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
 
           # Logic
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["AROOND_14_15m"] < 25.0)
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(aroond_14_15m < 25.0)
           short_entry_logic.append(close > (df["EMA_9"] * 1.058))
           short_entry_logic.append(close > (df["EMA_20"] * 1.040))
 
@@ -24076,10 +24081,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
-            (rsi_3_1h < 90.0)
-            | (df["RSI_3_change_pct_4h"] < 50.0)
-            | (df["AROOND_14_4h"] < 25.0)
-            | (stochrsi_k_1d > 60.0)
+            (rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d > 60.0)
           )
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0) | (df["ROC_2_1d"] > -50.0))
@@ -24128,13 +24130,13 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1d P&D, 4h still high
           short_entry_logic.append(
-            (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (df["AROOND_14_4h"] < 50.0)
+            (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (aroond_14_4h < 50.0)
           )
 
           # Logic
           short_entry_logic.append(df["RSI_14"] > 64.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["AROONU_14"] > 75.0)
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(aroonu_14 > 75.0)
           short_entry_logic.append(df["EMA_9"] > (df["EMA_26"] * 1.040))
 
         # Condition #542 - Quick mode (Short).
@@ -24274,8 +24276,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           short_entry_logic.append(df["WILLR_14"] > -50.0)
-          short_entry_logic.append(df["AROONU_14"] > 75.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
+          short_entry_logic.append(aroonu_14 > 75.0)
+          short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
           short_entry_logic.append(df["WILLR_84_1h"] > -30.0)
           short_entry_logic.append(stochrsi_k_1h > 80.0)
@@ -24299,7 +24301,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h down, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["CMF_20_1h"] < 0.2) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["AROOND_14_1h"] < 25.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (aroond_14_1h < 25.0) | (stochrsi_k_4h > 10.0))
           # 15m down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (df["OBV_change_pct_15m"] < 50.0) | (stochrsi_k_1h > 30.0))
           # 5m & 1h strong down move, 1h still not low enough
@@ -24308,7 +24310,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 90.0))
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0) | (df["AROOND_14_4h"] < 50.0)
+            (rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0) | (aroond_14_4h < 50.0)
           )
           # 15m & 1h down move, 4h still high, 4h downtrend
           short_entry_logic.append(
@@ -24323,7 +24325,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 75.0) | (stochrsi_k_1h > 30.0))
           # 15m down move, 15m still not low enoug, 1h high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 10.0))
           # 15m down move, 1h downtrend, 4h overbought
           short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
           # 1h & 4h down move, 4h still not low enough
@@ -24335,7 +24337,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
           # 1h down move, 1h not low enough, 1h still high
-          short_entry_logic.append((rsi_3_1h < 85.0) | (df["AROOND_14_1h"] < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 50.0))
           # 4h down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 4h still high, 1d downtrend
@@ -24359,7 +24361,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           short_entry_logic.append(df["RSI_14"] > 60.0)
           short_entry_logic.append(df["MFI_14"] > 60.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
+          short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(df["EMA_26"] < df["EMA_12"])
           short_entry_logic.append((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.024))
           short_entry_logic.append((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
@@ -24383,7 +24385,7 @@ class NostalgiaForInfinityX7(IStrategy):
         #   # Logic
         #   short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
         #   short_entry_logic.append(df["WILLR_14"] > -20.0)
-        #   short_entry_logic.append(df["AROOND_14"] < 25.0)
+        #   short_entry_logic.append(aroond_14 < 25.0)
 
         # Condition #641 - Top Coins mode (Short).
         if short_entry_condition_index == 641:
@@ -24403,7 +24405,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h high, 4h still not low enough
           short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
           # 15m down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 1d still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1d > 70.0))
           # 15m & 1h down move, 1h still not low enough
@@ -24438,7 +24440,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
           short_entry_logic.append(rsi_3 > 70.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
+          short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(close > df["SMA_16"] * 1.044)
 
         # Condition #642 - Top Coins mode (Short).
@@ -24453,7 +24455,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m & 4h still high
           short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
           # 5m down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3 < 85.0) | (df["AROOND_14_15m"] < 50.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h > 20.0))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 90.0))
           # 15m & 1h down move, 1d still not low enough
@@ -24564,35 +24566,35 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
 
           # 15m down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (df["AROOND_14_15m"] < 80.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (aroond_14_15m < 80.0))
           # 15m & 1h down move, 15m still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (aroond_14_15m < 50.0))
           # 15m down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 15m & 1h down move, 1h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (df["AROOND_14_1h"] < 70.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (aroond_14_1h < 70.0))
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_4h"] < 80.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (aroond_14_4h < 80.0))
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m > 50.0))
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (df["AROOND_14_15m"] < 50.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 4h still high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 60.0) | (df["AROOND_14_4h"] < 50.0) | (roc_9_1d > -100.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_4h < 50.0) | (roc_9_1d > -100.0))
           # 15m down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 55.0) | (df["AROOND_14_15m"] > 30.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 55.0) | (aroond_14_15m > 30.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h > 60.0))
           # 15m down move, 15m still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 75.0) | (df["AROOND_14_4h"] < 50.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (aroond_14_4h < 50.0) | (stochrsi_k_1d > 10.0))
           short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 60.0) | (stochrsi_k_1d > 10.0))
           # 1h & 4h down move, 4h high
           short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
@@ -24603,95 +24605,95 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 40.0))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (df["AROOND_14_4h"] < 85.0) | (df["AROOND_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (aroond_14_4h < 85.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 55.0) | (df["AROOND_14_1h"] < 50.0) | (df["AROOND_14_4h"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 55.0) | (aroond_14_1h < 50.0) | (aroond_14_4h < 90.0))
           # 1h down move, 1h high
           short_entry_logic.append((rsi_3_1h < 55.0) | (stochrsi_k_1h > 40.0))
           # 1h & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (df["AROOND_14_15m"] < 70.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (aroond_14_15m < 70.0))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_4h"] < 80.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 50.0) | (aroond_14_4h < 80.0))
           # 1h down move, 15m high, 1h still high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_15m"] < 70.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h > 60.0))
           # 1h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (df["AROOND_14_1h"] < 60.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_1h"] < 70.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d > 20.0))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 10.0))
           # 1h down move, 5m up move, 1h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h > 50.0))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (df["AROOND_14_1h"] < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 40.0))
           # 1h down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_1h"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_1h"] < 50.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_1h"] < 80.0) | (df["AROOND_14_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 80.0) | (aroond_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 60.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 60.0) | (aroond_14_4h < 70.0))
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 30.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (df["RSI_14_1d"] > 20.0))
           # 4h down move, 15m high
-          short_entry_logic.append((rsi_3_4h < 80.0) | (df["AROOND_14_15m"] < 80.0))
+          short_entry_logic.append((rsi_3_4h < 80.0) | (aroond_14_15m < 80.0))
           # 4h down move, 1h high
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h > 50.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h > 50.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (df["AROOND_14_15m"] < 80.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h still high, 4h still moving down
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h > 50.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 4h down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 55.0) | (df["AROOND_14_1h"] < 70.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_4h < 55.0) | (aroond_14_1h < 70.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (df["AROOND_14_15m"] < 70.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_4h > 60.0))
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 50.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 50.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still not low enough
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 70.0))
           # 4h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h > 50.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h > 50.0) | (aroond_14_4h < 70.0))
           # 4h down move, 15m & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_4h < 70.0))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (df["AROOND_14_15m"] < 80.0) | (df["AROOND_14_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 80.0) | (aroond_14_4h < 40.0))
           # 4h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 30.0))
           # 4h down move, 15m & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
           # 4h down move, 1h & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h > 30.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h > 30.0) | (aroond_14_4h < 70.0))
           # 4h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 20.0))
           # 15m high, 4h high
-          short_entry_logic.append((df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_4h"] < 85.0))
+          short_entry_logic.append((aroond_14_15m < 70.0) | (aroond_14_4h < 85.0))
           # 15m high, 4h still high
-          short_entry_logic.append((df["AROOND_14_15m"] < 80.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((aroond_14_15m < 80.0) | (stochrsi_k_4h > 50.0))
           # 15m high, 1h still high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 60.0))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (aroond_14_4h < 70.0))
           # 15m high, 1h still not low enough
           short_entry_logic.append((stochrsi_k_15m > 20.0) | (stochrsi_k_1h > 70.0))
 
           # Logic
           short_entry_logic.append(df["RSI_14"] > 50.0)
-          short_entry_logic.append(df["AROOND_14_15m"] < 90.0)
+          short_entry_logic.append(aroond_14_15m < 90.0)
           short_entry_logic.append(stochrsi_k_15m > 10.0)
           if isinstance(df["SMA_200"].iloc[-1], np.float64):
             short_entry_logic.append(df["SMA_21"].shift(1) > df["SMA_200"].shift(1))


### PR DESCRIPTION
## Summary
- Reuses repeated AROON Series reads inside `populate_entry_trend`.
- Keeps the branch independent on latest upstream `main`.

## Safety
- This only aliases dataframe Series already read by the same entry conditions.
- Indicator formulas, candle selection, thresholds, condition order, order classification, profit arithmetic, stake sizing, and return values are unchanged.
- Touched function: `populate_entry_trend`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read dataframe Series inside the same call. The same AROON columns and comparisons are evaluated in the same order.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in validator: passed
- `git merge-tree` conflict simulation against `origin/main`: no conflict markers
- targeted `git diff` review for `populate_entry_trend` AROON replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
