### PR TITLE
Hoist X7 long protection RSI-3 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4630,6 +4630,13 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_14_4h_lt_30 = protection_rsi_14_4h < 30.0
     rsi_3_15m_gt_30 = protection_rsi_3_15m > 30.0
     rsi_3_1h_gt_30 = protection_rsi_3_1h > 30.0
+    rsi_3_1h_gt_20 = protection_rsi_3_1h > 20.0
+    rsi_3_1h_gt_25 = protection_rsi_3_1h > 25.0
+    rsi_3_1h_gt_35 = protection_rsi_3_1h > 35.0
+    rsi_3_1h_gt_40 = protection_rsi_3_1h > 40.0
+    rsi_3_1h_gt_45 = protection_rsi_3_1h > 45.0
+    rsi_3_1h_gt_50 = protection_rsi_3_1h > 50.0
+    rsi_3_1h_gt_55 = protection_rsi_3_1h > 55.0
     rsi_14_15m_lt_20 = protection_rsi_14_15m < 20.0
     rsi_3_4h_gt_60 = protection_rsi_3_4h > 60.0
 
@@ -4639,7 +4646,7 @@ class NostalgiaForInfinityX7(IStrategy):
       (
         (protection_rsi_3 > 1.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_3_1d > 20.0)
         | rsi_14_1h_lt_30
@@ -4672,7 +4679,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_4h < 60.0)
@@ -4682,7 +4689,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
@@ -4693,7 +4700,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
@@ -4703,7 +4710,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_30
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -4736,7 +4743,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -4748,7 +4755,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -4761,7 +4768,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -4773,7 +4780,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_25
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -4811,7 +4818,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_30
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
@@ -4921,7 +4928,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still not low enough
       & (
         (protection_rsi_3_15m > 3.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -4943,7 +4950,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 4h downtrend, 15m & 1h still not low enough
       & (
         (protection_rsi_3_15m > 3.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 20.0)
@@ -5182,7 +5189,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 15m still not low enough, 1d high & overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -5193,7 +5200,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m downtrend, 1h still high, 15m still not low enough
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 50.0)
@@ -5202,7 +5209,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 1h & 4h high
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -5211,7 +5218,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m downtrend
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 5.0)
         | (protection_cmf_20_15m > -0.40)
@@ -5219,7 +5226,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -5229,7 +5236,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m downtrend, 4h high
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 80.0)
@@ -5277,7 +5284,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h still high, 15m still high
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -5299,7 +5306,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 3h down move, 1h & 4h still not low enough, 15m downtrend, 1h still high
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -5309,7 +5316,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h still high, 1d overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -5319,7 +5326,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1d overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -5607,7 +5614,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 1h & 4h downtrend, 15m & 1h & 4h still not low enough
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -5620,7 +5627,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.30)
@@ -5630,7 +5637,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 20.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5643,7 +5650,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 25.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 60.0)
@@ -5652,7 +5659,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_1h_lt_30
@@ -5662,7 +5669,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -5673,7 +5680,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -5686,7 +5693,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h stil high, 1h & 4h downtrend, 1h & 4h still not low
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_14_15m < 10.0)
         | rsi_14_1h_lt_30
@@ -5699,7 +5706,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 1h & 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -5710,7 +5717,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
@@ -5721,7 +5728,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -5733,7 +5740,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h & 4h still high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -5746,7 +5753,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low, 4h still high, 15m & 1h downtrend, 4h not low, 4h downtrend
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -5759,7 +5766,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h not low enouhg, 15m downtrend, 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -5770,7 +5777,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high. 1d high & overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_15m_lt_30
@@ -5782,7 +5789,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still not low enough, 1h & 4h downtrend
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
@@ -5795,7 +5802,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 1h still not low enough, 4h high & overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
@@ -5807,7 +5814,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_1d > 30.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
@@ -5860,7 +5867,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h not low enough, 4h high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 15.0)
         | rsi_14_15m_lt_30
@@ -5871,7 +5878,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1 & 4h still not low enough, 1h still high, 4h high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 35.0)
         | rsi_14_15m_lt_30
