### PR TITLE
Hoist X7 long protection high AROON 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4562,6 +4562,13 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_aroonu_14_15m = df["AROONU_14_15m"].to_numpy(copy=False)
     protection_cmf_20_15m = df["CMF_20_15m"].to_numpy(copy=False)
     protection_aroonu_14_4h = df["AROONU_14_4h"].to_numpy(copy=False)
+    # Hoist long protection high AROON 4h comparison masks
+    aroonu_14_4h_lt_70 = protection_aroonu_14_4h < 70.0
+    aroonu_14_4h_lt_75 = protection_aroonu_14_4h < 75.0
+    aroonu_14_4h_lt_80 = protection_aroonu_14_4h < 80.0
+    aroonu_14_4h_lt_85 = protection_aroonu_14_4h < 85.0
+    aroonu_14_4h_lt_90 = protection_aroonu_14_4h < 90.0
+    aroonu_14_4h_lt_100 = protection_aroonu_14_4h < 100.0
     protection_roc_9_1d = df["ROC_9_1d"].to_numpy(copy=False)
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
@@ -4696,7 +4703,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 5m & 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h high
@@ -4754,7 +4761,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 5m & 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high
@@ -4778,7 +4785,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_roc_9_4h < 80.0)
       )
@@ -4829,7 +4836,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 30.0)
@@ -5206,7 +5213,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend
       & (
@@ -5232,7 +5239,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 4h high
       & (
@@ -5293,7 +5300,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 15m & 1h & 3h down move, 1h & 4h still not low enough, 15m downtrend, 1h still high
@@ -5346,7 +5353,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 75.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -5378,7 +5385,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 10.0)
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 4h overbought
@@ -5388,7 +5395,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -5481,7 +5488,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
       )
       # 15m & 1h & 4h down move, 4h still not low enough, 1h still high, 4h high
       & (
@@ -5490,7 +5497,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 15m still not low enough
@@ -5545,7 +5552,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 80.0)
       )
@@ -5601,7 +5608,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.4)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 1h & 4h downtrend, 15m & 1h & 4h still not low enough
@@ -5647,7 +5654,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d overbought
       & (
@@ -5714,7 +5721,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -5726,7 +5733,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 20.0)
       )
@@ -5800,7 +5807,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -5834,7 +5841,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_14_1h < 45.0)
         | (protection_rsi_14_4h < 55.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 25.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -5846,7 +5853,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
       )
       # 15m & 1h down move, 4h high, 1d downtrend, 1h still not low enough, 1d overbought
       & (
@@ -5888,7 +5895,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
@@ -5900,7 +5907,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still high
@@ -5947,7 +5954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
@@ -5959,7 +5966,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h sitll high, 15m & 1h & 4h downtrend, 1h & 4h still high
@@ -6029,7 +6036,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high & overbought
@@ -6040,7 +6047,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -6054,7 +6061,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_1h < 10.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h downtrend, 15m still high, 1h high
@@ -6087,7 +6094,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -6121,7 +6128,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 65.0)
         | (protection_aroonu_14_15m < 80.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 1h & 4h overbought
@@ -6132,7 +6139,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -6172,7 +6179,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 30.0)
         | (protection_roc_9_4h < 80.0)
       )
@@ -6183,7 +6190,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -6243,7 +6250,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 50.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_1d > -40.0)
       )
       # 15m & 1h & 4h & 1d down move, 4h still not low enough, 15m & 1h & 4h downtrend
@@ -6267,7 +6274,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 45.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h > -30.0)
       )
       # 15m & 1h & 4h down move, 4h high, 1d overbought
@@ -6275,7 +6282,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_1d < 150.0)
       )
       # 15m & 1h down move, 15m & 1h still not low enough, 4h still high, 4h high
@@ -6298,7 +6305,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m downtrend
@@ -6343,7 +6350,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend, 1h high
       & (
@@ -6366,7 +6373,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 4h high, 1d overbought
@@ -6378,7 +6385,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d < 30.0)
       )
@@ -6402,7 +6409,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -6447,7 +6454,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_14_1h < 35.0)
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 25.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -6496,7 +6503,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 15.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 1d downtrend, 4h overbought
@@ -6509,7 +6516,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1d > -0.10)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high
@@ -6520,7 +6527,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h down move, 15m still high, 1h & dh high, 1d overbought
       & (
@@ -6528,7 +6535,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | rsi_14_15m_lt_40
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 1d high, 4h downtrend
@@ -6552,7 +6559,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -6564,7 +6571,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -6577,7 +6584,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
@@ -6600,7 +6607,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 40.0)
       )
