### PR TITLE
Hoist X7 long protection RSI-3 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4632,6 +4632,15 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_1h_gt_30 = protection_rsi_3_1h > 30.0
     rsi_14_15m_lt_20 = protection_rsi_14_15m < 20.0
     rsi_3_4h_gt_60 = protection_rsi_3_4h > 60.0
+    rsi_3_4h_gt_20 = protection_rsi_3_4h > 20.0
+    rsi_3_4h_gt_25 = protection_rsi_3_4h > 25.0
+    rsi_3_4h_gt_30 = protection_rsi_3_4h > 30.0
+    rsi_3_4h_gt_35 = protection_rsi_3_4h > 35.0
+    rsi_3_4h_gt_40 = protection_rsi_3_4h > 40.0
+    rsi_3_4h_gt_45 = protection_rsi_3_4h > 45.0
+    rsi_3_4h_gt_50 = protection_rsi_3_4h > 50.0
+    rsi_3_4h_gt_55 = protection_rsi_3_4h > 55.0
+    rsi_3_4h_gt_65 = protection_rsi_3_4h > 65.0
 
     # Global protections Long
     df["protections_long_global"] = (
@@ -4640,7 +4649,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 1.0)
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_rsi_3_1d > 20.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -4673,7 +4682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_1d < 80.0)
@@ -4694,7 +4703,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -4704,7 +4713,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_30
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -4716,7 +4725,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 5.0)
         | rsi_3_15m_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -4737,7 +4746,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -4749,7 +4758,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -4762,7 +4771,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -4799,7 +4808,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_25
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -4838,7 +4847,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 3.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_aroonu_14_1h < 50.0)
         | (protection_roc_9_15m > -10.0)
         | (protection_roc_9_1h > -15.0)
@@ -4847,7 +4856,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
@@ -4874,7 +4883,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
@@ -4884,7 +4893,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -4894,7 +4903,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.30)
         | (protection_aroonu_14_4h < 40.0)
@@ -4903,7 +4912,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.25)
@@ -4913,7 +4922,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 25.0)
@@ -4922,7 +4931,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_15m > -0.20)
@@ -4934,7 +4943,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 50.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_cci_20_1h < -250.0)
@@ -4944,7 +4953,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 30.0)
@@ -4961,7 +4970,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 1h & 4h still high, 15m still not low enough, 1h still high
       & (
         (protection_rsi_3_15m > 3.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 25.0)
@@ -4979,7 +4988,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.15)
@@ -4991,7 +5000,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.10)
@@ -5004,7 +5013,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -5014,7 +5023,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.40)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -5023,7 +5032,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -5033,7 +5042,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 30.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
@@ -5043,7 +5052,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
@@ -5053,7 +5062,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_aroonu_14_15m < 50.0)
@@ -5062,7 +5071,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 40.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_roc_9_1d < 100.0)
@@ -5071,7 +5080,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.20)
@@ -5082,7 +5091,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
@@ -5102,7 +5111,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -5111,7 +5120,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_rsi_3_1d > 55.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 40.0)
@@ -5132,7 +5141,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
@@ -5143,7 +5152,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
@@ -5155,7 +5164,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.10)
@@ -5167,7 +5176,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
@@ -5183,7 +5192,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -5194,7 +5203,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -5212,7 +5221,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 5.0)
         | (protection_cmf_20_15m > -0.40)
       )
@@ -5230,7 +5239,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 80.0)
       )
@@ -5238,7 +5247,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -5249,7 +5258,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_4h > -40.0)
       )
@@ -5257,7 +5266,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
@@ -5278,7 +5287,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5300,7 +5309,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
@@ -5310,7 +5319,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
@@ -5320,7 +5329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -5354,7 +5363,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.40)
@@ -5363,7 +5372,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h still not low enough, 1d overbought
       & (
         (protection_rsi_3_15m > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_rsi_14_15m < 10.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5457,7 +5466,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
@@ -5468,7 +5477,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_1h > -10.0)
@@ -5477,7 +5486,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
@@ -5487,7 +5496,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -5497,7 +5506,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_14_15m < 10.0)
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
@@ -5509,7 +5518,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -5522,7 +5531,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5533,7 +5542,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5553,7 +5562,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5564,7 +5573,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
@@ -5576,7 +5585,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -5589,7 +5598,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_roc_9_1d < 200.0)
@@ -5598,7 +5607,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.4)
         | (protection_aroonu_14_4h < 80.0)
