### PR TITLE
Reuse X7 entry change-series reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12654,6 +12654,12 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3 = df["RSI_3"]
     close = df["close"]
     roc_9_15m = df["ROC_9_15m"]
+    cci_20_change_pct_4h = df["CCI_20_change_pct_4h"]
+    cci_20_change_pct_1h = df["CCI_20_change_pct_1h"]
+    rsi_3_change_pct_1h = df["RSI_3_change_pct_1h"]
+    rsi_3_change_pct_4h = df["RSI_3_change_pct_4h"]
+    change_pct_4h = df["change_pct_4h"]
+    change_pct_1h = df["change_pct_1h"]
     rsi_14_4h = df["RSI_14_4h"]
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
@@ -12713,7 +12719,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m & 1h down move
-            ((rsi_3 > 3.0) | (rsi_3_15m > 3.0) | (df["RSI_3_change_pct_1h"] > -50.0))
+            ((rsi_3 > 3.0) | (rsi_3_15m > 3.0) | (rsi_3_change_pct_1h > -50.0))
             # 5m & 15m down move, 5h high
             & ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (rsi_14_4h < 60.0))
             # 5m & 15m down move, 4h high
@@ -13029,7 +13035,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_change_pct_1h"] > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_change_pct_1h > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m & 1h & 4h downtrend
             & ((df["CMF_20_15m"] > -0.3) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.3))
             # 15m high, 1d overbought
@@ -20786,7 +20792,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1d still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 50.0))
           # 1h & 1d down move, 1h still moving lower
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["CCI_20_change_pct_1h"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_4h > -10.0))
           # 1h & 4h down move, 1h still high
@@ -22658,7 +22664,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (rsi_14_4h < 50.0))
           # 4h down move, 1h still high, 4h still moving down
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (df["CCI_20_change_pct_4h"] > -0.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h high, 4h still high
@@ -22898,15 +22904,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought
             & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 1h P&D, 1h down move
-            & ((df["change_pct_1h"] > -10.0) | (df["change_pct_1h"].shift(12) < 10.0) | (rsi_3_1h > 50.0))
+            & ((change_pct_1h > -10.0) | (change_pct_1h.shift(12) < 10.0) | (rsi_3_1h > 50.0))
             # 4h P&D, 4h high
-            & ((df["change_pct_4h"] > -15.0) | (df["change_pct_4h"].shift(48) < 30.0) | (aroonu_14_4h < 90.0))
+            & ((change_pct_4h > -15.0) | (change_pct_4h.shift(48) < 30.0) | (aroonu_14_4h < 90.0))
             # 4h green, 15m & 1h down move
-            & ((df["change_pct_4h"] < 10.0) | (rsi_3_15m > 10.0) | (rsi_3_1h > 35.0))
+            & ((change_pct_4h < 10.0) | (rsi_3_15m > 10.0) | (rsi_3_1h > 35.0))
             # 4h green, 1h down move
-            & ((df["change_pct_4h"] < 40.0) | (rsi_3_1h > 50.0))
+            & ((change_pct_4h < 40.0) | (rsi_3_1h > 50.0))
             # 4h green with top wick
-            & ((df["change_pct_4h"] < 50.0) | (df["change_pct_4h"] < 50.0))
+            & ((change_pct_4h < 50.0) | (change_pct_4h < 50.0))
             # 1d green with top wick, 15m still high
             & ((df["change_pct_1d"] < 10.0) | (df["top_wick_pct_1d"] < 8.0) | (aroonu_14_15m < 50.0))
             # 1d green, 4h down move, 4h still high
@@ -23434,7 +23440,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
           # 15m & 1h up move, 4h still going up
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 4h still not high enough
@@ -23458,7 +23464,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h & 1d uptrend
           short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
           # 15m up move, 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 80.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 70.0))
           # 15m & 1h up move, 1h not high enough
@@ -23592,7 +23598,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 1h & 4h still not low enough
           short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 50.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
           short_entry_logic.append((df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
@@ -23614,9 +23620,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still not high enough, 1h & 4h overbought
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 1h & 4h & 1d uptrend
           short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
           # 5m green, 15m still not high enough
@@ -23715,7 +23721,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1h > 70.0))
           # 1h up move, 4h still low, 1h moving higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 1d low
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 40.0))
           # 1h strong up move, 15m still move higher
