### PR TITLE
Reuse X7 long protection low AROON 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4562,6 +4562,13 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_aroonu_14_15m = df["AROONU_14_15m"].to_numpy(copy=False)
     protection_cmf_20_15m = df["CMF_20_15m"].to_numpy(copy=False)
     protection_aroonu_14_4h = df["AROONU_14_4h"].to_numpy(copy=False)
+    # Reuse long protection low AROON 4h comparison masks
+    aroonu_14_4h_lt_20 = protection_aroonu_14_4h < 20.0
+    aroonu_14_4h_lt_25 = protection_aroonu_14_4h < 25.0
+    aroonu_14_4h_lt_30 = protection_aroonu_14_4h < 30.0
+    aroonu_14_4h_lt_40 = protection_aroonu_14_4h < 40.0
+    aroonu_14_4h_lt_50 = protection_aroonu_14_4h < 50.0
+    aroonu_14_4h_lt_60 = protection_aroonu_14_4h < 60.0
     protection_roc_9_1d = df["ROC_9_1d"].to_numpy(copy=False)
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
@@ -4675,7 +4682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_1d < 80.0)
       )
       # 5m & 15m & 1h down move, 1h & 4h still high, 15m still high, 1h high
@@ -4804,7 +4811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
       )
       # 5m & 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m & 4h high
@@ -4816,7 +4823,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
@@ -4859,7 +4866,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 20.0)
+        | aroonu_14_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m downtrend, 15m & 1h still not low enough
       & (
@@ -4897,7 +4904,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.30)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m downtrend
       & (
@@ -4907,7 +4914,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.25)
-        | (protection_aroonu_14_4h < 25.0)
+        | aroonu_14_4h_lt_25
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m still not low enough
       & (
@@ -4984,7 +4991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.15)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 20.0)
+        | aroonu_14_4h_lt_20
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h still high, 15m still not low enough, 15m & 1h downtrend
@@ -5087,7 +5094,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 4h still high
       & (
@@ -5124,7 +5131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 10.0)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 20.0)
+        | aroonu_14_4h_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
@@ -5261,7 +5268,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h high, 4h overbought
@@ -5283,7 +5290,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h high
@@ -5313,7 +5320,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_1d < 70.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1d overbought
@@ -5368,7 +5375,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 20.0)
+        | aroonu_14_4h_lt_20
         | (protection_roc_9_1d < 20.0)
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 1h overbought
@@ -5423,7 +5430,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.15)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m still high
       & (
@@ -5450,7 +5457,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still high, 4h still not low enough
@@ -5515,7 +5522,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 1h downtrend
@@ -5557,7 +5564,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 15m still not low enough
@@ -5635,7 +5642,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.25)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_cci_20_1h < -200.0)
         | (protection_cci_20_4h < -0.0)
         | (protection_roc_9_1d < 30.0)
@@ -5694,7 +5701,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 1h & 4h still high, 1d overbought
       & (
@@ -5753,7 +5760,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_aroonu_14_4h < 20.0)
+        | aroonu_14_4h_lt_20
         | (protection_roc_9_4h > -10.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h not low enouhg, 15m downtrend, 4h high, 1d overbought
@@ -5764,7 +5771,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_1d < 25.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high. 1d high & overbought
@@ -5788,7 +5795,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 25.0)
-        | (protection_aroonu_14_4h < 25.0)
+        | aroonu_14_4h_lt_25
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -5984,7 +5991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h high
@@ -6076,7 +6083,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
@@ -6100,7 +6107,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 10.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 15m & 1h high
@@ -6221,7 +6228,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 4h downtrend, 1h still not low enough
@@ -6257,7 +6264,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.0)
-        | (protection_aroonu_14_4h < 20.0)
+        | aroonu_14_4h_lt_20
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h high, 1h downtrend
       & (
@@ -6287,7 +6294,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high. 4h overbought
@@ -6331,7 +6338,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_1h > -10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
@@ -6390,7 +6397,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -6460,7 +6467,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 25.0)
         | (protection_roc_9_1d < 30.0)
       )
@@ -6484,7 +6491,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high, 4h high & overbought
@@ -6729,7 +6736,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.25)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # 15m ^ 1h down move, 15m & 1h & 4h still not low enough, 1h & 4h high, 1h overbought
@@ -6778,7 +6785,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 10.0)
@@ -6947,7 +6954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -7094,7 +7101,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.3)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -7221,7 +7228,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
       & (
@@ -7297,7 +7304,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_roc_9_1h > -15.0)
         | (protection_roc_9_4h > -30.0)
         | (protection_roc_9_1d < 40.0)
@@ -7337,7 +7344,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 25.0)
       )
@@ -7349,7 +7356,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
@@ -7382,7 +7389,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 200.0)
       )
@@ -7418,7 +7425,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_roc_9_4h > -50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h still high, 15m still not low enough, 1h still high
@@ -7429,7 +7436,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_roc_9_4h > -30.0)
@@ -7589,7 +7596,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_cci_20_1h < 0.0)
         | (protection_cci_20_4h < 0.0)
         | (protection_roc_9_4h < 40.0)
@@ -7849,7 +7856,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_4h < 15.0)
         | (protection_roc_9_1d < 60.0)
       )