@@ -6613,7 +6620,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.1)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1d < 20.0)
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h overbought
@@ -6625,7 +6632,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_stochrsik_14_14_3_3_4h < 85.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -6751,7 +6758,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 20.0)
@@ -6792,7 +6799,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d < 50.0)
       )
       # 14m & 1h down move, 15m & 1h still high, 4h high & overbought
@@ -6804,7 +6811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 65.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 35.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 5h still high, 15m still high, 4h & 1d overbought
@@ -6839,7 +6846,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m downtrend, 1h & 4h high, 4h overbought
@@ -6851,7 +6858,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 1h overbought
@@ -6863,7 +6870,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 15.0)
       )
       # 15m & 4h down move, 15m high, 4h downtrend
@@ -6930,7 +6937,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 4h down move, 1h high & overbought
@@ -6959,7 +6966,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -6980,7 +6987,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
@@ -7003,14 +7010,14 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_cmf_20_1d > -0.1)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 1d overbought
       & (
         (rsi_3_15m_gt_15)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d < 250.0)
       )
       # 15m down move, 15m & 1h still high, 1h high, 1h overbought, 4h & 1d downtrend
@@ -7052,7 +7059,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
@@ -7170,7 +7177,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h down move, 15m & 1h still not low enough, 4h still high, 15m still not low enough, 1h & 4h high
@@ -7182,7 +7189,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1d overbought
       & (
@@ -7253,7 +7260,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_4h < 40.0)
         | (protection_roc_9_1d > -50.0)
@@ -7311,7 +7318,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
@@ -7360,7 +7367,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -7393,7 +7400,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
@@ -7405,7 +7412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -7442,7 +7449,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 25.0)
         | (protection_mfi_14_1d < 50.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high
       & (
@@ -7454,7 +7461,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
@@ -7464,7 +7471,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 1h & 4h still high, 1d downtrend
@@ -7510,7 +7517,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -7577,7 +7584,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h overbought
@@ -7603,7 +7610,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 1h & 4h high, 4h overbought
@@ -7615,7 +7622,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 4h & 1d downtrend
@@ -7653,7 +7660,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h downtrend, 1d overbought
@@ -7690,7 +7697,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 1d overbought
       & (
@@ -7745,7 +7752,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
-        | (protection_aroonu_14_4h < 75.0)
+        | aroonu_14_4h_lt_75
         | (protection_roc_9_4h < 25.0)
         | (protection_roc_9_1d < 150.0)
       )
@@ -7756,7 +7763,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_1h < 40.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -7769,7 +7776,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m & 4h high, 15m & 1h still not low enough, 4h overbought
       & (
@@ -7779,7 +7786,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 65.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_roc_9_4h < 30.0)
@@ -7792,7 +7799,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_1h < 15.0)
       )
       # 15m & 1h down move, 15m still high, 1h high & overbought
@@ -7811,7 +7818,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m < 35.0)
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 75.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 100.0)
@@ -7826,7 +7833,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 15m still high, 1h & 4h high, 1d overbought
@@ -7838,7 +7845,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h sitll high, 4h high, 4h & 1d overbought
@@ -7941,7 +7948,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
@@ -7966,7 +7973,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 1h & 4h overbought
       & (
@@ -7975,7 +7982,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_1h < 50.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -7985,7 +7992,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_4h < 75.0)
@@ -7997,7 +8004,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 50.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -8045,7 +8052,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 1d overbought
       & (
@@ -8080,7 +8087,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
@@ -8091,7 +8098,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h stil high, 15m still high, 1d overbought
@@ -8174,7 +8181,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
@@ -8185,7 +8192,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h downtrend, 1d overbought
@@ -8230,7 +8237,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h still high, 1d downtrend
@@ -8295,7 +8302,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
       & (
@@ -8304,7 +8311,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 80.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -8316,7 +8323,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
@@ -8345,7 +8352,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -8368,7 +8375,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 15.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -8443,7 +8450,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 4h high & overbought
@@ -8455,7 +8462,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -8492,7 +8499,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 30.0)
@@ -8545,7 +8552,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h & 1d overbought
@@ -8581,7 +8588,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h high, 4h downtrend
@@ -8601,7 +8608,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_1d > -30.0)
       )
@@ -8624,7 +8631,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_4h < 60.0)
@@ -8648,7 +8655,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_4h < 120.0)
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 1h & 4h & 1d overbought
@@ -8659,7 +8666,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 50.0)
         | (protection_roc_9_1d < 250.0)
@@ -8743,7 +8750,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h overbought
@@ -8766,7 +8773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 25.0)
         | (protection_roc_9_1d < 200.0)
       )
