### PR TITLE
Reuse X7 long exit target lookups

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -25130,7 +25130,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # Cached target profit data
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
-    target_data = cache_data.get(pair) if cache_data else None
+    profit_target_get = cache_data.get if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
 
     # Profit target logic
     if target_data:
@@ -25418,7 +25419,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # -------------------------------------------------------------------------
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
-    target_data = cache_data.get(pair) if cache_data else None
+    profit_target_get = cache_data.get if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
 
     # -------------------------------------------------------------------------
     # Profit target logic
@@ -25705,7 +25707,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # Profit Target Signal
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
-    target_data = cache_data.get(pair) if cache_data else None
+    profit_target_get = cache_data.get if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
 
     if target_data:
       previous_rate = target_data["rate"]
@@ -25953,7 +25956,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # Profit Target Signal
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
-    target_data = cache_data.get(pair) if cache_data else None
+    profit_target_get = cache_data.get if cache_data is not None else None
+    target_data = profit_target_get(pair) if profit_target_get is not None else None
 
     if target_data:
       previous_rate = target_data["rate"]
@@ -26145,7 +26149,8 @@ class NostalgiaForInfinityX7(IStrategy):
     mode = self.long_rapid_mode_name
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
-    pair_cache = cache_data.get(pair) if cache_data else None
+    profit_target_get = cache_data.get if cache_data is not None else None
+    pair_cache = profit_target_get(pair) if profit_target_get is not None else None
 
     sell = False
     signal_name = None
@@ -26510,7 +26515,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
-    pair_cache = cache_data.get(pair) if cache_data else None
+    profit_target_get = cache_data.get if cache_data is not None else None
+    pair_cache = profit_target_get(pair) if profit_target_get is not None else None
 
     sell = False
     signal_name = None
@@ -26822,7 +26828,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # Profit Target Signal
     cache = self.target_profit_cache
     cache_data = cache.data if cache is not None else None
-    pair_data = cache_data.get(pair) if cache_data and pair in cache_data else None
+    profit_target_get = cache_data.get if cache_data is not None else None
+    pair_data = profit_target_get(pair) if profit_target_get is not None else None
 
     if pair_data:
       previous_rate = pair_data["rate"]


### PR DESCRIPTION
## Summary
- Reuses the target-profit cache `get` method across long exit target paths not covered by the existing short-side lookup PR.
- Covers `long_exit_pump`, `long_exit_quick`, `long_exit_rebuy`, `long_exit_high_profit`, `long_exit_rapid`, `long_exit_top_coins`, and `long_exit_scalp`.
- Independent on latest upstream `main`.

## Safety
- Reuses the same `cache_data.get` callable already used inside each function.
- Does not change cache keys, target data values, indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or entry/exit labels.
- Touched active runtime paths: long exit target handlers listed above.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this only reuses the same cache lookup callable inside each existing exit handler. It does not change formulas, thresholds, target data, order classification, stake sizing, or trading outputs by design.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`