@@ -5608,7 +5617,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.15)
@@ -5621,7 +5630,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
@@ -5631,7 +5640,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.25)
@@ -5644,7 +5653,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -5653,7 +5662,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5663,7 +5672,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -5674,7 +5683,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -5687,7 +5696,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_14_15m < 10.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5700,7 +5709,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -5734,7 +5743,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -5747,7 +5756,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5760,7 +5769,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
@@ -5771,7 +5780,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -5783,7 +5792,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
@@ -5820,7 +5829,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5831,7 +5840,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_14_1h < 45.0)
         | (protection_rsi_14_4h < 55.0)
         | (protection_aroonu_14_4h < 70.0)
@@ -5861,7 +5870,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_3_1d > 15.0)
         | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 35.0)
@@ -5872,7 +5881,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_3_1d > 35.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -5895,7 +5904,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -5907,7 +5916,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -5966,7 +5975,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
@@ -5979,7 +5988,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -5991,7 +6000,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -6003,7 +6012,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
@@ -6015,7 +6024,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -6048,7 +6057,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6061,7 +6070,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_cmf_20_1h > -0.0)
         | (protection_cmf_20_4h > -0.4)
         | (protection_aroonu_14_15m < 50.0)
@@ -6071,7 +6080,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6148,7 +6157,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h & 1d down move, 15m & 1h still not low enough, 1h still high, 4h & 1d downtrend
       & (
         (rsi_3_15m_gt_10)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_rsi_3_1d > 20.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -6215,7 +6224,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6228,7 +6237,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_3_1d > 50.0)
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
@@ -6239,7 +6248,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_3_1d > 50.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 60.0)
@@ -6250,7 +6259,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_rsi_3_1d > 40.0)
         | (protection_rsi_14_15m > 20.0)
         | rsi_14_4h_lt_30
@@ -6263,7 +6272,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 45.0)
         | (protection_aroonu_14_1h < 40.0)
@@ -6274,7 +6283,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_1d < 150.0)
       )
@@ -6305,7 +6314,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -6315,7 +6324,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6326,7 +6335,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -6338,7 +6347,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -6386,7 +6395,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6420,7 +6429,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_15m < 25.0)
         | (protection_rsi_14_1h < 25.0)
@@ -6433,7 +6442,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
@@ -6444,7 +6453,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_14_1h < 35.0)
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
@@ -6455,7 +6464,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6468,7 +6477,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 45.0)
@@ -6478,7 +6487,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6491,7 +6500,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -6535,7 +6544,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_rsi_3_1d > 40.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -6548,7 +6557,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6560,7 +6569,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6585,7 +6594,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -6633,7 +6642,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_rsi_3_1d > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6646,7 +6655,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_1h < 35.0)
         | (protection_rsi_14_4h < 35.0)
@@ -6661,7 +6670,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6674,7 +6683,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -6688,7 +6697,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_cmf_20_4h > -0.10)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_4h > -30.0)
@@ -6697,7 +6706,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -6723,7 +6732,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6773,7 +6782,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -6925,7 +6934,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h high, 4h downtrend
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6935,10 +6944,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 1h high & overbought
       & (
-        (rsi_3_15m_gt_15)
-        | (protection_rsi_3_4h > 45.0)
-        | (protection_stochrsik_14_14_3_3_1h < 90.0)
-        | (protection_roc_9_1h < 10.0)
+        (rsi_3_15m_gt_15) | rsi_3_4h_gt_45 | (protection_stochrsik_14_14_3_3_1h < 90.0) | (protection_roc_9_1h < 10.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
@@ -7078,7 +7084,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 45.0)
         | (protection_cmf_20_15m > -0.40)
         | (protection_aroonu_14_1h < 20.0)
@@ -7091,7 +7097,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.3)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -7102,7 +7108,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 30.0)
@@ -7115,7 +7121,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -7129,7 +7135,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_aroonu_14_1h < 25.0)
         | (protection_roc_9_1d < 200.0)
       )
