### PR TITLE
Hoist X7 long protection high ROC 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4567,6 +4567,17 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
     protection_roc_9_4h = df["ROC_9_4h"].to_numpy(copy=False)
+    # Hoist long protection high ROC 4h comparison masks
+    roc_9_4h_lt_50 = protection_roc_9_4h < 50.0
+    roc_9_4h_lt_60 = protection_roc_9_4h < 60.0
+    roc_9_4h_lt_70 = protection_roc_9_4h < 70.0
+    roc_9_4h_lt_75 = protection_roc_9_4h < 75.0
+    roc_9_4h_lt_80 = protection_roc_9_4h < 80.0
+    roc_9_4h_lt_100 = protection_roc_9_4h < 100.0
+    roc_9_4h_lt_120 = protection_roc_9_4h < 120.0
+    roc_9_4h_lt_130 = protection_roc_9_4h < 130.0
+    roc_9_4h_lt_250 = protection_roc_9_4h < 250.0
+    roc_9_4h_lt_300 = protection_roc_9_4h < 300.0
     protection_cmf_20_1d = df["CMF_20_1d"].to_numpy(copy=False)
     protection_roc_9_15m = df["ROC_9_15m"].to_numpy(copy=False)
     protection_roc_9_1h = df["ROC_9_1h"].to_numpy(copy=False)
