### PR TITLE
Reuse X7 long protection low AROON 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4564,6 +4564,13 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_aroonu_14_4h = df["AROONU_14_4h"].to_numpy(copy=False)
     protection_roc_9_1d = df["ROC_9_1d"].to_numpy(copy=False)
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
+    # Reuse long protection low AROON 1h comparison masks
+    aroonu_14_1h_lt_20 = protection_aroonu_14_1h < 20.0
+    aroonu_14_1h_lt_25 = protection_aroonu_14_1h < 25.0
+    aroonu_14_1h_lt_30 = protection_aroonu_14_1h < 30.0
+    aroonu_14_1h_lt_40 = protection_aroonu_14_1h < 40.0
+    aroonu_14_1h_lt_50 = protection_aroonu_14_1h < 50.0
+    aroonu_14_1h_lt_60 = protection_aroonu_14_1h < 60.0
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
     protection_roc_9_4h = df["ROC_9_4h"].to_numpy(copy=False)
@@ -4777,7 +4784,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_roc_9_4h < 80.0)
@@ -4839,7 +4846,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 3.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_roc_9_15m > -10.0)
         | (protection_roc_9_1h > -15.0)
       )
@@ -4849,7 +4856,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 15m downtrend, 1h & 4h still not low enough
@@ -4858,7 +4865,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m downtrend, 15m & 1h still not low enough
@@ -4936,7 +4943,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 50.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_cci_20_1h < -250.0)
         | (protection_cci_20_4h < -250.0)
       )
@@ -4947,7 +4954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 50.0)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 20.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
       )
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 1h still not low enough
       & (
@@ -4983,7 +4990,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.15)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 20.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -4995,7 +5002,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_roc_9_15m > -15.0)
         | (protection_roc_9_1h > -15.0)
@@ -5086,7 +5093,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 4h still high
@@ -5114,7 +5121,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 55.0)
         | (protection_rsi_3_1d > 55.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
         | (protection_roc_9_4h < 10.0)
@@ -5123,7 +5130,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 10.0)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
@@ -5149,7 +5156,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 4h still not low enough, 15m & 4h still not low
       & (
@@ -5196,7 +5203,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 15m & 1h down move, 1h & 4h high
@@ -5282,7 +5289,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
@@ -5358,7 +5365,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.40)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h still not low enough, 1d overbought
       & (
@@ -5367,7 +5374,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m < 10.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 20.0)
         | (protection_roc_9_1d < 20.0)
       )
@@ -5441,7 +5448,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_roc_9_1h > -15.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m still high
@@ -5449,7 +5456,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
       )
@@ -5469,7 +5476,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_1h > -10.0)
       )
@@ -5489,7 +5496,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_4h_lt_30
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
@@ -5646,7 +5653,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 100.0)
       )
       # 15m & 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d overbought
@@ -5693,7 +5700,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 1h & 4h still high, 1d overbought
@@ -5725,7 +5732,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 10.0)
         | (protection_roc_9_1d < 20.0)
@@ -5787,7 +5794,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_1h < 25.0)
+        | aroonu_14_1h_lt_25
         | (protection_aroonu_14_4h < 25.0)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -30.0)
@@ -5799,7 +5806,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h < 30.0)
@@ -5854,7 +5861,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | (protection_rsi_14_4h < 70.0)
         | (protection_cmf_20_1d > -0.3)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h not low enough, 4h high
@@ -5899,7 +5906,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -5935,7 +5942,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.3)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_1d < 90.0)
         | (protection_stochrsik_14_14_3_3_1d < 80.0)
       )
@@ -6008,7 +6015,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 14h & 1d overbought
@@ -6039,7 +6046,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 50.0)
@@ -6075,7 +6082,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 40.0)
         | (protection_roc_9_1d < 200.0)
       )
@@ -6233,7 +6240,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.30)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 15m & 4h high, 1d downtrend
       & (
@@ -6266,7 +6273,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 45.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h > -30.0)
       )
@@ -6286,7 +6293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
@@ -6297,7 +6304,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -6342,7 +6349,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 85.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend, 1h high
@@ -6365,7 +6372,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
@@ -6483,7 +6490,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -6495,7 +6502,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 15.0)
       )