@@ -5883,7 +5890,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -5894,7 +5901,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
@@ -5906,7 +5913,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -5919,7 +5926,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h still high, 1d downtrend
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -5932,7 +5939,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 4h still high, 15m downtrend, 1h & 1d high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.3)
         | (protection_aroonu_14_1h < 60.0)
@@ -5942,7 +5949,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h still high, 1h & 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -5953,7 +5960,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -5965,7 +5972,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h sitll high, 15m & 1h & 4h downtrend, 1h & 4h still high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -5978,7 +5985,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m stil not low enough, 1h & 4h still high, 15m & 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -5990,7 +5997,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6002,7 +6009,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h still high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
@@ -6014,7 +6021,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 14h & 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
@@ -6025,7 +6032,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -6035,7 +6042,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high & overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
@@ -6047,7 +6054,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high, 1h overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6060,7 +6067,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h downtrend, 15m still high, 1h high
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_1h > -0.0)
         | (protection_cmf_20_4h > -0.4)
@@ -6070,7 +6077,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6082,7 +6089,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -6094,7 +6101,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -6304,7 +6311,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -6314,7 +6321,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high, 1h still high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -6325,7 +6332,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m downtrend, 4h high, 1h downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 30.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -6337,7 +6344,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
@@ -6348,7 +6355,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend, 1h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -6360,7 +6367,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 1h still high, 4h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -6372,7 +6379,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_15m_lt_30
@@ -6385,7 +6392,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6397,7 +6404,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 15m & 1h still not low enough, 4h high, 1d downtrend, 4h overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -6409,7 +6416,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 1h & 4h downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -6534,7 +6541,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 1d high, 4h downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 40.0)
         | (protection_rsi_3_1d > 40.0)
         | rsi_14_15m_lt_30
@@ -6547,7 +6554,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 1d downtrend, 4h overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6559,7 +6566,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h high & overbought, 1d overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6571,7 +6578,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
@@ -6584,7 +6591,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1d downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6595,7 +6602,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 1h & 4h high, 1h & 4h overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
@@ -6607,7 +6614,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d downtrend, 1h & 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -6619,7 +6626,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -6632,7 +6639,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 1h still high, 4h still not low enough, 4h downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_3_1d > 30.0)
         | rsi_14_1h_lt_30
@@ -6645,7 +6652,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h downtrend, 1h & 4h still not low enough, 1d downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_1h < 35.0)
@@ -6660,7 +6667,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h overbought, 4h downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -6673,7 +6680,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h still high, 4h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -6687,7 +6694,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 4h downtrend, 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_4h > -0.10)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
@@ -6696,7 +6703,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h & 1d still high, 1h downtrend, 1d downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -6722,7 +6729,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h downtrend, 15m & 4h still not low, 1h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -6735,7 +6742,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m ^ 1h down move, 15m & 1h & 4h still not low enough, 1h & 4h high, 1h overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6746,7 +6753,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -6759,7 +6766,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 1h & 4h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -6772,7 +6779,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
@@ -6786,7 +6793,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_1d > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
@@ -6798,7 +6805,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 14m & 1h down move, 15m & 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 65.0)
@@ -7090,7 +7097,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m downtrend, 1h & 4h till high, 15m still high, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.3)
         | (protection_aroonu_14_1h < 50.0)
@@ -7101,7 +7108,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 4h & 1d still not low enough, 1d downtrend, 1h & 4h still high, 1d downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_4h_lt_30
@@ -7114,7 +7121,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 30.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -7128,7 +7135,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h still not low enough, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 25.0)
         | (protection_roc_9_1d < 200.0)
@@ -7136,7 +7143,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 1d still high, 1d downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_4h_lt_30
@@ -7151,7 +7158,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 15m & 1h downtrend, 1h & 4h still not low enough
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
         | (protection_rsi_14_1h < 20.0)