@@ -7137,7 +7143,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 50.0)
@@ -7152,7 +7158,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_rsi_3_1d > 50.0)
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
@@ -7165,7 +7171,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7188,7 +7194,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -7201,7 +7207,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
@@ -7227,7 +7233,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7282,7 +7288,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -7292,7 +7298,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 40.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -7306,7 +7312,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -7319,7 +7325,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -7331,7 +7337,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
@@ -7345,7 +7351,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7413,7 +7419,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -7425,7 +7431,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
@@ -7438,7 +7444,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 25.0)
         | (protection_mfi_14_1d < 50.0)
         | (protection_aroonu_14_1h < 50.0)
@@ -7448,7 +7454,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_rsi_3_1d > 55.0)
         | (protection_rsi_14_15m < 25.0)
         | rsi_14_1h_lt_50
@@ -7460,7 +7466,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7517,7 +7523,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h downtrend, 15m & 1h still high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -7531,7 +7537,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_roc_9_1d < 100.0)
@@ -7540,7 +7546,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -7551,7 +7557,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_cmf_20_4h > -0.40)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -30.0)
@@ -7560,7 +7566,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -7584,7 +7590,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -7598,7 +7604,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -7622,7 +7628,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -7636,7 +7642,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7648,7 +7654,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -7672,7 +7678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -7696,7 +7702,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7707,7 +7713,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -7719,7 +7725,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
@@ -7730,7 +7736,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -7844,7 +7850,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h sitll high, 4h high, 4h & 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7856,7 +7862,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h & 1d down move, 15m & 1h & 4h s till high, 15m & 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -7868,7 +7874,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h still not low enough, 15m still high, 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | (protection_aroonu_14_15m < 40.0)
@@ -7878,7 +7884,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h still high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_4h > -30.0)
@@ -7886,7 +7892,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m &4d down move, 15m & 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -30.0)
@@ -7894,7 +7900,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 4h still high, 4h downtrend, 1d overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h > -30.0)
         | (protection_roc_9_1d < 100.0)
@@ -7902,7 +7908,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still not low enough, 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -7913,7 +7919,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15, & 4h still high, 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -7925,7 +7931,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still high, 1h high, 4h overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -7949,7 +7955,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m still high, 1h still high, 4h high & overbought
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -7960,7 +7966,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m still not low enough, 1h & 4h high, 15m & 1h & 4h high
       & (
         (rsi_3_15m_gt_20)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
@@ -8005,7 +8011,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -8016,7 +8022,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -8027,7 +8033,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8051,7 +8057,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 55.0)
         | (protection_rsi_14_15m < 25.0)
         | rsi_14_1h_lt_30
@@ -8098,7 +8104,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -8110,7 +8116,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 30.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.40)
@@ -8121,7 +8127,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -8132,7 +8138,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -8144,7 +8150,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
@@ -8156,7 +8162,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8169,7 +8175,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -8192,7 +8198,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -8204,7 +8210,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -8215,7 +8221,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
@@ -8226,7 +8232,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -8237,7 +8243,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -8264,7 +8270,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -8399,7 +8405,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -8412,7 +8418,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -8426,7 +8432,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8438,7 +8444,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -8450,7 +8456,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8501,7 +8507,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -8588,7 +8594,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -25.0)
@@ -8696,7 +8702,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h & 1d down move, 15m high, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 30.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_roc_9_1d < 50.0)
@@ -8715,7 +8721,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h still not low enough, 4h still high,  1h & 4h downtrend, 15m & 1h & 4h still high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -8728,7 +8734,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 1h & 4h downtrend
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -8738,7 +8744,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8773,7 +8779,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h still high, 4h overbought
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8895,7 +8901,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -8909,7 +8915,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_50
@@ -8921,7 +8927,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 30.0)
         | (protection_rsi_14_15m < 25.0)
         | (protection_rsi_14_1h < 25.0)