@@ -8804,7 +8811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
@@ -8817,7 +8824,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
@@ -8829,7 +8836,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 25.0)
@@ -8841,7 +8848,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -8852,7 +8859,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 75.0)
         | (protection_cmf_20_1d > -0.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_4h < 50.0)
       )
       # 15m down move, 15m & 1h high, 1h & 4h overbought
@@ -8955,7 +8962,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.15)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_cci_20_1h < -100.0)
         | (protection_cci_20_4h < 0.0)
       )
@@ -8968,7 +8975,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1d high
@@ -8992,7 +8999,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 25.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
@@ -9027,7 +9034,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m high, 4h downtrend
       & (
@@ -9049,7 +9056,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -9086,7 +9093,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h still high, 4h high
@@ -9111,7 +9118,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 1h & 4h down move, 15m high
@@ -9143,7 +9150,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m & 4h still high, 4h overbought
@@ -9166,7 +9173,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 45.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d > -50.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 4h downtrend, 1d overbought
@@ -9201,7 +9208,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high, 4h & 1d overbought
@@ -9260,7 +9267,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_cmf_20_1h > -0.10)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high, 1d overbought
       & (
@@ -9271,7 +9278,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1h & 1d overbought
@@ -9328,7 +9335,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 25.0)
@@ -9352,7 +9359,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 50.0)
         | (protection_roc_9_1d < 150.0)
       )
@@ -9364,7 +9371,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h < 50.0)
         | (protection_roc_9_4h < 100.0)
       )
@@ -9375,7 +9382,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_4h < 130.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still high
@@ -9417,7 +9424,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high & overbought
       & (
@@ -9427,7 +9434,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 75.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 40.0)
         | (protection_roc_9_4h < 40.0)
       )
@@ -9449,7 +9456,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
@@ -9471,7 +9478,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
@@ -9495,7 +9502,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h still high, 1d downtrend
@@ -9530,7 +9537,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 15m high, 4h high & overbought
@@ -9541,7 +9548,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 40.0)
       )
@@ -9603,7 +9610,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_1d < 40.0)
       )
@@ -9617,7 +9624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_1h > -0.30)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
@@ -9670,7 +9677,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_1h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 4h overbought
@@ -9694,7 +9701,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_1d < 75.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 1h high
@@ -9741,7 +9748,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 65.0)
         | (protection_rsi_14_15m < 50.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h < 20.0)
       )
       # 15m & 4h down move, 15m & 1h high, 4h downtrend
@@ -9804,7 +9811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_stochrsik_14_14_3_3_1h < 60.0)
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
         | (protection_roc_9_1h < 20.0)
@@ -9830,7 +9837,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h sitll not low enough, 4h still high, 15m high
@@ -9863,7 +9870,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.40)
-        | (protection_aroonu_14_4h < 75.0)
+        | aroonu_14_4h_lt_75
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
@@ -9874,7 +9881,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
@@ -9884,7 +9891,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 90.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h high & overbought
@@ -9895,7 +9902,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high, 1h & 4h downtrend
@@ -9928,7 +9935,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still high, 15m & 1h high, 1d overbought
       & (
@@ -9965,7 +9972,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h high, 4h overbought
@@ -10025,7 +10032,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m < 50.0)
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -10037,7 +10044,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 90.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 100.0)
       )
       # 15m down move, 15m still high, 1h & 4h high & overbought
@@ -10047,7 +10054,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 70.0)
         | (protection_roc_9_4h < 80.0)
       )
@@ -10059,7 +10066,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h still high, 4h & 1d overbought
       & (
@@ -10084,7 +10091,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h & 1d downtrend, 1h & 4h high
@@ -10098,7 +10105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.10)
         | (protection_cmf_20_1d > -0.30)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
       )
       # 15m & 1h down move, 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
@@ -10106,7 +10113,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 45.0)
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_1h < 30.0)
         | (protection_roc_9_4h < 100.0)
@@ -10132,7 +10139,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 1h & 4h high, 1h & 4h overbought
@@ -10143,7 +10150,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1h < 30.0)
         | (protection_roc_9_4h < 80.0)
       )
@@ -10189,7 +10196,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 40.0)
         | (protection_roc_9_4h < 100.0)
       )
@@ -10203,7 +10210,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h high, 1h & 4h overbought
@@ -10214,7 +10221,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1h < 30.0)
         | (protection_roc_9_4h < 70.0)
       )
@@ -10277,7 +10284,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_1d < 50.0)
       )
       # 1h & 4h down move, 1h & 4h still high, 4h high, 15m & 1h downtrend
@@ -10297,7 +10304,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_1d < 100.0)
       )
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h high
@@ -10424,7 +10431,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 80.0)
       )