@@ -6508,7 +6515,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_1d > -0.10)
         | (protection_aroonu_14_15m < 20.0)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 20.0)
       )
@@ -6519,7 +6526,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 100.0)
       )
       # 15m & 1h down move, 15m still high, 1h & dh high, 1d overbought
@@ -6576,7 +6583,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -6612,7 +6619,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.1)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1d < 20.0)
       )
@@ -6624,7 +6631,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_4h < 85.0)
         | (protection_roc_9_4h < 10.0)
@@ -6679,7 +6686,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -6777,7 +6784,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -6803,7 +6810,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 65.0)
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 35.0)
       )
@@ -6979,7 +6986,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
@@ -7070,7 +7077,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 5.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -7081,7 +7088,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 45.0)
         | (protection_cmf_20_15m > -0.40)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 15.0)
         | (protection_stochrsik_14_14_3_3_4h < 15.0)
         | (protection_cci_20_1h < -350.0)
@@ -7093,7 +7100,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.3)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_roc_9_1d < 100.0)
@@ -7107,7 +7114,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 30.0)
         | (protection_cmf_20_1d > -0.20)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
         | (protection_roc_9_1d > -15.0)
       )
@@ -7130,7 +7137,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_aroonu_14_1h < 25.0)
+        | aroonu_14_1h_lt_25
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 1d still high, 1d downtrend, 1d overbought
@@ -7169,7 +7176,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -7220,7 +7227,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.15)
         | (protection_aroonu_14_15m < 20.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
@@ -7336,7 +7343,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 25.0)
@@ -7381,7 +7388,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 200.0)
@@ -7441,7 +7448,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_rsi_3_1d > 25.0)
         | (protection_mfi_14_1d < 50.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high
@@ -7576,7 +7583,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | rsi_14_15m_lt_30
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -7588,7 +7595,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_cci_20_1h < 0.0)
         | (protection_cci_20_4h < 0.0)
@@ -7825,7 +7832,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_4h < 20.0)
       )
@@ -8020,7 +8027,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m high, 1h & 4h still high
@@ -8032,7 +8039,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h high
@@ -8067,7 +8074,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1d > -0.20)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -15.0)
@@ -8079,7 +8086,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 70.0)
       )
@@ -8090,7 +8097,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -8137,7 +8144,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 15m downtrend, 15m still not low enough
@@ -8149,7 +8156,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_15m < 20.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h stil high, 4h high, 4h overbought
@@ -8160,7 +8167,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 25.0)
@@ -8208,7 +8215,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 4h & 1d overbought
@@ -8242,7 +8249,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -40.0)
@@ -8294,7 +8301,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
@@ -8315,7 +8322,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 90.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
@@ -8344,7 +8351,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_roc_9_4h < 30.0)
@@ -8442,7 +8449,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 70.0)
       )
@@ -8519,7 +8526,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -8544,7 +8551,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 40.0)
       )
@@ -8580,7 +8587,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -8722,7 +8729,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 40.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 1h & 4h downtrend
@@ -8792,7 +8799,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_mfi_14_4h < 50.0)
         | (protection_cmf_20_1h > -0.0)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
@@ -9048,7 +9055,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 80.0)
@@ -9098,7 +9105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
@@ -9259,7 +9266,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high, 1d overbought
@@ -9270,7 +9277,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -9281,7 +9288,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -9327,7 +9334,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -9342,7 +9349,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.30)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 4h high, 4h & 1d overbought
@@ -9363,7 +9370,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h < 50.0)
         | (protection_roc_9_4h < 100.0)
@@ -9616,7 +9623,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
@@ -9782,7 +9789,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h downtrend
@@ -10036,7 +10043,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m < 50.0)
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 90.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 100.0)
       )
@@ -10202,7 +10209,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
@@ -10261,7 +10268,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 50.0)
       )
       # 1h & 4h down move, 15m & 1hg downtrend, 4h downtrend