@@ -8935,7 +8941,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -8949,7 +8955,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -8963,7 +8969,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -8975,7 +8981,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
@@ -8987,7 +8993,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9022,7 +9028,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9033,7 +9039,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9044,7 +9050,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9093,7 +9099,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9106,7 +9112,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9118,7 +9124,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
@@ -9126,7 +9132,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9139,7 +9145,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9150,7 +9156,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9162,7 +9168,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 45.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 85.0)
@@ -9173,7 +9179,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -9185,7 +9191,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9208,7 +9214,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -9221,7 +9227,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9233,7 +9239,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
@@ -9266,7 +9272,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9289,7 +9295,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_rsi_3_1d > 55.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_4h > -0.20)
@@ -9300,7 +9306,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -9310,7 +9316,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -9323,7 +9329,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -9400,7 +9406,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h still high, 1h & 4h downtrend, 15m & 1h still high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | (protection_cmf_20_1h > -0.10)
@@ -9412,7 +9418,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9434,7 +9440,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9444,7 +9450,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h stil high, 14m & 4h high
       & (
         (rsi_3_15m_gt_30)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -9502,7 +9508,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -9515,7 +9521,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
@@ -9525,7 +9531,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
@@ -9549,7 +9555,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -9559,7 +9565,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
@@ -9572,7 +9578,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9585,7 +9591,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9598,7 +9604,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9634,7 +9640,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_stochrsik_14_14_3_3_15m < 90.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high, 1d overbought
@@ -9652,7 +9658,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -9664,7 +9670,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9677,7 +9683,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9756,7 +9762,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m still high, 1h high, 15m & 1h high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
@@ -9765,7 +9771,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9775,7 +9781,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 15m & 1h still high
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9788,7 +9794,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h downtrend
       & (
         (protection_rsi_3_15m > 35.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9825,7 +9831,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9837,7 +9843,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -9848,7 +9854,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_rsi_3_1d > 45.0)
         | (protection_cmf_20_1d > -0.40)
         | (protection_aroonu_14_4h < 30.0)
@@ -9859,7 +9865,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.40)
@@ -9902,7 +9908,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
@@ -9914,7 +9920,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9925,7 +9931,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -9961,7 +9967,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -9972,7 +9978,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9998,7 +10004,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m &4h down move, 15m & 1h & 4h still high, 15m still high, 1h high, 15m & 1h overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -10010,7 +10016,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h overbought
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -10065,7 +10071,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -10115,7 +10121,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
@@ -10127,7 +10133,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -10160,7 +10166,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h & 4h still high
       & (
         (protection_rsi_3_15m > 45.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -10227,17 +10233,13 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h downtrend, 4h still high
       & (
         (protection_rsi_3_1h > 3.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_1h > -0.30)
         | (protection_aroonu_14_4h < 50.0)
       )
       # 1h & 4h down move, 1h still not low enough, 4h still high, 1d overbought
       & (
-        (protection_rsi_3_1h > 3.0)
-        | (protection_rsi_3_4h > 35.0)
-        | rsi_14_1h_lt_30
-        | rsi_14_4h_lt_50
-        | (protection_roc_9_1d < 80.0)
+        (protection_rsi_3_1h > 3.0) | rsi_3_4h_gt_35 | rsi_14_1h_lt_30 | rsi_14_4h_lt_50 | (protection_roc_9_1d < 80.0)
       )
       # 1h & 4h & 1d down move, 1d still not low enough, 1d downtrend
       & (
@@ -10257,7 +10259,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still high
       & (
         (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
@@ -10267,7 +10269,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 15m & 1hg downtrend, 4h downtrend
       & (
         (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.40)
         | (protection_roc_9_4h > -20.0)
@@ -10275,7 +10277,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h still high, 4h high, 1d overbought
       & (
         (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1d < 50.0)
@@ -10283,7 +10285,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h & 4h still high, 4h high, 15m & 1h downtrend
       & (
         (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -10293,7 +10295,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 15m & 1h still not low enough, 4h high, 1d overbought
       & (
         (protection_rsi_3_1h > 5.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -10303,7 +10305,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h high
       & (
         (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_15m > -0.0)
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
@@ -10312,7 +10314,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h & 4h downtrend, 1h high
       & (
         (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 20.0)
+        | rsi_3_4h_gt_20
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.40)
         | (protection_aroonu_14_1h < 60.0)
@@ -10361,7 +10363,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h & 4h downtrend, 1h high, 4h downtrend
       & (
         (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_1h < 80.0)
@@ -10370,7 +10372,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h & 1d down move, 1h & 4h still not low enough, 1d high & overbought
       & (
         (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -10392,7 +10394,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d downtrend
       & (
         (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -10401,7 +10403,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h & 4h still not low enough, 4h still high, 1h & 4h downtrend, 1d overbought
       & (
         (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
@@ -10412,7 +10414,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 5m & 15m & 1h & 4h down move, 15m downtrend, 4h high, 1d overbought
       & (
         (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_cmf_20_15m > -0.5)
         | (protection_cmf_20_1h > -0.3)
         | (protection_cmf_20_4h > -0.3)
@@ -10431,7 +10433,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h still high
       & (
         (rsi_3_1h_gt_30)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 5.0)
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
@@ -10441,7 +10443,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 1h & 4h still high, 1h still not low enough, 4h still high, 1h downtrend, 4h & 1d overbought
       & (
         (rsi_3_1h_gt_30)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 25.0)
@@ -10580,7 +10582,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 4h & 1d down move, 1h still high, 4h high, 1d downtrend
       & (
-        (protection_rsi_3_4h > 25.0)
+        rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -10590,7 +10592,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 4h down move, 1h & 4h still not low enough, 15m high, 4h downtrend
       & (
-        (protection_rsi_3_4h > 25.0)
+        rsi_3_4h_gt_25
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
@@ -10599,7 +10601,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1h still high, 4h downtrend
       & (
-        (protection_rsi_3_4h > 30.0)
+        rsi_3_4h_gt_30
         | (protection_rsi_3_1d > 40.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
@@ -10610,7 +10612,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 4h down move, 15m & 1h & 4h still high, 15m high, 4h still not low enough, 1d overbought
       & (
-        (protection_rsi_3_4h > 35.0)
+        rsi_3_4h_gt_35
         | (protection_rsi_14_15m < 50.0)
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -10622,7 +10624,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 4h down move, 15m high, 15m & 1h & 4h high, 4h & 1d overbought
       & (
-        (protection_rsi_3_4h > 55.0)
+        rsi_3_4h_gt_55
         | (protection_aroonu_14_15m < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -10715,7 +10717,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_4h > -30.0)
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 70.0)
@@ -10726,7 +10728,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_change_pct_4h.shift(48) < 5.0)
         | (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -10798,7 +10800,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -20.0)
         | (protection_change_pct_1d.shift(288) < 20.0)
         | rsi_3_15m_gt_20
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
@@ -10807,7 +10809,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -20.0)
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_rsi_14_1h < 35.0)
         | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
@@ -10817,7 +10819,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d > -20.0)
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -10830,7 +10832,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -20.0)
         | rsi_3_15m_gt_30
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_aroonu_14_1d < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -10841,7 +10843,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_change_pct_1d.shift(288) < 15.0)
         | (protection_rsi_3_15m > 50.0)
         | (protection_rsi_3_1h > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -10883,7 +10885,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_change_pct_1d.shift(288) < 20.0)
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
@@ -10895,7 +10897,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_change_pct_1d.shift(288) < 50.0)
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -10930,7 +10932,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_change_pct_1d.shift(288) < 10.0)
         | rsi_3_15m_gt_25
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_roc_9_1h > -25.0)
@@ -10942,7 +10944,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -5.0)
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1d < 85.0)
@@ -10967,7 +10969,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 10.0)
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 30.0)
@@ -11001,7 +11003,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 10.0)
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
@@ -11024,7 +11026,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 10.0)
         | (protection_top_wick_pct_1d < 10.0)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
       )
@@ -11045,7 +11047,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d < 20.0)
         | (protection_top_wick_pct_1d < 20.0)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
@@ -11084,7 +11086,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 20.0)
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1d < 100.0)
@@ -11136,7 +11138,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 50.0)
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | rsi_14_4h_lt_50
         | (protection_roc_9_4h < 40.0)
         | (protection_roc_9_1d < 100.0)
@@ -11147,7 +11149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 50.0)
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 30.0)
+        | rsi_3_4h_gt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 70.0)
@@ -11165,7 +11167,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 50.0)
         | (protection_top_wick_pct_1d < 50.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_4h_lt_40
         | (protection_roc_9_1d < 200.0)
       )
@@ -11173,7 +11175,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_change_pct_1d < 50.0)
         | (protection_rsi_3_15m > 50.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -11208,7 +11210,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_top_wick_pct_1d < 20.0)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 45.0)
