### PR TITLE
Reuse X7 entry momentum series

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12639,6 +12639,13 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_1h = df["RSI_3_1h"]
     rsi_3_15m = df["RSI_3_15m"]
     rsi_3_4h = df["RSI_3_4h"]
+    stochrsi_k = df["STOCHRSIk_14_14_3_3"]
+    willr_14 = df["WILLR_14"]
+    roc_2 = df["ROC_2"]
+    roc_9 = df["ROC_9"]
+    mfi_14_1h = df["MFI_14_1h"]
+    mfi_14_15m = df["MFI_14_15m"]
+    bbb_20_2_0_1h = df["BBB_20_2.0_1h"]
     roc_9_1d = df["ROC_9_1d"]
     aroonu_14_4h = df["AROONU_14_4h"]
     roc_9_4h = df["ROC_9_4h"]
@@ -13061,13 +13068,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -40.0))
             # 5m down move, 15m still not low enough, 1h high
-            & ((df["ROC_2"] > -10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
+            & ((roc_2 > -10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
             # 5m down move, 15m still high
-            & ((df["ROC_2"] > -10.0) | (aroonu_14_15m < 50.0))
+            & ((roc_2 > -10.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 15m & 1h down move, 15m still high
-            & ((df["ROC_9"] > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
+            & ((roc_9 > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 4h down move, 15m downtrend, 1h high
-            & ((df["ROC_9"] > -15.0) | (rsi_3_4h > 45.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_1h < 60.0))
+            & ((roc_9 > -15.0) | (rsi_3_4h > 45.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_1h < 60.0))
             # 1h downtrend, 4h high & overbought
             & ((roc_9_1h > -25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
@@ -13762,7 +13769,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 40.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h high & overbought
             & ((aroonu_14_4h < 70.0) | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
@@ -13805,7 +13812,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             # (df["RSI_3"] > 5.0)
             (df["AROONU_14"] < 30.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
+            & (stochrsi_k < 30.0)
             # & (rsi_3_15m > 5.0)
             & (aroonu_14_15m < 50.0)
             & (close < (df["EMA_20"] * 0.948))
@@ -14482,7 +14489,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (df["RSI_4"] < 45.0)
             & (df["RSI_14"] > 30.0)
             & (df["AROONU_14"] < 20.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (stochrsi_k < 20.0)
             & (close < df["SMA_16"] * 0.965)
             & (close < df["SMA_16_1h"] * 0.985)
           )
@@ -14742,7 +14749,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
             # 4h & 1d high, 4h overbought
@@ -15066,7 +15073,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
@@ -15115,7 +15122,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 < 50.0)
             & (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
+            & (stochrsi_k < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.020))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
@@ -15871,7 +15878,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_20"] < df["RSI_20"].shift(1))
             & (rsi_3 < 46.0)
             & (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (stochrsi_k < 20.0)
             & (aroonu_14_15m < 50.0)
             & (close < df["SMA_16"] * 0.960)
           )
@@ -16098,7 +16105,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (stochrsi_k < 20.0)
             & (aroonu_14_15m < 50.0)
             & (close < df["EMA_16"] * 0.960)
             & (((df["EMA_50"] - df["EMA_200"]) / close * 100.0) > 6.0)
@@ -17261,11 +17268,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["WILLR_14"] < -50.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            (willr_14 < -50.0)
+            & (stochrsi_k < 20.0)
             & (df["WILLR_84_1h"] < -70.0)
             & (stochrsi_k_1h < 20.0)
-            & (df["BBB_20_2.0_1h"] > 16.0)
+            & (bbb_20_2_0_1h > 16.0)
             & (df["close_max_48"] >= (close * 1.10))
           )
 
@@ -18175,7 +18182,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
           # 1h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
           # 15m & 1d down move, 1d high
@@ -18628,7 +18635,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(stochrsi_k_15m < 20.0)
           long_entry_logic.append(df["WILLR_84_1h"] < -70.0)
           long_entry_logic.append(stochrsi_k_1h < 20.0)
-          long_entry_logic.append(df["BBB_20_2.0_1h"] > 12.0)
+          long_entry_logic.append(bbb_20_2_0_1h > 12.0)
           long_entry_logic.append(df["close_max_48"] >= (close * 1.10))
 
         # Condition #61 - Rebuy mode (Long).
@@ -18931,7 +18938,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
@@ -18962,7 +18969,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 < 50.0)
             & (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
+            & (stochrsi_k < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.030))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
@@ -19311,11 +19318,11 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 < 40.0)
             & (df["AROONU_14"] < 30.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (stochrsi_k < 20.0)
             & (stochrsi_k_15m < 70.0)
             & (df["WILLR_84_1h"] < -70.0)
             & (stochrsi_k_1h < 30.0)
-            & (df["BBB_20_2.0_1h"] > 12.0)
+            & (bbb_20_2_0_1h > 12.0)
             & (df["close_max_48"] >= (close * 1.10))
           )
 
@@ -19987,7 +19994,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
           # 1h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_4h > -30.0))
           # 1h down move, 1d downtrend
@@ -20127,7 +20134,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(rsi_3 > 3.0)
           long_entry_logic.append(df["RSI_14"] < 36.0)
           long_entry_logic.append(df["AROONU_14"] < 25.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
+          long_entry_logic.append(stochrsi_k < 20.0)
           long_entry_logic.append(close < (df["SMA_16"] * 0.946))
           long_entry_logic.append(aroonu_14_15m < 50.0)
 
@@ -20477,8 +20484,8 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append((close > (df["high_max_30_1d"] * 0.20)) | (stochrsi_k_1h < 80.0))
 
           # Logic
-          long_entry_logic.append(df["WILLR_14"] < -95.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 10.0)
+          long_entry_logic.append(willr_14 < -95.0)
+          long_entry_logic.append(stochrsi_k < 10.0)
           long_entry_logic.append(close < (df["BBL_20_2.0"] * 0.999))
           long_entry_logic.append(close < (df["EMA_20"] * 0.960))
 
@@ -20488,7 +20495,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
           long_entry_logic.append(df["protections_long_global"] == True)
 
-          long_entry_logic.append(df["ROC_2"] > -0.0)
+          long_entry_logic.append(roc_2 > -0.0)
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 80.0))
           # 15m & 1h & 4h down move
@@ -20917,7 +20924,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(rsi_3 < 40.0)
           long_entry_logic.append(df["AROONU_14"] < 25.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
+          long_entry_logic.append(stochrsi_k < 20.0)
           long_entry_logic.append(aroonu_14_15m < 25.0)
           long_entry_logic.append(stochrsi_k_15m < 30.0)
           long_entry_logic.append(close < df["EMA_16"] * 0.975)
@@ -20944,10 +20951,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["WILLR_14"] < -80.0)
-            & (df["AROONU_14"] < 25.0)
-            & (close < (df["EMA_20"] * 0.978))
+            (stochrsi_k < 20.0) & (willr_14 < -80.0) & (df["AROONU_14"] < 25.0) & (close < (df["EMA_20"] * 0.978))
           )
 
         # Condition #141 - Top Coins mode (Long).
@@ -21798,7 +21802,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 > 5.0)
             & (df["RSI_4"] < 46.0)
-            # & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            # & (stochrsi_k < 20.0)
             & (df["RSI_20"] < df["RSI_20"].shift(1))
             & (close < df["SMA_16"] * 0.960)
           )
@@ -22010,7 +22014,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 40.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (stochrsi_k < 20.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.020))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
@@ -22272,11 +22276,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["WILLR_14"] < -50.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
+            (willr_14 < -50.0)
+            & (stochrsi_k < 30.0)
             # & (df["STOCHRSIk_14_14_3_3_15m"] < 40.0)
             & (stochrsi_k_1h < 40.0)
-            & (df["BBB_20_2.0_1h"] > 12.0)
+            & (bbb_20_2_0_1h > 12.0)
             & (df["close_max_48"] >= (close * 1.10))
           )
 
@@ -22746,7 +22750,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (close > df["EMA_200_4h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_4h"].notna()
           )
           long_entry_logic.append(df["BBB_20_2.0"] > 1.5)
-          long_entry_logic.append(df["BBB_20_2.0_1h"] > 6.0)
+          long_entry_logic.append(bbb_20_2_0_1h > 6.0)
 
         # Condition #162 - Scalp mode (Long).
         if long_entry_condition_index == 162:
@@ -22931,7 +22935,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (df["AROONU_14"] < 25.0)
             & (df["AROOND_14"] > 75.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
+            & (stochrsi_k < 30.0)
             & (df["EMA_26"] > df["EMA_12"])
             & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.030))
             & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
@@ -23157,7 +23161,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (df["MFI_14_1h"] < 80.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h > 30.0) | (mfi_14_1h < 80.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h high
@@ -23347,7 +23351,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["RSI_14"] < 30.0)
             & (df["AROONU_14"] < 25.0)
             & (df["AROOND_14"] > 75.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (stochrsi_k < 20.0)
             & (df["EMA_9"] < (df["EMA_26"] * 0.982))
             & (close < df["SMA_9"])
           )
@@ -23532,7 +23536,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1d still low, 1h uptrend
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 50.0) | (roc_9_1h < 30.0))
           # 1h & 4h strong up move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 95.0) | (rsi_3_4h < 95.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (mfi_14_1h < 95.0) | (rsi_3_4h < 95.0))
           # 1h up move, 1d still low, 1h uptrend
           short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1d > 50.0) | (roc_9_1h < 20.0))
           # 1h strong up move, 15m still move higher