@@ -7164,7 +7171,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -7176,7 +7183,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h still not low enough, 4h still high, 15m still not low enough, 1h & 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -7187,7 +7194,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -7200,7 +7207,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h high, 1h & 4h downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -7212,7 +7219,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
@@ -7226,7 +7233,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -7239,7 +7246,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7249,7 +7256,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 1h still not low enough, 1h still high, 4h high & overbought, 1d downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7261,7 +7268,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7271,7 +7278,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 1h & 4h still high, 15m downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_1d > 55.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7412,7 +7419,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h still not low enough, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -7424,7 +7431,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h still high, 15m still not low enough, 1h still high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
@@ -7437,7 +7444,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 1d still high, 1h still high, 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 25.0)
         | (protection_mfi_14_1d < 50.0)
@@ -7447,7 +7454,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 55.0)
         | (protection_rsi_3_1d > 55.0)
         | (protection_rsi_14_15m < 25.0)
@@ -7459,7 +7466,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -7470,7 +7477,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 1h & 4h still high, 1d downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -7483,7 +7490,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m still not lowenough, 1h high, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7494,7 +7501,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -7505,7 +7512,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h sitll high, 4h high, 1h & 4h high, 1h & 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -7530,7 +7537,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m downtrend, 15m still high, 1h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 50.0)
@@ -7539,7 +7546,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
@@ -7550,7 +7557,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 4d downtrend, 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_4h > -0.40)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -7559,7 +7566,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 15m high, 4h & 1d downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -7572,7 +7579,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | (protection_aroonu_14_15m < 30.0)
@@ -7583,7 +7590,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
@@ -7597,7 +7604,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still high, 4h high, 15m stil high, 4h high & overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -7609,7 +7616,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -7621,7 +7628,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 4h & 1d downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_15m_lt_20
@@ -7635,7 +7642,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high, 1h still high, 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -7647,7 +7654,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
@@ -7659,7 +7666,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -7671,7 +7678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low, 1h & 4h sitll high, 15m & 1h downtrend, 15m still high, 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -7684,7 +7691,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m still high, 1h & 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -7695,7 +7702,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -7706,7 +7713,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h high & overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -7718,7 +7725,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m & 1h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.10)
@@ -7729,7 +7736,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -7741,7 +7748,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h & 4h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -7752,7 +7759,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h stil high, 4h high, 1h & 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -7763,7 +7770,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m & 1h & 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -8004,7 +8011,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8015,7 +8022,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h high, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -8026,7 +8033,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m high, 1h & 4h still high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8038,7 +8045,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8050,7 +8057,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 55.0)
         | (protection_rsi_14_15m < 25.0)
@@ -8062,7 +8069,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 1h & 4h still high, 1d downtrend, 1h high, 1h & 4h still high, 1d downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8075,7 +8082,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h stil high, 4h high & overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
@@ -8086,7 +8093,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
@@ -8191,7 +8198,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -8203,7 +8210,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h still high, 15m still high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -8214,7 +8221,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -8225,7 +8232,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8236,7 +8243,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h still high, 1d downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -8250,7 +8257,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1d downtrend, 1h high, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_1d > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8263,7 +8270,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -8276,7 +8283,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 4h & 1d downtrend, 1h & 4h high, 1d downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_1d > 35.0)
         | (protection_cmf_20_4h > -0.1)
         | (protection_cmf_20_1d > -0.1)
@@ -8287,7 +8294,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -8300,7 +8307,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
@@ -8311,7 +8318,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
@@ -8325,7 +8332,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 10.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -8339,7 +8346,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8352,7 +8359,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -8363,7 +8370,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -8375,7 +8382,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m sitll not low enough, 1h still high, 4h high, 15m & 1h downtrend, 15m & 1h still high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -8387,7 +8394,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -8398,7 +8405,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -8411,7 +8418,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 15m high, 4h downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -8425,7 +8432,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m & 4h high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8437,7 +8444,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8449,7 +8456,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -8462,7 +8469,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 1d down move, 15m & 1h & 4h still high, 15m & 1d downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_1d > 55.0)
         | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 45.0)