+        | rsi_3_4h_gt_45
         | (protection_cmf_20_15m > -0.2)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1d < 80.0)
@@ -11216,7 +11218,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d top wick, 4h down move, 4h still high, 1d overbought
       & (
         (protection_top_wick_pct_1d < 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_14_4h < 45.0)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_roc_9_1d < 200.0)
@@ -11226,7 +11228,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_top_wick_pct_1d < 25.0)
         | rsi_3_15m_gt_10
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
         | (protection_aroonu_14_4h < 50.0)
@@ -11261,7 +11263,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_top_wick_pct_1d < 80.0)
         | (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_3_4h > 65.0)
+        | rsi_3_4h_gt_65
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -11274,7 +11276,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_close < (protection_low_min_6_1d * 1.25))
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 45.0)
         | (protection_roc_9_1d < 20.0)
       )
@@ -11293,7 +11295,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (((protection_high_max_12_1d - protection_low_min_12_1d) / protection_low_min_12_1d) < 3.0)
         | rsi_3_15m_gt_20
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -11323,7 +11325,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_12_1h * 0.50))
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_4h > 55.0)
+        | rsi_3_4h_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -11343,7 +11345,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_24_4h * 0.40))
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_roc_9_4h < 20.0)
@@ -11362,7 +11364,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_24_4h * 0.35))
         | (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 30.0)
         | (protection_aroonu_14_1d < 80.0)
         | (protection_roc_9_4h > -40.0)
