### PR TITLE
Reuse X7 long protection low ROC 1d masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4563,6 +4563,16 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_cmf_20_15m = df["CMF_20_15m"].to_numpy(copy=False)
     protection_aroonu_14_4h = df["AROONU_14_4h"].to_numpy(copy=False)
     protection_roc_9_1d = df["ROC_9_1d"].to_numpy(copy=False)
+    # Reuse long protection low ROC 1d comparison masks
+    roc_9_1d_lt_15 = protection_roc_9_1d < 15.0
+    roc_9_1d_lt_20 = protection_roc_9_1d < 20.0
+    roc_9_1d_lt_25 = protection_roc_9_1d < 25.0
+    roc_9_1d_lt_30 = protection_roc_9_1d < 30.0
+    roc_9_1d_lt_40 = protection_roc_9_1d < 40.0
+    roc_9_1d_lt_50 = protection_roc_9_1d < 50.0
+    roc_9_1d_lt_60 = protection_roc_9_1d < 60.0
+    roc_9_1d_lt_70 = protection_roc_9_1d < 70.0
+    roc_9_1d_lt_75 = protection_roc_9_1d < 75.0
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
@@ -5314,7 +5324,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_1d < 70.0)
+        | roc_9_1d_lt_70
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1d overbought
       & (
@@ -5325,7 +5335,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
-        | (protection_roc_9_1d < 60.0)
+        | roc_9_1d_lt_60
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still not low enough
       & (
@@ -5369,7 +5379,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 20.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 1h overbought
       & (
@@ -5638,7 +5648,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 50.0)
         | (protection_cci_20_1h < -200.0)
         | (protection_cci_20_4h < -0.0)
-        | (protection_roc_9_1d < 30.0)
+        | roc_9_1d_lt_30
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h high
       & (
@@ -5657,7 +5667,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 45.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
@@ -5728,7 +5738,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 10.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h & 4h still high
       & (
@@ -5765,7 +5775,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_1d < 25.0)
+        | roc_9_1d_lt_25
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still not low enough, 4h still high. 1d high & overbought
       & (
@@ -5836,7 +5846,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 55.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 25.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend, 4h high
       & (
@@ -5948,7 +5958,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h & 4h high, 4h overbought
       & (
@@ -6089,7 +6099,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 10.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
@@ -6380,7 +6390,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_1d < 30.0)
+        | roc_9_1d_lt_30
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
@@ -6462,7 +6472,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 25.0)
-        | (protection_roc_9_1d < 30.0)
+        | roc_9_1d_lt_30
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
@@ -6529,7 +6539,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 1d high, 4h downtrend
       & (
@@ -6566,7 +6576,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
@@ -6614,7 +6624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1d > -0.1)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 4h overbought
       & (
@@ -6793,7 +6803,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 14m & 1h down move, 15m & 1h still high, 4h high & overbought
       & (
@@ -7043,7 +7053,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m down move, 15m & 1h & 4h still high, 1h & 4h high, 1h & 4h overbought
       & (
@@ -7146,7 +7156,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cci_20_1h < -250.0)
         | (protection_cci_20_4h < -200.0)
         | (protection_roc_9_4h > -10.0)
-        | (protection_roc_9_1d < 15.0)
+        | roc_9_1d_lt_15
       )
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 15m & 1h downtrend, 1h & 4h still not low enough
       & (
@@ -7195,7 +7205,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h high, 1h & 4h downtrend, 1d overbought
       & (
@@ -7300,7 +7310,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 40.0)
         | (protection_roc_9_1h > -15.0)
         | (protection_roc_9_4h > -30.0)
-        | (protection_roc_9_1d < 40.0)
+        | roc_9_1d_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m stil high, 4h high
       & (
@@ -7339,7 +7349,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 25.0)
+        | roc_9_1d_lt_25
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
@@ -7362,7 +7372,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high
       & (
@@ -7666,7 +7676,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_4h > -20.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low, 1h & 4h sitll high, 15m & 1h downtrend, 15m still high, 4h high
       & (
@@ -7839,7 +7849,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 4h down move, 15m & 1h & 4h sitll high, 4h high, 4h & 1d overbought
       & (
@@ -7851,7 +7861,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 15.0)
-        | (protection_roc_9_1d < 60.0)
+        | roc_9_1d_lt_60
       )
       # 15m & 4h & 1d down move, 15m & 1h & 4h s till high, 15m & 4h high
       & (
@@ -8057,7 +8067,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_roc_9_1d < 30.0)
+        | roc_9_1d_lt_30
       )
       # 15m & 1h & 1d down move, 1h & 4h still high, 1d downtrend, 1h high, 1h & 4h still high, 1d downtrend
       & (
@@ -8104,7 +8114,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h downtrend, 4h downtrend
       & (
@@ -8258,7 +8268,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1d > -0.20)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h & 1d overbought
       & (
@@ -8271,7 +8281,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 15m & 1h & 1d down move, 4h & 1d downtrend, 1h & 4h high, 1d downtrend
       & (
@@ -8370,7 +8380,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 15.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h down move, 15m sitll not low enough, 1h still high, 4h high, 15m & 1h downtrend, 15m & 1h still high
       & (
@@ -8508,7 +8518,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_roc_9_1d < 30.0)
+        | roc_9_1d_lt_30
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high
       & (
@@ -8699,7 +8709,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 4h down move, 15m & 1h still high, 15m & 1h high, 4h downtrend
       & (
@@ -8744,7 +8754,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h overbought
       & (
@@ -9179,7 +9189,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_roc_9_4h > -20.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high
       & (
@@ -9215,7 +9225,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_roc_9_4h < 10.0)
-        | (protection_roc_9_1d < 30.0)
+        | roc_9_1d_lt_30
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1d overbought
       & (
@@ -9566,7 +9576,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still highm 15m & 1h high, 1h still high, 4h high
       & (
@@ -9592,7 +9602,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 10.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
       & (
@@ -9605,7 +9615,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_1d < 40.0)
+        | roc_9_1d_lt_40
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h still high, 4h high
       & (
@@ -9695,7 +9705,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_1d < 75.0)
+        | roc_9_1d_lt_75
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 1h high
       & (
@@ -9941,7 +9951,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h downtrend, 4h overbought
       & (
@@ -10180,7 +10190,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_roc_9_4h < 10.0)
-        | (protection_roc_9_1d < 40.0)
+        | roc_9_1d_lt_40
       )
       # 15m down move, 15m & 1h & 4h high, 1h & 4h high, 1h & 4h overbought
       & (
@@ -10278,7 +10288,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 1h & 4h down move, 1h & 4h still high, 4h high, 15m & 1h downtrend
       & (
@@ -10618,7 +10628,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 4h down move, 15m high, 15m & 1h & 4h high, 4h & 1d overbought
       & (
@@ -10628,7 +10638,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 30.0)
+        | roc_9_1d_lt_30
       )
       # 1d down move, 15m & 1h still not low enough, 4h & 1d downtrend
       & (
@@ -10754,7 +10764,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 4h green with top wick, 15m & 1h down move, 1h still high, 4h high
       & (
@@ -10887,7 +10897,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_roc_9_1d < 25.0)
+        | roc_9_1d_lt_25
       )
       # 1d P&D, 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend, 1d overbought
       & (
@@ -10935,7 +10945,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 30.0)
         | (protection_roc_9_1h > -25.0)
         | (protection_roc_9_4h > -25.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 1d red, 15m & 1h & 4h down move, 1h & 4h still not low enough, 1d high, 4h downtrend, 1d overbought
       & (
@@ -10947,7 +10957,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1d < 85.0)
         | (protection_roc_9_4h > -30.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 1d green with top wick, 15m & 1h & 1d down move, 1h still not low enough, 4h still high, 1d overbought
       & (
@@ -10959,7 +10969,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 1h & 4h still high
       & (
@@ -10981,7 +10991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
-        | (protection_roc_9_1d < 40.0)
+        | roc_9_1d_lt_40
       )
       # 1d green with top wick, 15m down move, 15m & 1h still high, 4h & 1d high, 4h overbought
       & (
@@ -11050,7 +11060,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 1d green with top wick, 15m down move, 15m & 1h & 4h still high, 4h & 1d overbought
       & (
@@ -11064,7 +11074,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 15m still not low enough, 4h high, 1d overbought
       & (
@@ -11076,7 +11086,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 25.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_1d < 40.0)
+        | roc_9_1d_lt_40
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1d overbought
       & (
@@ -11109,7 +11119,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 40.0)
-        | (protection_roc_9_1d < 50.0)
+        | roc_9_1d_lt_50
       )
       # 1d green with top wick, 15m & 1h down move, 1h & 4h still high, 4h overbought
       & (
@@ -11276,7 +11286,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 45.0)
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # pump, drop in lays days, 1h & 4h down move, 1h & 4h still not low enough, 1d overbought
       & (
@@ -11286,7 +11296,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 50.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_roc_9_1d < 20.0)
+        | roc_9_1d_lt_20
       )
       # pump, 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h downtrend, 1h high
       & (


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection low ROC 1d comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