@@ -10457,7 +10464,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -10471,7 +10478,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_mfi_14_1d < 50.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_4h < 25.0)
       )
       # 4h down move, 15m & 1h & 4h still not low enough
@@ -10585,7 +10592,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
         | (protection_roc_9_1d > -40.0)
       )
       # 4h down move, 1h & 4h still not low enough, 15m high, 4h downtrend
@@ -10675,7 +10682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h > -60.0)
       )
       # 1d down move, 1h still high, 4h high
-      & ((protection_rsi_3_1d > 5.0) | (protection_aroonu_14_1h < 40.0) | (protection_aroonu_14_4h < 70.0))
+      & ((protection_rsi_3_1d > 5.0) | (protection_aroonu_14_1h < 40.0) | aroonu_14_4h_lt_70)
       # 1d down move, 4h high, 1h & 4h downtrend
       & (
         (protection_rsi_3_1d > 5.0)
@@ -10699,7 +10706,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_1d > -40.0)
       )
       # 15m & 1h & 4h still high, 4h downtrend, 4h overbought
@@ -10718,7 +10725,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
       )
       # 4h P&D, 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
@@ -10731,7 +10738,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 4h green with top wick, 15m & 1h down move, 15m still not low enough, 1h & 4h high
       & (
@@ -10743,7 +10750,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
       )
       # 4h green with top wick, 1h down move, 1h still high, 4h high, 1d overbought
       & (
@@ -10753,7 +10760,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 90.0)
+        | aroonu_14_4h_lt_90
         | (protection_roc_9_1d < 20.0)
       )
       # 4h green with top wick, 15m & 1h down move, 1h still high, 4h high
@@ -10763,7 +10770,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 35.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 4h green with top wick, 15m & 1h down move, 1h & 4h high
       & (
@@ -10772,7 +10779,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_20
         | (protection_rsi_3_1h > 40.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 4h green, 15m & 1h down move, 15m still not low enough, 1h & 4h high
       & (
@@ -10783,7 +10790,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 1d red, 1h & 4h down move, 1h still high, 4d downtrend
       & (
@@ -10991,7 +10998,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 75.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_aroonu_14_1d < 90.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -11016,7 +11023,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 80.0)
       )
       # 1d green with top wick, 1h & 4h down move, 1h & 4h still high
@@ -11037,7 +11044,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 20.0)
       )
       # 1d green with top wick, 1h & 4h down move, 1h still not low enough, 4h still high, 4h & 1d overbought
@@ -11075,7 +11082,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 70.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 25.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_1d < 40.0)
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1d overbought
@@ -11097,7 +11104,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 50.0)
       )
       # 1d green with top wick, 1h down move, 1h still high, 4h high & overbought, 1d overbought
@@ -11107,7 +11114,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 50.0)
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
         | (protection_roc_9_4h < 40.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -11119,7 +11126,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 25.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 30.0)
       )
       # 1d green with top wick, 15m & 4h down move, 15m & 1h still high, 1d overbought
@@ -11150,7 +11157,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_4h < 70.0)
+        | aroonu_14_4h_lt_70
       )
       # 1d green with top wick, 1d down move, 4h still high & overbought
       & (
@@ -11202,7 +11209,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 100.0)
+        | aroonu_14_4h_lt_100
       )
       # 1d top wick, 1h & 4h down move, 15m downtrend, 4h still high, 1d overbought
       & (
@@ -11253,7 +11260,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 50.0)
       )
       # 1d top wick, 15m & 1h & 4h down move, 15m & 1h & 4h still high
@@ -11313,11 +11320,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_1d > -25.0)
       )
       # drop in the last 4 hours, 1h & 4h high
-      & (
-        (protection_close > (protection_close_max_48 * 0.30))
-        | (protection_aroonu_14_1h < 85.0)
-        | (protection_aroonu_14_4h < 85.0)
-      )
+      & ((protection_close > (protection_close_max_48 * 0.30)) | (protection_aroonu_14_1h < 85.0) | aroonu_14_4h_lt_85)
       # drop in last 12 hours, 14m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
         (protection_close > (protection_high_max_12_1h * 0.50))
@@ -11327,7 +11330,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_4h < 80.0)
+        | aroonu_14_4h_lt_80
         | (protection_roc_9_4h < 25.0)
       )
       # drop in last 12 hours, 1h & 4h down move, 1h & 4h downtrend
@@ -11493,7 +11496,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 55.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_aroonu_14_4h < 85.0)
+        | aroonu_14_4h_lt_85
         | (protection_roc_9_4h < 80.0)
       )
       # drop in last 30 days, 15m down move, 15m & 1h high


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Hoist long protection high AROON 4h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