@@ -11381,7 +11383,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_24_4h * 0.25))
         | (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 25.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_roc_9_1h > -20.0)
@@ -11420,7 +11422,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 4 days, 4h & 1d down move, 1h high
       & (
         (protection_close > (protection_high_max_24_4h * 0.15))
-        | (protection_rsi_3_4h > 25.0)
+        | rsi_3_4h_gt_25
         | (protection_rsi_3_1d > 25.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
@@ -11447,7 +11449,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_12_1d * 0.25))
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 10.0)
-        | (protection_rsi_3_4h > 35.0)
+        | rsi_3_4h_gt_35
         | (protection_rsi_3_1d > 35.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -40.0)
@@ -11500,7 +11502,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_30_1d * 0.05))
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_4h > 50.0)
+        | rsi_3_4h_gt_50
         | (protection_aroonu_14_15m < 80.0)
         | (protection_stochrsik_14_14_3_3_1h < 85.0)
       )
@@ -11509,7 +11511,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_30_1d * 0.05))
         | rsi_3_15m_gt_25
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_4h > 40.0)
+        | rsi_3_4h_gt_40
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )


### PR DESCRIPTION
## Summary
- Hoists repeated long-global protection RSI-3 4h comparison masks in `populate_indicators`.
- Independent on latest upstream `main`.

## Safety
- Reuses exact boolean comparisons already evaluated from `protection_rsi_3_4h` inside the same `populate_indicators` call.
- Does not change indicator formulas, candle selection, thresholds, condition order, order classification, profit arithmetic, stake sizing, return values, or entry/exit labels.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this only reuses exact boolean masks inside the same `populate_indicators` call. It does not change formulas, thresholds, condition order, or trading outputs by design.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`