@@ -23813,7 +23817,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
+          short_entry_logic.append(stochrsi_k > 80.0)
           short_entry_logic.append(close > (df["EMA_20"] * 1.060))
           short_entry_logic.append(close > (df["BBU_20_2.0"] * 0.995))
           short_entry_logic.append(df["AROOND_14_15m"] < 25.0)
@@ -23830,7 +23834,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 5m down move, 4h still high
           short_entry_logic.append((rsi_3 < 90.0) | (df["MFI_14"] > 10.0) | (stochrsi_k_4h > 30.0))
           # 5m & 1h down move, 1h still high
@@ -23896,7 +23900,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
           # 15m strong down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["MFI_14_15m"] < 85.0) | (df["AROOND_14_15m"] < 25.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (mfi_14_15m < 85.0) | (df["AROOND_14_15m"] < 25.0))
           # 14m down move, 4h still high
           short_entry_logic.append((rsi_3_15m < 80.0) | (df["AROOND_14_15m"] < 50.0) | (df["UO_7_14_28_4h"] > 50.0))
           # 15m down move, 1h stil high, 1d overbought
@@ -23988,10 +23992,10 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (df["MFI_14_15m"] < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 50.0)
+            (rsi_3_15m < 95.0) | (mfi_14_15m < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 50.0)
           )
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["MFI_14_15m"] < 85.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (mfi_14_15m < 85.0) | (stochrsi_k_4h > 30.0))
           # 14m & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h & 4h still high