@@ -23737,7 +23743,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 70.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_14_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 20.0))
           # 1h up move, 4h low
@@ -23759,7 +23765,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_4h > 80.0))
           # 4h up move, 15m still not high enough, 4h moving higher
-          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 80.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 80.0) | (cci_20_change_pct_4h < 0.0))
           # 4h up move, 15m still low
           short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 50.0))
           # 4h up move, 1h still low
@@ -23866,9 +23872,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 50.0) | (rsi_14_4h > 50.0))
           # 15m & 1h & 4h down move
-          short_entry_logic.append(
-            (rsi_3_15m < 90.0) | (df["RSI_3_change_pct_1h"] > -60.0) | (df["RSI_3_change_pct_4h"] > -40.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_change_pct_1h > -60.0) | (rsi_3_change_pct_4h > -40.0))
           # 15m down move, 1d downtrend, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (roc_9_1d > -25.0) | (stochrsi_k_1h > 30.0))
           # 15m & 1d down move, 1h still high
@@ -23894,7 +23898,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m downtrend, 1h & 4h still high
           short_entry_logic.append((roc_9_15m < 10.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 50.0))
           # 15m & 1h & 4h down move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_4h < 0.0))
           # 15m strong down move
           short_entry_logic.append((rsi_3_15m < 90.0) | (df["MFI_14_15m"] < 85.0) | (df["AROOND_14_15m"] < 25.0))
           # 14m down move, 4h still high
@@ -23904,7 +23908,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 1d overbought
           short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | (roc_9_1d > -50.0))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h < 10.0))
           # 1h down move, 4h still not low enough, 1d overbought
@@ -23916,12 +23920,12 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((df["RSI_3_change_pct_1h"] > -65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_change_pct_1h > -65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
           # 4h & 1d down move, 1h still high
           short_entry_logic.append((rsi_3_4h < 90.0) | (df["ROC_2_1d"] < 20.0) | (stochrsi_k_1h > 50.0))
           # 15m still high, 1h down move, 4h high
           short_entry_logic.append(
-            (df["AROOND_14_15m"] < 50.0) | (df["RSI_3_change_pct_1h"] < 50.0) | (stochrsi_k_4h > 30.0)
+            (df["AROOND_14_15m"] < 50.0) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h > 30.0)
           )
           # 15m still high, 1h & 4h down move, 4h still high
           short_entry_logic.append(
@@ -23943,22 +23947,22 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((df["ROC_2_1d"] < 10.0) | (roc_9_1d > -50.0) | (stochrsi_k_1h > 5.0))
           # 1h red, previous 1h green, 1h overbought
           short_entry_logic.append(
-            (df["change_pct_1h"] < 1.0) | (df["change_pct_1h"].shift(12) > -5.0) | (df["RSI_14_1h"].shift(12) < 80.0)
+            (change_pct_1h < 1.0) | (change_pct_1h.shift(12) > -5.0) | (df["RSI_14_1h"].shift(12) < 80.0)
           )
           # 1h red, 1h stil high, 4h downtrend
-          short_entry_logic.append((df["change_pct_1h"] < 5.0) | (stochrsi_k_1h > 50.0) | (roc_9_4h > -25.0))
+          short_entry_logic.append((change_pct_1h < 5.0) | (stochrsi_k_1h > 50.0) | (roc_9_4h > -25.0))
           # 4h red, 15m down move, 4h still high
-          short_entry_logic.append((df["change_pct_4h"] < 5.0) | (rsi_3_15m < 90.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((change_pct_4h < 5.0) | (rsi_3_15m < 90.0) | (stochrsi_k_4h > 30.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (roc_9_4h.shift(48) > -25.0)
+            (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (roc_9_4h.shift(48) > -25.0)
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 10.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
+            (change_pct_4h < 10.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
           )
           # 4h red, 4h still high, 1d downtrend
-          short_entry_logic.append((df["change_pct_4h"] < 10.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 40.0))
+          short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 40.0))
           # 1d P&D, 1d overbought
           short_entry_logic.append(
             (df["change_pct_1d"] < 10.0) | (df["change_pct_1d"].shift(288) > -10.0) | (roc_9_1d > -100.0)
@@ -23967,7 +23971,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(
             (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (df["AROOND_14_4h"] < 50.0)
           )
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < 0.0))
 
           # Logic
           short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
@@ -23999,7 +24003,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h strong down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_1h"] < 40.0) | (stochrsi_k_4h > 30.0))
           # 1h strong down move, 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still not low enough
@@ -24031,11 +24035,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m strong down move, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_4h > 10.0))
           # 15m & 1h down move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_1h"] > 0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_1h > 0.0))
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 30.0))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 50.0) | (df["MFI_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 50.0) | (df["MFI_14_4h"] > 50.0))
           # 15m strong down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["MFI_14_15m"] < 90.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 1h not low enough
@@ -24053,9 +24057,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 30.0))
           # 15m down move, 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["RSI_3_change_pct_1h"] < 30.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_change_pct_1h < 30.0) | (stochrsi_k_4h > 10.0))
           # 1m down move, 1h still dropping, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["CCI_20_change_pct_1h"] < 0.0) | (rsi_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h > 20.0))
           # 15m down move, 1h high
           short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h > 10.0))
           # 1h strong down move, 4h high