@@ -4780,7 +4791,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 5m & 15m & 1h & 1d down move, 1h & 4h still high, 1d downtrend
       & (
@@ -5547,7 +5558,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 4h overbought
       & (
@@ -5889,7 +5900,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
       & (
@@ -6042,7 +6053,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high, 1h overbought
       & (
@@ -6122,7 +6133,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 65.0)
         | (protection_aroonu_14_15m < 80.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h high, 1h & 4h overbought
       & (
@@ -6174,7 +6185,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 30.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m down move, 15m & 1h & 4h still high, 15m still high, 4h high, 4h overbought
       & (
@@ -6299,7 +6310,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m downtrend
       & (
@@ -6472,7 +6483,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 45.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
@@ -6840,7 +6851,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m downtrend, 1h & 4h high, 4h overbought
       & (
@@ -7059,12 +7070,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h < 20.0)
       )
       # 15m down move, 15m high, 1h & 4h overbought
-      & (
-        (rsi_3_15m_gt_15)
-        | (protection_aroonu_14_15m < 75.0)
-        | (protection_roc_9_1h < 50.0)
-        | (protection_roc_9_4h < 80.0)
-      )
+      & ((rsi_3_15m_gt_15) | (protection_aroonu_14_15m < 75.0) | (protection_roc_9_1h < 50.0) | roc_9_4h_lt_80)
       # 15m & 1h & 4h down move, 1h still high, 15m still not low enough, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
@@ -7758,7 +7764,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_1h < 40.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m & 1h & 4h high
       & (
@@ -7814,7 +7820,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high & overbought
       & (
@@ -7931,7 +7937,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 1h still high & overbought
       & (
@@ -7955,7 +7961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h high, 15m & 1h & 4h high
       & (
@@ -7977,7 +7983,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1h < 50.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m down move, 15m still high, 1h & 4h high, 4h overbought
       & (
@@ -7988,7 +7994,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
-        | (protection_roc_9_4h < 75.0)
+        | roc_9_4h_lt_75
       )
       # 15m down move, 15m & 1h & 4h high, 1h & 4h overbought
       & (
@@ -7999,7 +8005,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 50.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
@@ -8010,7 +8016,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h high, 1d overbought
       & (
@@ -8081,7 +8087,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
@@ -8186,7 +8192,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h downtrend, 1d overbought
       & (
@@ -8231,7 +8237,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h still high, 1d downtrend
       & (
@@ -8305,7 +8311,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 4h overbought
@@ -8320,7 +8326,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 60.0)
+        | roc_9_4h_lt_60
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend
       & (
@@ -8444,7 +8450,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 4h high & overbought
       & (
@@ -8627,7 +8633,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
-        | (protection_roc_9_4h < 60.0)
+        | roc_9_4h_lt_60
       )
       # 15m & 1h down move, 15m & 1hstill high, 4h downtrend, 15m still high, 1h high
       & (
@@ -8649,7 +8655,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_4h < 120.0)
+        | roc_9_4h_lt_120
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 1h & 4h & 1d overbought
       & (
@@ -8661,7 +8667,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
         | (protection_roc_9_1d < 250.0)
       )
       # 15m & 4h down move, 15m high, 1h still not low enough, 4h downtrend
@@ -8780,7 +8786,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 4h still high
       & (
@@ -8853,7 +8859,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 75.0)
         | (protection_cmf_20_1d > -0.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m down move, 15m & 1h high, 1h & 4h overbought
       & (
@@ -8993,7 +8999,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 25.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
@@ -9144,7 +9150,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m & 4h still high, 4h overbought
       & (
@@ -9238,7 +9244,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m still high, 1h high
       & (
@@ -9353,7 +9359,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
         | (protection_roc_9_1d < 150.0)
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high & overbought
@@ -9366,7 +9372,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h < 50.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 4h overbought
       & (
@@ -9376,7 +9382,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_4h < 130.0)
+        | roc_9_4h_lt_130
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still high
       & (
@@ -9628,7 +9634,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_stochk_14_3_3_1h < 60.0)
         | (protection_stochk_14_3_3_4h < 90.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m high
       & (
@@ -9683,7 +9689,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
       & (
@@ -9819,7 +9825,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_roc_9_1h < 15.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high & overbought
       & (
@@ -9831,7 +9837,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 15m & 1h & 4h down move, 15m & 1h sitll not low enough, 4h still high, 15m high
       & (
@@ -9875,7 +9881,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
@@ -9885,7 +9891,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 90.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h high & overbought
       & (
@@ -9896,7 +9902,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high, 1h & 4h downtrend
       & (
@@ -9966,7 +9972,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h high, 4h overbought
       & (
@@ -10038,7 +10044,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 90.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m down move, 15m still high, 1h & 4h high & overbought
       & (
@@ -10049,7 +10055,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 70.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m down move, 15m & 1h & 4h still high, 15m & 1h & 4h high
       & (
@@ -10109,7 +10115,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_1h < 30.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m still high, 1d overbought
       & (
@@ -10145,7 +10151,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
         | (protection_roc_9_1h < 30.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 15m & 1h down move, 15m still high, 1h high, 15m overbought
       & (
@@ -10191,7 +10197,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 40.0)
-        | (protection_roc_9_4h < 100.0)
+        | roc_9_4h_lt_100
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m & 4h high
       & (
@@ -10216,7 +10222,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 30.0)
-        | (protection_roc_9_4h < 70.0)
+        | roc_9_4h_lt_70
       )
       # 1h & 4h down move, 15m high
       & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | (protection_stochrsik_14_14_3_3_15m < 50.0))
@@ -10426,7 +10432,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h still high
       & (
@@ -10462,7 +10468,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h < 25.0)
       )
       # 1h down move, 1h still high, 4h overbought
-      & ((protection_rsi_3_1h > 55.0) | rsi_14_1h_lt_40 | (protection_roc_9_4h < 300.0))
+      & ((protection_rsi_3_1h > 55.0) | rsi_14_1h_lt_40 | roc_9_4h_lt_300)
       # 1h & 1d down move, 1h & 4h & 1d still high, 1h & 4h high, 4h overbought
       & (
         (protection_rsi_3_1h > 60.0)
@@ -10708,7 +10714,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_4h > -0.2)
-        | (protection_roc_9_4h < 250.0)
+        | roc_9_4h_lt_250
       )
       # 4h red, 15m & 1h & 4h down move, 1h & 4h still high, 4h high
       & (
@@ -11017,7 +11023,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # 1d green with top wick, 1h & 4h down move, 1h & 4h still high
       & (
@@ -11098,7 +11104,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 1d green with top wick, 1h down move, 1h still high, 4h high & overbought, 1d overbought
       & (
@@ -11159,7 +11165,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 45.0)
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 1d green with top wick, 4h down move, 4h still high, 1d overbought
       & (
@@ -11190,7 +11196,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 4h top wick, 15m & 1h down move, 15m & 1h still high, 1h & 4h high
       & (
@@ -11254,7 +11260,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_4h < 50.0)
+        | roc_9_4h_lt_50
       )
       # 1d top wick, 15m & 1h & 4h down move, 15m & 1h & 4h still high
       & (
@@ -11494,7 +11500,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 55.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_4h < 80.0)
+        | roc_9_4h_lt_80
       )
       # drop in last 30 days, 15m down move, 15m & 1h high
       & (


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Hoist long protection high ROC 4h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