@@ -24005,7 +24009,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 75.0) | (df["AROOND_14_4h"] < 50.0))
           # 15m down move, 1h strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
           short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
 
@@ -24025,9 +24029,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m & 1h down move
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0) | (rsi_3_1h < 95.0))
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 15m & 1h strong down move & downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h > 5.0))
           # 15m strong down move, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_4h > 10.0))
           # 15m & 1h down move
@@ -24037,7 +24041,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 50.0) | (df["MFI_14_4h"] > 50.0))
           # 15m strong down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["MFI_14_15m"] < 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (mfi_14_15m < 90.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 1h not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 80.0))
           # 15m down move, 1h strong down move
@@ -24086,7 +24090,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h downtrend, 4h still high, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_4h > 70.0) | (roc_9_1d < 60.0))
           # 15m down move, 1h strong down move, 1d overbought
-          short_entry_logic.append((df["MFI_14_15m"] < 80.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((mfi_14_15m < 80.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (roc_9_1d > -50.0))
           # 1h not low enough, 4h high, 1d strong downtrend
           short_entry_logic.append((stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
           # 1h down move, 4h still high, 1d downtrend
@@ -24113,11 +24117,9 @@ class NostalgiaForInfinityX7(IStrategy):
             (df["change_pct_1h"] < 5.0) | (df["change_pct_1h"].shift(12) > -5.0) | (roc_9_1d > -100.0)
           )
           # 1h & 4h red, 1h not low enough
-          short_entry_logic.append(
-            (df["change_pct_1h"] < 10.0) | (df["change_pct_4h"] < 10.0) | (df["MFI_14_1h"] > 50.0)
-          )
+          short_entry_logic.append((df["change_pct_1h"] < 10.0) | (df["change_pct_4h"] < 10.0) | (mfi_14_1h > 50.0))
           # 1h red, 1h still not low enough, 1d down move
-          short_entry_logic.append((df["change_pct_1h"] < 15.0) | (df["MFI_14_1h"] > 50.0) | (rsi_3_1d < 90.0))
+          short_entry_logic.append((df["change_pct_1h"] < 15.0) | (mfi_14_1h > 50.0) | (rsi_3_1d < 90.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
             (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
@@ -24273,13 +24275,13 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((close < (df["low_min_30_1d"] * 4.0)) | (rsi_3_4h < 85.0))
 
           # Logic
-          short_entry_logic.append(df["WILLR_14"] > -50.0)
+          short_entry_logic.append(willr_14 > -50.0)
           short_entry_logic.append(df["AROONU_14"] > 75.0)
           short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
+          short_entry_logic.append(stochrsi_k > 80.0)
           short_entry_logic.append(df["WILLR_84_1h"] > -30.0)
           short_entry_logic.append(stochrsi_k_1h > 80.0)
-          short_entry_logic.append(df["BBB_20_2.0_1h"] > 20.0)
+          short_entry_logic.append(bbb_20_2_0_1h > 20.0)
           short_entry_logic.append(df["close_min_48"] <= (close * 0.90))
 
         # Condition #543 - Rapid mode (Short).
@@ -24291,7 +24293,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(df["RSI_14_1d"] > 10.0)
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 15m down move, 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 60.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 1h down move, 4h still not low enough
@@ -24305,7 +24307,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h strong down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 70.0))
           # 5m & 1h strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 90.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h < 90.0))
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
             (rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0) | (df["AROOND_14_4h"] < 50.0)
@@ -24381,8 +24383,8 @@ class NostalgiaForInfinityX7(IStrategy):
         #   short_entry_logic.append(df["close_max_48"] >= (df["close"] * 1.10))
 
         #   # Logic
-        #   short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
-        #   short_entry_logic.append(df["WILLR_14"] > -20.0)
+        #   short_entry_logic.append(stochrsi_k > 80.0)
+        #   short_entry_logic.append(willr_14 > -20.0)
         #   short_entry_logic.append(df["AROOND_14"] < 25.0)
 
         # Condition #641 - Top Coins mode (Short).
@@ -24706,7 +24708,7 @@ class NostalgiaForInfinityX7(IStrategy):
             short_entry_logic.append(close < df["EMA_200_4h"])
           else:
             short_entry_logic.append(pd.Series([False]))
-          short_entry_logic.append(df["BBB_20_2.0_1h"] > 4.0)
+          short_entry_logic.append(bbb_20_2_0_1h > 4.0)
 
         ###############################################################################################
 


### PR DESCRIPTION
## Summary
- Reuses repeated momentum, MFI, and base Stoch RSI Series inside `populate_entry_trend`.
- Keeps the branch independent on latest upstream `main`.

## Safety
- This only aliases dataframe Series already read by the same entry condition ladder.
- Indicator formulas, candle selection, thresholds, condition order, order classification, profit arithmetic, stake sizing, and return values are unchanged.
- Touched function: `populate_entry_trend`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read dataframe Series inside the same call. The same columns and comparisons are evaluated in the same order.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local scan included in validator: passed
- `git merge-tree` conflict simulation against `origin/main`: no conflict markers
- targeted `git diff` review for `populate_entry_trend` momentum replacements
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