@@ -8475,7 +8482,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h stil high, 15m & 1h & 4h high, 1d downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8487,7 +8494,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -8500,7 +8507,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 4h downtrend, 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_15m_lt_20
@@ -8513,7 +8520,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
@@ -8527,7 +8534,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -8539,7 +8546,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -8551,7 +8558,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -8562,7 +8569,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h & 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -8574,7 +8581,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high & overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -8587,7 +8594,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -8596,7 +8603,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still high, 1h & 4h high, 1h overbought, 1d downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -9021,7 +9028,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9032,7 +9039,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m high, 4h downtrend
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9043,7 +9050,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9056,7 +9063,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1h still not low enough, 4h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9069,7 +9076,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h downtrend, 15m & 1h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9081,7 +9088,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h sitll high, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
@@ -9092,7 +9099,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h still high, 4h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9105,7 +9112,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15h & 4h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9117,7 +9124,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
@@ -9125,7 +9132,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9138,7 +9145,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still low, 1h & 4h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9149,7 +9156,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m & 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9161,7 +9168,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h high, 1d downtrend
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
         | (protection_aroonu_14_15m < 60.0)
@@ -9172,7 +9179,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 4h downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_15m_lt_30
@@ -9184,7 +9191,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9195,7 +9202,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m & 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9207,7 +9214,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
@@ -9220,7 +9227,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1d overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9232,7 +9239,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still high, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -9243,7 +9250,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m still high, 1h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -9254,7 +9261,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h stil high, 4h high, 1h downtrend
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
@@ -9265,7 +9272,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9277,7 +9284,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1h & 1d overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -9288,7 +9295,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 4h downtrend, 15m & 1h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | (protection_rsi_3_1d > 55.0)
         | (protection_cmf_20_15m > -0.25)
@@ -9299,7 +9306,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -9309,7 +9316,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -9322,7 +9329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -9490,7 +9497,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h still high, 1h & 4h high, 4h overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -9501,7 +9508,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h still high, 1d downtrend
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -9514,7 +9521,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h high, 1d overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -9524,7 +9531,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h still high, 4h high, 15m & 4h high, 4h overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -9536,7 +9543,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 15m high, 4h high & overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
@@ -9548,7 +9555,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
@@ -9558,7 +9565,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still high, 15m & 1h high, 1d overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_15m_lt_40
@@ -9571,7 +9578,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still highm 15m & 1h high, 1h still high, 4h high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9584,7 +9591,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9597,7 +9604,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9610,7 +9617,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h still high, 4h high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9622,7 +9629,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
@@ -9633,14 +9640,14 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 90.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high, 1d overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_3_4h_gt_60
         | (protection_rsi_14_15m < 50.0)
         | rsi_14_1h_lt_50
@@ -9651,7 +9658,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h still high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -9663,7 +9670,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 1h & 4h high, 1h overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9676,7 +9683,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 4h overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9688,7 +9695,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9824,7 +9831,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high & overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9836,7 +9843,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h sitll not low enough, 4h still high, 15m high
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -9847,7 +9854,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 1d downtrend, 4h still not low enough, 15m still high, 1h downtrend
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
         | (protection_cmf_20_1d > -0.40)
