### PR TITLE
Reuse X7 short grind order fields

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -67251,75 +67251,80 @@ class NostalgiaForInfinityX7(IStrategy):
     grind_2_derisk_1_buy_orders = []
     grind_2_derisk_1_distance_ratio = 0.0
     for order in reversed(filled_orders):
-      if (order.ft_order_side == "sell") and (order is not filled_orders[0]):
+      order_side = order.ft_order_side
+      if (order_side == "sell") and (order is not filled_orders[0]):
         order_tag = ""
         if has_order_tags:
-          if order.ft_order_tag is not None:
-            order_tag = order.ft_order_tag
+          order_ft_tag = order.ft_order_tag
+          if order_ft_tag is not None:
+            order_tag = order_ft_tag
+        order_safe_filled = order.safe_filled
+        order_safe_price = order.safe_price
+        order_id = order.id
         if not is_derisk_1 and order_tag == "d1":
           derisk_1_sub_grind_count += 1
-          derisk_1_total_amount += order.safe_filled
-          derisk_1_total_cost += order.safe_filled * order.safe_price
-          derisk_1_buy_orders.append(order.id)
+          derisk_1_total_amount += order_safe_filled
+          derisk_1_total_cost += order_safe_filled * order_safe_price
+          derisk_1_buy_orders.append(order_id)
           if not derisk_1_reentry_found and not is_derisk_1:
-            derisk_1_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            derisk_1_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             derisk_1_reentry_found = True
             derisk_1_reentry_order = order
         elif not grind_1_derisk_1_is_sell_found and order_tag == "dl1":
           grind_1_derisk_1_sub_grind_count += 1
-          grind_1_derisk_1_total_amount += order.safe_filled
-          grind_1_derisk_1_total_cost += order.safe_filled * order.safe_price
-          grind_1_derisk_1_buy_orders.append(order.id)
+          grind_1_derisk_1_total_amount += order_safe_filled
+          grind_1_derisk_1_total_cost += order_safe_filled * order_safe_price
+          grind_1_derisk_1_buy_orders.append(order_id)
           if not grind_1_derisk_1_found:
-            grind_1_derisk_1_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_1_derisk_1_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_1_derisk_1_found = True
         elif not grind_2_derisk_1_is_sell_found and order_tag == "dl2":
           grind_2_derisk_1_sub_grind_count += 1
-          grind_2_derisk_1_total_amount += order.safe_filled
-          grind_2_derisk_1_total_cost += order.safe_filled * order.safe_price
-          grind_2_derisk_1_buy_orders.append(order.id)
+          grind_2_derisk_1_total_amount += order_safe_filled
+          grind_2_derisk_1_total_cost += order_safe_filled * order_safe_price
+          grind_2_derisk_1_buy_orders.append(order_id)
           if not grind_2_derisk_1_found:
-            grind_2_derisk_1_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_2_derisk_1_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_2_derisk_1_found = True
         elif not grind_6_is_sell_found and order_tag == "gd6":
           grind_6_sub_grind_count += 1
-          grind_6_total_amount += order.safe_filled
-          grind_6_total_cost += order.safe_filled * order.safe_price
-          grind_6_buy_orders.append(order.id)
+          grind_6_total_amount += order_safe_filled
+          grind_6_total_cost += order_safe_filled * order_safe_price
+          grind_6_buy_orders.append(order_id)
           if not grind_6_found:
-            grind_6_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_6_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_6_found = True
         elif not grind_5_is_sell_found and order_tag == "gd5":
           grind_5_sub_grind_count += 1
-          grind_5_total_amount += order.safe_filled
-          grind_5_total_cost += order.safe_filled * order.safe_price
-          grind_5_buy_orders.append(order.id)
+          grind_5_total_amount += order_safe_filled
+          grind_5_total_cost += order_safe_filled * order_safe_price
+          grind_5_buy_orders.append(order_id)
           if not grind_5_found:
-            grind_5_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_5_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_5_found = True
         elif not grind_4_is_sell_found and order_tag == "gd4":
           grind_4_sub_grind_count += 1
-          grind_4_total_amount += order.safe_filled
-          grind_4_total_cost += order.safe_filled * order.safe_price
-          grind_4_buy_orders.append(order.id)
+          grind_4_total_amount += order_safe_filled
+          grind_4_total_cost += order_safe_filled * order_safe_price
+          grind_4_buy_orders.append(order_id)
           if not grind_4_found:
-            grind_4_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_4_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_4_found = True
         elif not grind_3_is_sell_found and order_tag == "gd3":
           grind_3_sub_grind_count += 1
-          grind_3_total_amount += order.safe_filled
-          grind_3_total_cost += order.safe_filled * order.safe_price
-          grind_3_buy_orders.append(order.id)
+          grind_3_total_amount += order_safe_filled
+          grind_3_total_cost += order_safe_filled * order_safe_price
+          grind_3_buy_orders.append(order_id)
           if not grind_3_found:
-            grind_3_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_3_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_3_found = True
         elif not grind_2_is_sell_found and order_tag == "gd2":
           grind_2_sub_grind_count += 1
-          grind_2_total_amount += order.safe_filled
-          grind_2_total_cost += order.safe_filled * order.safe_price
-          grind_2_buy_orders.append(order.id)
+          grind_2_total_amount += order_safe_filled
+          grind_2_total_cost += order_safe_filled * order_safe_price
+          grind_2_buy_orders.append(order_id)
           if not grind_2_found:
-            grind_2_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_2_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_2_found = True
         elif not grind_1_is_sell_found and order_tag not in [
           "r",
@@ -67348,20 +67353,21 @@ class NostalgiaForInfinityX7(IStrategy):
           "gdr",
         ]:
           grind_1_sub_grind_count += 1
-          grind_1_total_amount += order.safe_filled
-          grind_1_total_cost += order.safe_filled * order.safe_price
-          grind_1_buy_orders.append(order.id)
+          grind_1_total_amount += order_safe_filled
+          grind_1_total_cost += order_safe_filled * order_safe_price
+          grind_1_buy_orders.append(order_id)
           if not grind_1_found:
-            grind_1_distance_ratio = (exit_rate - order.safe_price) / order.safe_price
+            grind_1_distance_ratio = (exit_rate - order_safe_price) / order_safe_price
             grind_1_found = True
-      elif order.ft_order_side == "buy":
+      elif order_side == "buy":
         if order is filled_exits[-1] and (order.safe_remaining * exit_rate / stake_scale_leverage) > min_stake:
           partial_sell = True
           break
         order_tag = ""
         if has_order_tags:
-          if order.ft_order_tag is not None:
-            order_tag = order.ft_order_tag.partition(" ")[0]
+          order_ft_tag = order.ft_order_tag
+          if order_ft_tag is not None:
+            order_tag = order_ft_tag.partition(" ")[0]
         if order_tag in ["dl1", "ddl1"]:
           grind_1_derisk_1_is_sell_found = True
         elif order_tag in ["dl2", "ddl2"]:


### PR DESCRIPTION
## Summary
- Reuses per-order fields inside `short_grind_adjust_trade_position` while scanning filled orders.
- Independent on latest upstream `main`.

## Safety
- Reuses values already read from the same `order` object during the same loop iteration.
- Does not change order classification, profit arithmetic, stake sizing, thresholds, condition order, return values, or entry/exit labels.
- Touched active runtime path: `short_grind_adjust_trade_position`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this only reuses exact per-order field values inside the same loop iteration. It does not change formulas, thresholds, order classification, stake sizing, or trading outputs by design.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`