@@ -24067,30 +24071,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h strong down move
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_4h"] < 40.0))
           # 1h & 4h down move, 4h still going down
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < 0.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 70.0))
           # 1h down move, 4h down move, 4h P&D
-          short_entry_logic.append(
-            (rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 70.0) | (rsi_14_4h.shift(48) > 30.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 70.0) | (rsi_14_4h.shift(48) > 30.0))
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
-            (rsi_3_1h < 90.0)
-            | (df["RSI_3_change_pct_4h"] < 50.0)
-            | (df["AROOND_14_4h"] < 25.0)
-            | (stochrsi_k_1d > 60.0)
+            (rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 50.0) | (df["AROOND_14_4h"] < 25.0) | (stochrsi_k_1d > 60.0)
           )
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0) | (df["ROC_2_1d"] > -50.0))
           # 4h downtrend, 4h still high, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_4h > 70.0) | (roc_9_1d < 60.0))
           # 15m down move, 1h strong down move, 1d overbought
-          short_entry_logic.append((df["MFI_14_15m"] < 80.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((df["MFI_14_15m"] < 80.0) | (rsi_3_change_pct_1h < 80.0) | (roc_9_1d > -50.0))
           # 1h not low enough, 4h high, 1d strong downtrend
           short_entry_logic.append((stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((df["RSI_3_change_pct_1h"] < 65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_change_pct_1h < 65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
           # 15m strong down move, 1h still high
           short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 30.0))
           # 15m downtrend, 4h down move, 4h stil high
@@ -24105,22 +24104,16 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d P&D
           short_entry_logic.append((roc_9_4h < 20.0) | (df["ROC_2_1d"] < 20.0) | (roc_9_1d > -50.0))
           # 1h P&D, 4h overbought
-          short_entry_logic.append(
-            (df["change_pct_1h"] < 2.0) | (df["change_pct_1h"].shift(12) > 2.0) | (rsi_14_4h > 20.0)
-          )
+          short_entry_logic.append((change_pct_1h < 2.0) | (change_pct_1h.shift(12) > 2.0) | (rsi_14_4h > 20.0))
           # 1h P&D, 1d overbought
-          short_entry_logic.append(
-            (df["change_pct_1h"] < 5.0) | (df["change_pct_1h"].shift(12) > -5.0) | (roc_9_1d > -100.0)
-          )
+          short_entry_logic.append((change_pct_1h < 5.0) | (change_pct_1h.shift(12) > -5.0) | (roc_9_1d > -100.0))
           # 1h & 4h red, 1h not low enough
-          short_entry_logic.append(
-            (df["change_pct_1h"] < 10.0) | (df["change_pct_4h"] < 10.0) | (df["MFI_14_1h"] > 50.0)
-          )
+          short_entry_logic.append((change_pct_1h < 10.0) | (change_pct_4h < 10.0) | (df["MFI_14_1h"] > 50.0))
           # 1h red, 1h still not low enough, 1d down move
-          short_entry_logic.append((df["change_pct_1h"] < 15.0) | (df["MFI_14_1h"] > 50.0) | (rsi_3_1d < 90.0))
+          short_entry_logic.append((change_pct_1h < 15.0) | (df["MFI_14_1h"] > 50.0) | (rsi_3_1d < 90.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
+            (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
           )
           # 1d P&D, 1d overbought
           short_entry_logic.append(
@@ -24150,9 +24143,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (cci_20_change_pct_1h < -0.0))
           # 15m & 4h up move, 4h still moving higher
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1d up move, 4h uptrend
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1d < 80.0) | (roc_9_4h < 20.0))
           # 15m up move, 15m & 4h high
@@ -24176,7 +24169,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 60.0) | (aroonu_14_4h > 40.0))
           # 1h & 1d up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_15m > 80.0))
           # 1h & 4h up move, 1d uptrend
@@ -24184,11 +24177,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d still low
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (df["RSI_14_1d"] > 50.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 95.0) | (aroonu_14_4h > 10.0))
           # 1h & 4h up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_4h > 80.0))
           # 1h & 1d up move, 15m still low
@@ -24198,13 +24191,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 30.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 15m uptrend
           short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 30.0))
           # 1h up move, 15m & 4h uptrend
           short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 20.0) | (roc_9_4h < 20.0))
           # 1h & 4h up move, 4h still moving higher
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (df["CCI_20_change_pct_4h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (cci_20_change_pct_4h < -0.0))
           # 1h up move, 15m low
           short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_15m > 40.0))
           # 1h up move, 4h still not high enough, 1d low
