### PR TITLE
Reuse X7 long protection low ROC 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4567,6 +4567,14 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
     protection_roc_9_4h = df["ROC_9_4h"].to_numpy(copy=False)
+    # Reuse long protection low ROC 4h comparison masks
+    roc_9_4h_lt_10 = protection_roc_9_4h < 10.0
+    roc_9_4h_lt_15 = protection_roc_9_4h < 15.0
+    roc_9_4h_lt_20 = protection_roc_9_4h < 20.0
+    roc_9_4h_lt_25 = protection_roc_9_4h < 25.0
+    roc_9_4h_lt_30 = protection_roc_9_4h < 30.0
+    roc_9_4h_lt_35 = protection_roc_9_4h < 35.0
+    roc_9_4h_lt_40 = protection_roc_9_4h < 40.0
     protection_cmf_20_1d = df["CMF_20_1d"].to_numpy(copy=False)
     protection_roc_9_15m = df["ROC_9_15m"].to_numpy(copy=False)
     protection_roc_9_1h = df["ROC_9_1h"].to_numpy(copy=False)
@@ -4832,7 +4840,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h & 4h down move, 1h still high, 15m & 1h downtrend
       & (
@@ -4878,7 +4886,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
-        | (protection_roc_9_4h < 15.0)
+        | roc_9_4h_lt_15
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 1h & 4h still not low enough
       & (
@@ -5117,7 +5125,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h down move, 1h & 4h still not low enough, 4h high
       & (
@@ -5224,7 +5232,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h down move, 15m downtrend, 4h high
       & (
@@ -5272,7 +5280,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h still high, 15m still high
       & (
@@ -5348,7 +5356,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 75.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h < 10.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend, 1h still high
       & (
@@ -5390,7 +5398,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h & 4h downtrend
       & (
@@ -5558,7 +5566,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 15m still not low enough
       & (
@@ -5668,7 +5676,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high
       & (
@@ -5716,7 +5724,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 1d overbought
       & (
@@ -5727,7 +5735,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
         | (protection_roc_9_1d < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h & 4h still high
@@ -5802,7 +5810,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h > -20.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h overbought
       & (
@@ -5814,7 +5822,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 1h downtrend
       & (
@@ -5835,7 +5843,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 45.0)
         | (protection_rsi_14_4h < 55.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend, 4h high
@@ -5901,7 +5909,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still high
       & (
@@ -5960,7 +5968,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h down move, 1h & 4h sitll high, 15m & 1h & 4h downtrend, 1h & 4h still high
       & (
@@ -6019,7 +6027,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 4h overbought
@@ -6030,7 +6038,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high & overbought
       & (
@@ -6088,7 +6096,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m still not low enough, 1h & 4h high, 4h overbought
@@ -6101,7 +6109,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 10.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 15m & 1h high
       & (
@@ -6134,7 +6142,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 4h & 1d down move, 15m high, 15m & 4h still high
       & (
@@ -6163,7 +6171,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m down move, 15m still not low enough, 1h & 4h high & overbought
       & (
@@ -6187,7 +6195,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend
       & (
@@ -6404,7 +6412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1h > -10.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 1h & 4h downtrend
       & (
@@ -6448,7 +6456,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 35.0)
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h still high, 4h & 1d overbought
@@ -6461,7 +6469,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
         | (protection_roc_9_1d < 30.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
@@ -6485,7 +6493,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high, 4h high & overbought
       & (
@@ -6497,7 +6505,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 15.0)
+        | roc_9_4h_lt_15
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 1d downtrend, 4h overbought
       & (
@@ -6510,7 +6518,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high
       & (
@@ -6554,7 +6562,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_1h > -20.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h high & overbought, 1d overbought
       & (
@@ -6565,7 +6573,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
@@ -6602,7 +6610,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d downtrend, 1h & 4h high, 1d overbought
       & (
@@ -6627,7 +6635,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_4h < 85.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h & 1d down move, 1h still high, 4h still not low enough, 4h downtrend
       & (
@@ -6754,7 +6762,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 1h & 4h high
       & (
@@ -6781,7 +6789,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h high, 1d overbought
       & (
@@ -6805,7 +6813,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 35.0)
+        | roc_9_4h_lt_35
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 5h still high, 15m still high, 4h & 1d overbought
       & (
@@ -6817,7 +6825,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1d overbought
@@ -6852,7 +6860,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 1h overbought
       & (
@@ -6949,7 +6957,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1h < 10.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h overbought
       & (
@@ -6961,7 +6969,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1d down move, 15m still not low enough, 1h & 4h high
       & (
@@ -7042,7 +7050,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 50.0)
       )
       # 15m down move, 15m & 1h & 4h still high, 1h & 4h high, 1h & 4h overbought
@@ -7056,7 +7064,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m down move, 15m high, 1h & 4h overbought
       & (
@@ -7171,7 +7179,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h down move, 15m & 1h still not low enough, 4h still high, 15m still not low enough, 1h & 4h high
       & (
@@ -7255,7 +7263,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
         | (protection_roc_9_1d > -50.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
@@ -7338,7 +7346,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 25.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
@@ -7350,7 +7358,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high, 4h & 1d overbought
       & (
@@ -7361,7 +7369,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high
@@ -7383,7 +7391,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
@@ -7396,7 +7404,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h down move, 1h still high, 1h & 4h high, 4h & 1d overbought
       & (
@@ -7406,7 +7414,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h still not low enough, 4h downtrend
@@ -7465,7 +7473,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 1h & 4h still high, 1d downtrend
       & (
@@ -7500,7 +7508,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h down move, 15m & 1h sitll high, 4h high, 1h & 4h high, 1h & 4h overbought
       & (
@@ -7512,7 +7520,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h downtrend, 15m & 1h still high, 4h downtrend
       & (
@@ -7578,7 +7586,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h overbought
       & (
@@ -7592,7 +7600,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 50.0)
         | (protection_cci_20_1h < 0.0)
         | (protection_cci_20_4h < 0.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h still high, 4h high, 15m stil high, 4h high & overbought
       & (
@@ -7604,7 +7612,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 1h & 4h high, 4h overbought
       & (
@@ -7616,7 +7624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high, 1h high, 4h & 1d downtrend
       & (
@@ -7642,7 +7650,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h overbought
       & (
@@ -7654,7 +7662,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h downtrend, 1d overbought
       & (
@@ -7746,7 +7754,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 75.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
         | (protection_roc_9_1d < 150.0)
       )
       # 15m & 1h down move, 15m & 1h stil high, 4h high, 1h & 4h overbought
@@ -7782,7 +7790,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 1h & 4h high, 1h overbought
       & (
@@ -7827,7 +7835,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 15m still high, 1h & 4h high, 1d overbought
       & (
@@ -7850,7 +7858,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_4h < 15.0)
+        | roc_9_4h_lt_15
         | (protection_roc_9_1d < 60.0)
       )
       # 15m & 4h & 1d down move, 15m & 1h & 4h s till high, 15m & 4h high
@@ -7908,7 +7916,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15, & 4h still high, 1h high, 4h downtrend
       & (
@@ -7944,7 +7952,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 4h down move, 15m still high, 1h still high, 4h high & overbought
       & (
@@ -8092,7 +8100,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h stil high, 15m still high, 1d overbought
       & (
@@ -8163,7 +8171,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m still not low, 4h high, 1h still high
       & (
@@ -8219,7 +8227,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
@@ -8270,7 +8278,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 20.0)
       )
       # 15m & 1h & 1d down move, 4h & 1d downtrend, 1h & 4h high, 1d downtrend
@@ -8347,7 +8355,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
@@ -8358,7 +8366,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
@@ -8369,7 +8377,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 15.0)
+        | roc_9_4h_lt_15
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h down move, 15m sitll not low enough, 1h still high, 4h high, 15m & 1h downtrend, 15m & 1h still high
@@ -8406,7 +8414,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 15m high, 4h downtrend
       & (
@@ -8457,7 +8465,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h & 1d down move, 15m & 1h & 4h still high, 15m & 1d downtrend
       & (
@@ -8495,7 +8503,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 4h downtrend, 4h high, 1d overbought
       & (
@@ -8534,7 +8542,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h & 4h high, 4h overbought
       & (
@@ -8546,7 +8554,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h & 1d overbought
       & (
@@ -8556,7 +8564,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h & 4h overbought
@@ -8569,7 +8577,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_roc_9_1h < 10.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high & overbought
       & (
@@ -8582,7 +8590,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h high, 4h downtrend
       & (
@@ -8767,7 +8775,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h still high, 4h overbought
@@ -8807,7 +8815,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m down move, 15m & 1h & 4h still high, 15m & 1h downtrend, 4h high, 15m & 1h still high
       & (
@@ -8832,7 +8840,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m down move, 15m still high, 1h & 4h high, 4h overbought
       & (
@@ -8843,7 +8851,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m down move, 15m still high, 1h & 4h high, 1d downtrend, 4h overbought
       & (
@@ -8862,7 +8870,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
         | (protection_roc_9_1h < 10.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h still not low enough
       & (
@@ -8969,7 +8977,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1d high
       & (
@@ -9050,7 +9058,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1h still not low enough, 4h high
@@ -9087,7 +9095,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h still high, 4h high
       & (
@@ -9156,7 +9164,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h high, 1d downtrend
       & (
@@ -9202,7 +9210,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high, 4h & 1d overbought
       & (
@@ -9214,7 +9222,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
         | (protection_roc_9_1d < 30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1d overbought
@@ -9331,7 +9339,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 4h downtrend, 1h still high
       & (
@@ -9429,7 +9437,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 40.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m high
       & (
@@ -9485,7 +9493,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h down move, 15m & 1h still high, 1h & 4h high, 4h overbought
       & (
@@ -9496,7 +9504,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h still high, 1d downtrend
       & (
@@ -9531,7 +9539,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 15m high, 4h high & overbought
       & (
@@ -9543,7 +9551,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h high
       & (
@@ -9591,7 +9599,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
@@ -9808,7 +9816,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_1h < 60.0)
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 15m down move, 15m & 1h still high, 4h high, 15m downtrend, 15m high, 1h & 4h overbought
       & (
@@ -9955,7 +9963,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
       & (
@@ -9980,7 +9988,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m still high, 1h high, 1h overbought
       & (
@@ -10071,7 +10079,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
@@ -10133,7 +10141,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 1h & 4h high, 1h & 4h overbought
       & (
@@ -10179,7 +10187,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
         | (protection_roc_9_1d < 40.0)
       )
       # 15m down move, 15m & 1h & 4h high, 1h & 4h high, 1h & 4h overbought
@@ -10447,7 +10455,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 25.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1h > -10.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 100.0)
       )
       # 1h & 4h down move, 1h & 4h still high, 4h high, 1h & 4h overbought
@@ -10459,7 +10467,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1h < 10.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 1h down move, 1h still high, 4h overbought
       & ((protection_rsi_3_1h > 55.0) | rsi_14_1h_lt_40 | (protection_roc_9_4h < 300.0))
@@ -10472,7 +10480,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_mfi_14_1d < 50.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 4h down move, 15m & 1h & 4h still not low enough
       & ((protection_rsi_3_4h > 3.0) | rsi_14_15m_lt_20 | (protection_rsi_14_1h < 20.0) | rsi_14_4h_lt_30)
@@ -10627,7 +10635,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 30.0)
       )
       # 1d down move, 15m & 1h still not low enough, 4h & 1d downtrend
@@ -10993,7 +11001,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 75.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_aroonu_14_1d < 90.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high
       & (
@@ -11038,7 +11046,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # 1d green with top wick, 1h & 4h down move, 1h still not low enough, 4h still high, 4h & 1d overbought
       & (
@@ -11049,7 +11057,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 10.0)
+        | roc_9_4h_lt_10
         | (protection_roc_9_1d < 50.0)
       )
       # 1d green with top wick, 15m down move, 15m & 1h & 4h still high, 4h & 1d overbought
@@ -11063,7 +11071,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
         | (protection_roc_9_1d < 50.0)
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 15m still not low enough, 4h high, 1d overbought
@@ -11108,7 +11116,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
         | (protection_roc_9_1d < 50.0)
       )
       # 1d green with top wick, 15m & 1h down move, 1h & 4h still high, 4h overbought
@@ -11120,7 +11128,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
       )
       # 1d green with top wick, 15m & 4h down move, 15m & 1h still high, 1d overbought
       & (
@@ -11138,7 +11146,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_15
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_4h_lt_50
-        | (protection_roc_9_4h < 40.0)
+        | roc_9_4h_lt_40
         | (protection_roc_9_1d < 100.0)
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 1h & 4h still high, 4h high
@@ -11178,7 +11186,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_roc_9_4h < 30.0)
+        | roc_9_4h_lt_30
         | (protection_roc_9_1d < 200.0)
       )
       # 4h top wick, 15m down move, 15m still not low enough, 1h & 4h still high, 4h overbought
@@ -11328,7 +11336,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 25.0)
+        | roc_9_4h_lt_25
       )
       # drop in last 12 hours, 1h & 4h down move, 1h & 4h downtrend
       & (
@@ -11346,7 +11354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 50.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
-        | (protection_roc_9_4h < 20.0)
+        | roc_9_4h_lt_20
       )
       # drop in last 4 days, 15m & 1h & 4h & 1d down move, 4h high
       & (


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection low ROC 4h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