@@ -9858,7 +9865,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h high
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 45.0)
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.40)
@@ -9868,7 +9875,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9880,7 +9887,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 90.0)
@@ -9890,7 +9897,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -9901,7 +9908,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high, 1h & 4h downtrend
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -9913,7 +9920,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9924,7 +9931,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h high
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
@@ -9933,7 +9940,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still high, 15m & 1h high, 1d overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_15m_lt_40
@@ -9946,7 +9953,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h downtrend, 4h overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9960,7 +9967,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -10064,7 +10071,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h still high, 4h & 1d overbought
       & (
         (protection_rsi_3_15m > 45.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
@@ -10077,7 +10084,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
       & (
         (protection_rsi_3_15m > 45.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -10090,7 +10097,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h & 1d downtrend, 1h & 4h high
       & (
         (protection_rsi_3_15m > 45.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -10103,7 +10110,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h down move, 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
         (protection_rsi_3_15m > 45.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -10114,7 +10121,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m still high, 1d overbought
       & (
         (protection_rsi_3_15m > 45.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_15m_lt_30
@@ -10126,7 +10133,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h high & overbought
       & (
         (protection_rsi_3_15m > 45.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -10196,7 +10203,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m & 4h high
       & (
         (protection_rsi_3_15m > 55.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -10353,14 +10360,14 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h down move, 1h still not low enough, 4h downtrend
       & (
-        (protection_rsi_3_1h > 20.0)
+        rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 3.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_roc_9_4h > -25.0)
       )
       # 1h & 4h down move, 1h & 4h downtrend, 1h high, 4h downtrend
       & (
-        (protection_rsi_3_1h > 20.0)
+        rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
@@ -10369,7 +10376,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h & 1d down move, 1h & 4h still not low enough, 1d high & overbought
       & (
-        (protection_rsi_3_1h > 20.0)
+        rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 40.0)
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_1h_lt_30
@@ -10380,7 +10387,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 1d down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 1h still high
       & (
-        (protection_rsi_3_1h > 20.0)
+        rsi_3_1h_gt_20
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_15m < 10.0)
         | (protection_rsi_14_1h < 20.0)
@@ -10391,7 +10398,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d downtrend
       & (
-        (protection_rsi_3_1h > 25.0)
+        rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -10400,7 +10407,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h down move, 1h & 4h still not low enough, 4h still high, 1h & 4h downtrend, 1d overbought
       & (
-        (protection_rsi_3_1h > 25.0)
+        rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -10411,7 +10418,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 5m & 15m & 1h & 4h down move, 15m downtrend, 4h high, 1d overbought
       & (
-        (protection_rsi_3_1h > 25.0)
+        rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.5)
         | (protection_cmf_20_1h > -0.3)
@@ -10420,7 +10427,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h down move, 1h & 4h high, 4h overbought
       & (
-        (protection_rsi_3_1h > 25.0)
+        rsi_3_1h_gt_25
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -10462,7 +10469,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h < 25.0)
       )
       # 1h down move, 1h still high, 4h overbought
-      & ((protection_rsi_3_1h > 55.0) | rsi_14_1h_lt_40 | (protection_roc_9_4h < 300.0))
+      & (rsi_3_1h_gt_55 | rsi_14_1h_lt_40 | (protection_roc_9_4h < 300.0))
       # 1h & 1d down move, 1h & 4h & 1d still high, 1h & 4h high, 4h overbought
       & (
         (protection_rsi_3_1h > 60.0)
@@ -10714,7 +10721,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_4h > -30.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -10725,7 +10732,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_4h > -5.0)
         | (protection_change_pct_4h.shift(48) < 5.0)
         | (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -10738,7 +10745,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_4h < 10.0)
         | (protection_top_wick_pct_4h < 10.0)
         | (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -10749,7 +10756,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_4h < 10.0)
         | (protection_top_wick_pct_4h < 10.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
@@ -10761,7 +10768,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_4h < 15.0)
         | (protection_top_wick_pct_4h < 15.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
       )
@@ -10770,7 +10777,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_4h < 15.0)
         | (protection_top_wick_pct_4h < 10.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
       )
@@ -10778,7 +10785,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_4h < 15.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -10788,7 +10795,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d red, 1h & 4h down move, 1h still high, 4d downtrend
       & (
         (protection_change_pct_1d > -40.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 10.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_4h > -35.0)
@@ -10806,7 +10813,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -20.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_14_1h < 35.0)
         | rsi_14_4h_lt_40
@@ -10816,7 +10823,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d red, 1h & 4h & 1d down move, 1h still not low enough, 4h & 1d still high, 1d downtrend
       & (
         (protection_change_pct_1d > -20.0)
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_1h_lt_30
@@ -10829,7 +10836,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -20.0)
         | rsi_3_15m_gt_30
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_1d < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
@@ -10840,7 +10847,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -15.0)
         | (protection_change_pct_1d.shift(288) < 15.0)
         | (protection_rsi_3_15m > 50.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -10853,7 +10860,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 10.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 10.0)
         | (protection_rsi_3_1d > 40.0)
         | rsi_14_4h_lt_30
@@ -10863,7 +10870,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 10.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
@@ -10882,7 +10889,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 20.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -10894,7 +10901,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -10.0)
         | (protection_change_pct_1d.shift(288) < 50.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -10908,7 +10915,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -10.0)
         | (protection_top_wick_pct_1d < 10.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_cmf_20_1h > -0.2)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -10918,7 +10925,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -5.0)
         | (protection_change_pct_1d.shift(288) < 10.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -10941,7 +10948,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -5.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -10966,7 +10973,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -11000,7 +11007,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -11023,7 +11030,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -11033,7 +11040,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 20.0)
         | (protection_top_wick_pct_1d < 20.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -11044,7 +11051,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 20.0)
         | (protection_top_wick_pct_1d < 20.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -11083,7 +11090,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 20.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -11104,7 +11111,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 20.0)
-        | (protection_rsi_3_1h > 50.0)
+        | rsi_3_1h_gt_50
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 70.0)
@@ -11116,7 +11123,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 30.0)
         | (protection_top_wick_pct_1d < 30.0)
         | rsi_3_15m_gt_25
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 80.0)
@@ -11146,7 +11153,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 50.0)
         | (protection_top_wick_pct_1d < 50.0)
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -11156,7 +11163,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 50.0)
         | (protection_top_wick_pct_1d < 50.0)
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 50.0)
@@ -11196,7 +11203,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_top_wick_pct_4h < 20.0)
         | (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -11273,7 +11280,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_close > (protection_high_max_6_4h * 0.70))
         | (protection_close < (protection_low_min_6_1d * 1.25))
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 45.0)
         | (protection_roc_9_1d < 20.0)
@@ -11304,7 +11311,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (((protection_high_max_30_1d - protection_low_min_30_1d) / protection_low_min_30_1d) < 10.0)
         | (protection_close > (protection_high_max_6_1d * 0.50))
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -11322,7 +11329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_12_1h * 0.50))
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_1h > 35.0)
+        | rsi_3_1h_gt_35
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -11342,7 +11349,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_24_4h * 0.40))
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -11352,7 +11359,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_24_4h * 0.40))
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 40.0)
+        | rsi_3_1h_gt_40
         | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 10.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -11361,7 +11368,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_24_4h * 0.35))
         | (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_aroonu_14_1d < 80.0)