@@ -7862,7 +7869,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 15m still high, 1h high, 4h downtrend
@@ -7895,7 +7902,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h > -30.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -7907,7 +7914,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15, & 4h still high, 1h high, 4h downtrend
@@ -7918,7 +7925,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -7954,7 +7961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h high, 15m & 1h & 4h high
@@ -8009,7 +8016,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h high, 1d overbought
@@ -8033,7 +8040,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h high
       & (
@@ -8150,7 +8157,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h stil high, 4h high, 4h overbought
       & (
@@ -8218,7 +8225,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -8269,7 +8276,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 20.0)
       )
@@ -8357,7 +8364,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high, 4h & 1d overbought
@@ -8403,7 +8410,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_4h < 10.0)
@@ -8520,7 +8527,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
@@ -8723,7 +8730,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 1h & 4h downtrend
       & (
@@ -8886,7 +8893,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 10.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -30.0)
@@ -8941,7 +8948,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -9016,7 +9023,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
@@ -9062,7 +9069,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
@@ -9155,7 +9162,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h high, 1d downtrend
@@ -9461,7 +9468,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_roc_9_1d < 200.0)
       )
       # 15m down move, 15m still not low enough, 1h & 4h high
@@ -9590,7 +9597,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -9731,7 +9738,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1d < 150.0)
       )
@@ -9841,7 +9848,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
       # 15m & 1h & 4h & 1d down move, 1d downtrend, 4h still not low enough, 15m still high, 1h downtrend
@@ -9851,7 +9858,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
         | (protection_cmf_20_1d > -0.40)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_1h > -25.0)
       )
@@ -9952,7 +9959,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_4h > -0.15)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 25.0)
@@ -10070,7 +10077,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 40.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -10221,7 +10228,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 15m high
       & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | (protection_stochrsik_14_14_3_3_15m < 50.0))
       # 1h & 4h down move, 4h still not low enough
-      & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | (protection_aroonu_14_4h < 20.0))
+      & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | aroonu_14_4h_lt_20)
       # 1h & 4h down move, 15m still not low enough, 4h downtrend
       & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 5.0) | rsi_14_15m_lt_30 | (protection_cmf_20_4h > -0.30))
       # 1h & 4h down move, 1h downtrend, 4h still high
@@ -10229,7 +10236,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 3.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 1h & 4h down move, 1h still not low enough, 4h still high, 1d overbought
       & (
@@ -10262,7 +10269,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 1h & 4h down move, 15m & 1hg downtrend, 4h downtrend
       & (
@@ -10285,7 +10292,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_15m > -10.0)
         | (protection_roc_9_1h > -20.0)
@@ -10333,7 +10340,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 20.0)
+        | aroonu_14_4h_lt_20
         | (protection_stochrsik_14_14_3_3_15m < 80.0)
         | (protection_roc_9_1h > -30.0)
         | (protection_roc_9_4h > -30.0)
@@ -10374,7 +10381,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 60.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_aroonu_14_1d < 70.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -10445,7 +10452,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 25.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 100.0)
@@ -10513,7 +10520,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 3.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 4h down move, 15m & 1h high, 4h downtrend
@@ -10538,7 +10545,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 4h down move, 1h & 4h downtrend, 1h still not low enough, 4h high
@@ -10615,7 +10622,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_1d < 50.0)
@@ -10846,7 +10853,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 1d P&D, 15m & 1h & 4h & 1d down move, 4h still not low enough
       & (
@@ -10932,7 +10939,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 30.0)
+        | aroonu_14_4h_lt_30
         | (protection_roc_9_1h > -25.0)
         | (protection_roc_9_4h > -25.0)
         | (protection_roc_9_1d < 50.0)
@@ -10971,7 +10978,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
       )
       # 1d green with top wick, 15m down move, 1h & 4h high, 1d overbought
       & (
@@ -11006,7 +11013,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_4h < 60.0)
+        | aroonu_14_4h_lt_60
       )
       # 1d green with top wick, 15m down move, 15m & 1h still high, 4h high & overbought
       & (
@@ -11026,7 +11033,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 1d green with top wick, 15m & 1h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
@@ -11048,7 +11055,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -11086,7 +11093,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_1d < 100.0)
       )
       # 1d green with top wick, 15m down move, 15m & 1h still high, 4h high & overbought
@@ -11158,7 +11165,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 50.0)
         | (protection_rsi_3_1h > 45.0)
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_4h < 50.0)
       )
       # 1d green with top wick, 4h down move, 4h still high, 1d overbought
@@ -11210,7 +11217,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_cmf_20_15m > -0.2)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_roc_9_1d < 80.0)
       )
       # 1d top wick, 4h down move, 4h still high, 1d overbought
@@ -11218,7 +11225,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_top_wick_pct_1d < 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_14_4h < 45.0)
-        | (protection_aroonu_14_4h < 40.0)
+        | aroonu_14_4h_lt_40
         | (protection_roc_9_1d < 200.0)
       )
       # 1d top wick, 15m & 1h & 4h down move, 15m & 1h downtrend, 4h still high
@@ -11229,7 +11236,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 50.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # 1d top wick, 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high
       & (
@@ -11241,7 +11248,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
       )
@@ -11265,7 +11272,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_4h < 50.0)
+        | aroonu_14_4h_lt_50
       )
       # pump, drop but not yet near the previous lows, 15m & 1h & 4h & 1d down move, 1d overbought
       & (


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection low AROON 4h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