@@ -10276,7 +10283,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -10284,7 +10291,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_15m > -10.0)
@@ -10307,7 +10314,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.0)
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
       )
       # 1h & 4h down move, 1h & 4h downtrend, 1h high
       & (
@@ -10315,7 +10322,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.40)
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
       )
       # 1h & 4h & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 1h still not low enough
       & (
@@ -10332,7 +10339,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 20.0)
         | (protection_stochrsik_14_14_3_3_15m < 80.0)
         | (protection_roc_9_1h > -30.0)
@@ -10347,7 +10354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_roc_9_1h > -10.0)
       )
@@ -10416,7 +10423,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.5)
         | (protection_cmf_20_1h > -0.3)
         | (protection_cmf_20_4h > -0.3)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
       )
       # 1h & 4h down move, 1h & 4h high, 4h overbought
       & (
@@ -10444,7 +10451,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_aroonu_14_1h < 25.0)
+        | aroonu_14_1h_lt_25
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h < 20.0)
@@ -10456,7 +10463,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h < 25.0)
@@ -10481,7 +10488,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_4h > 3.0)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
       )
       # 4h down move, 1h & 4h downtrend, 1h & 4h & 1d downtrend
       & (
@@ -10584,7 +10591,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1d > -40.0)
       )
@@ -10645,7 +10652,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1d > 3.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_1d > -30.0)
@@ -10675,7 +10682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h > -60.0)
       )
       # 1d down move, 1h still high, 4h high
-      & ((protection_rsi_3_1d > 5.0) | (protection_aroonu_14_1h < 40.0) | (protection_aroonu_14_4h < 70.0))
+      & ((protection_rsi_3_1d > 5.0) | aroonu_14_1h_lt_40 | (protection_aroonu_14_4h < 70.0))
       # 1d down move, 4h high, 1h & 4h downtrend
       & (
         (protection_rsi_3_1d > 5.0)
@@ -10698,7 +10705,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1d > -40.0)
       )
@@ -10742,7 +10749,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 60.0)
+        | aroonu_14_1h_lt_60
         | (protection_aroonu_14_4h < 90.0)
       )
       # 4h green with top wick, 1h down move, 1h still high, 4h high, 1d overbought
@@ -10762,7 +10769,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_4h < 15.0)
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 35.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 100.0)
       )
       # 4h green with top wick, 15m & 1h down move, 1h & 4h high
@@ -10867,7 +10874,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
       )
       # 1d P&D, 15m down move, 1h high
       & (
@@ -10931,7 +10938,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_25
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 30.0)
         | (protection_roc_9_1h > -25.0)
         | (protection_roc_9_4h > -25.0)
@@ -10970,7 +10977,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 65.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
         | (protection_aroonu_14_4h < 60.0)
       )
       # 1d green with top wick, 15m down move, 1h & 4h high, 1d overbought
@@ -11025,7 +11032,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 10.0)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_aroonu_14_4h < 50.0)
       )
       # 1d green with top wick, 15m & 1h down move, 15m & 1h & 4h still high, 4h high & overbought
@@ -11085,7 +11092,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_aroonu_14_1h < 20.0)
+        | aroonu_14_1h_lt_20
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -11373,7 +11380,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1d > 30.0)
         | (protection_aroonu_14_15m < 25.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_1d < 80.0)
         | (protection_roc_9_4h > -50.0)
       )
@@ -11383,7 +11390,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -35.0)
       )
@@ -11415,7 +11422,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.40)
         | (protection_cmf_20_1d > -0.50)
-        | (protection_aroonu_14_1h < 30.0)
+        | aroonu_14_1h_lt_30
       )
       # drop in last 4 days, 4h & 1d down move, 1h high
       & (
@@ -11429,7 +11436,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_24_4h * 0.15))
         | (protection_rsi_3_1d > 20.0)
         | (protection_cmf_20_1d > -0.30)
-        | (protection_aroonu_14_1h < 50.0)
+        | aroonu_14_1h_lt_50
         | (protection_roc_2_1d > -40.0)
       )
       # drop in last 6 days, 1d down move, 1h & 4h & 1d downtrend, 1d still high, 4h downtrend
@@ -11492,7 +11499,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_30_1d * 0.10))
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 55.0)
-        | (protection_aroonu_14_1h < 40.0)
+        | aroonu_14_1h_lt_40
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 80.0)
       )


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection low AROON 1h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