@@ -11380,7 +11387,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 4 days, 1h & 5h & 1d down move, 1h still high, 1h & 4h downtrend
       & (
         (protection_close > (protection_high_max_24_4h * 0.25))
-        | (protection_rsi_3_1h > 20.0)
+        | rsi_3_1h_gt_20
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 25.0)
         | (protection_aroonu_14_1h < 50.0)
@@ -11466,7 +11473,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_20_1d * 0.05))
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_1d > 25.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
@@ -11474,7 +11481,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 20 days, 1h & 4h & 1d down move, 1h & 4h still not low enough, 1h & 4h & 1d downtrend
       & (
         (protection_close > (protection_high_max_20_1d * 0.01))
-        | (protection_rsi_3_1h > 45.0)
+        | rsi_3_1h_gt_45
         | rsi_3_4h_gt_60
         | (protection_rsi_3_1d > 15.0)
         | (protection_rsi_14_1h < 15.0)
@@ -11491,7 +11498,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_30_1d * 0.10))
         | rsi_3_15m_gt_10
-        | (protection_rsi_3_1h > 55.0)
+        | rsi_3_1h_gt_55
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 80.0)
@@ -11508,7 +11515,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_30_1d * 0.05))
         | rsi_3_15m_gt_25
-        | (protection_rsi_3_1h > 25.0)
+        | rsi_3_1h_gt_25
         | (protection_rsi_3_4h > 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)


### PR DESCRIPTION
## Summary
- Hoists repeated long-global protection RSI-3 1h comparison masks in `populate_indicators`.
- Independent on latest upstream `main`.

## Safety
- Reuses exact boolean comparisons already evaluated from `protection_rsi_3_1h` inside the same `populate_indicators` call.
- Does not change indicator formulas, candle selection, thresholds, condition order, order classification, profit arithmetic, stake sizing, return values, or entry/exit labels.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this only reuses exact boolean masks inside the same `populate_indicators` call. It does not change formulas, thresholds, condition order, or trading outputs by design.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`