@@ -24244,7 +24237,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 4h low
           short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h > 40.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h high, 4h uptrend
           short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
           # 15m & 4h high, 1h uptrend
@@ -24260,9 +24253,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h still not high enough
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 70.0))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 1d bot wick, 4h still not high enough
           short_entry_logic.append((df["bot_wick_pct_1d"] < 30.0) | (stochrsi_k_4h > 80.0))
           # rise in the last 12 hours, relatively stable before the 12 hours
@@ -24293,9 +24286,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m strong down move
           short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
           # 15m down move, 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 60.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 60.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 40.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 40.0) | (stochrsi_k_4h > 30.0))
           # 5m down move, 1h down, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["CMF_20_1h"] < 0.2) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h still not low enough, 4h high
@@ -24329,9 +24322,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 70.0))
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
           # 1h down move, 1h not low enough, 1h still high
@@ -24346,14 +24339,11 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h > 70.0) | (roc_9_1d < 50.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
+            (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
           )
           # 4h red, 4h moving down, 4h still high, 1d downtrend
           short_entry_logic.append(
-            (df["change_pct_4h"] < 10.0)
-            | (df["CCI_20_change_pct_4h"] < 0.0)
-            | (stochrsi_k_4h > 50.0)
-            | (roc_9_1d < 40.0)
+            (change_pct_4h < 10.0) | (cci_20_change_pct_4h < 0.0) | (stochrsi_k_4h > 50.0) | (roc_9_1d < 40.0)
           )
 
           # Logic
@@ -24653,7 +24643,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h still high, 4h still moving down
-          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h > 50.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h > 50.0) | (cci_20_change_pct_4h < 0.0))
           # 4h down move, 1h high, 4h still high
           short_entry_logic.append((rsi_3_4h < 55.0) | (df["AROOND_14_1h"] < 70.0) | (df["AROOND_14_4h"] < 50.0))
           # 4h down move, 15m high, 4h still high


### PR DESCRIPTION
## Summary
- Reuses repeated change-percent and CCI change Series inside `populate_entry_trend`.
- Keeps the branch independent on latest upstream `main`.

## Safety
- This only aliases dataframe Series already read by the same entry condition ladder.
- Indicator formulas, candle selection, thresholds, condition order, order classification, profit arithmetic, stake sizing, and return values are unchanged.
- Touched function: `populate_entry_trend`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read dataframe Series inside the same call. The same columns and comparisons are evaluated in the same order.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in validator: passed
- `git merge-tree` conflict simulation against `origin/main`: no conflict markers
- targeted `git diff` review for `populate_entry_trend` change-series replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
