### PR TITLE
Hoist X7 long protection high ROC 1d masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4563,6 +4563,12 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_cmf_20_15m = df["CMF_20_15m"].to_numpy(copy=False)
     protection_aroonu_14_4h = df["AROONU_14_4h"].to_numpy(copy=False)
     protection_roc_9_1d = df["ROC_9_1d"].to_numpy(copy=False)
+    # Hoist long protection high ROC 1d comparison masks
+    roc_9_1d_lt_80 = protection_roc_9_1d < 80.0
+    roc_9_1d_lt_100 = protection_roc_9_1d < 100.0
+    roc_9_1d_lt_150 = protection_roc_9_1d < 150.0
+    roc_9_1d_lt_200 = protection_roc_9_1d < 200.0
+    roc_9_1d_lt_250 = protection_roc_9_1d < 250.0
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
@@ -4676,7 +4682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 5m & 15m & 1h down move, 1h & 4h still high, 15m still high, 1h high
       & (
@@ -5065,7 +5071,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 40.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m & 4h still not low enough
       & (
@@ -5188,7 +5194,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1d < 90.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m downtrend, 1h still high, 15m still not low enough
       & (
@@ -5537,7 +5543,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h down move, 1h still high, 4h high & overbought
       & (
@@ -5592,7 +5598,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h & 4h down move, 1h downtrend, 4h high
       & (
@@ -5705,7 +5711,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
@@ -5777,7 +5783,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1d < 70.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still not low enough, 1h & 4h downtrend
       & (
@@ -5855,7 +5861,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_cmf_20_1d > -0.3)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h not low enough, 4h high
       & (
@@ -5985,7 +5991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h high
       & (
@@ -6020,7 +6026,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
@@ -6077,7 +6083,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
       & (
@@ -6276,7 +6282,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_1d < 150.0)
+        | roc_9_1d_lt_150
       )
       # 15m & 1h down move, 15m & 1h still not low enough, 4h still high, 4h high
       & (
@@ -6392,7 +6398,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 1d down move, 15m & 1h still not low enough, 4h high, 1d downtrend, 4h overbought
       & (
@@ -6449,7 +6455,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 25.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h still high, 4h & 1d overbought
       & (
@@ -6818,7 +6824,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
@@ -6829,7 +6835,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h down move, 15m & 1h stil high, 4h high, 15m & 4h high, 4h overbought
       & (
@@ -7011,7 +7017,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1d < 250.0)
+        | roc_9_1d_lt_250
       )
       # 15m down move, 15m & 1h still high, 1h high, 1h overbought, 4h & 1d downtrend
       & (
@@ -7032,7 +7038,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_1h < 40.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 4h & 1d overbought
       & (
@@ -7096,7 +7102,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h & 1d down move, 4h & 1d still not low enough, 1d downtrend, 1h & 4h still high, 1d downtrend
       & (
@@ -7131,7 +7137,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 25.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 1d still high, 1d downtrend, 1d overbought
       & (
@@ -7207,7 +7213,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -10.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend
       & (
@@ -7266,7 +7272,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_roc_9_1d < 150.0)
+        | roc_9_1d_lt_150
       )
       # 15m & 1h & 1d down move, 1h & 4h still high, 15m downtrend, 1d overbought
       & (
@@ -7276,7 +7282,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.3)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h still high, 4h downtrend
       & (
@@ -7384,7 +7390,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
       & (
@@ -7407,7 +7413,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h still not low enough, 4h downtrend
       & (
@@ -7489,7 +7495,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 25.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h overbought
       & (
@@ -7534,7 +7540,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h downtrend
       & (
@@ -7701,7 +7707,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_roc_9_1h < 10.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h high & overbought
       & (
@@ -7747,7 +7753,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 75.0)
         | (protection_roc_9_4h < 25.0)
-        | (protection_roc_9_1d < 150.0)
+        | roc_9_1d_lt_150
       )
       # 15m & 1h down move, 15m & 1h stil high, 4h high, 1h & 4h overbought
       & (
@@ -7897,7 +7903,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h > -30.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still not low enough, 4h still high, 4h overbought
       & (
@@ -8021,7 +8027,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m high, 1h & 4h still high
       & (
@@ -8126,7 +8132,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h still high
       & (
@@ -8198,7 +8204,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_roc_9_4h > -20.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h still high, 15m still high
       & (
@@ -8220,7 +8226,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
@@ -8306,7 +8312,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_4h < 80.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 4h overbought
       & (
@@ -8393,7 +8399,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 4h overbought
       & (
@@ -8557,7 +8563,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h & 4h overbought
       & (
@@ -8662,7 +8668,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 100.0)
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 50.0)
-        | (protection_roc_9_1d < 250.0)
+        | roc_9_1d_lt_250
       )
       # 15m & 4h down move, 15m high, 1h still not low enough, 4h downtrend
       & (
@@ -8768,7 +8774,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 25.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h & 4h still high, 4h overbought
       & (
@@ -9004,7 +9010,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend, 15m & 4h high
       & (
@@ -9051,7 +9057,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1h still not low enough, 4h high
       & (
@@ -9227,7 +9233,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cci_20_1h < 0.0)
         | (protection_cci_20_4h < 0.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h & 4h down move, 15m & 1h still high, 1h & 4h high, 4h overbought
       & (
@@ -9272,7 +9278,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1h & 1d overbought
       & (
@@ -9283,7 +9289,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_roc_9_1h < 20.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h & 1d down move, 15m & 4h downtrend, 15m & 1h high
       & (
@@ -9354,7 +9360,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
         | (protection_roc_9_4h < 50.0)
-        | (protection_roc_9_1d < 150.0)
+        | roc_9_1d_lt_150
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high & overbought
       & (
@@ -9462,7 +9468,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 30.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m down move, 15m still not low enough, 1h & 4h high
       & (
@@ -9519,7 +9525,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 15m & 1h & 4h down move, 15m & 1h still high, 4h high, 15m & 4h high, 4h overbought
       & (
@@ -9646,7 +9652,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h still high
       & (
@@ -9733,7 +9739,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_roc_9_1d < 150.0)
+        | roc_9_1d_lt_150
       )
       # 15m & 1h down move, 15m & 1h & 4h high, 1h overbought
       & (
@@ -10072,7 +10078,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 15m & 1h & 4h downtrend, 4h high
       & (
@@ -10121,7 +10127,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h high & overbought
       & (
@@ -10233,11 +10239,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1h & 4h down move, 1h still not low enough, 4h still high, 1d overbought
       & (
-        (protection_rsi_3_1h > 3.0)
-        | (protection_rsi_3_4h > 35.0)
-        | rsi_14_1h_lt_30
-        | rsi_14_4h_lt_50
-        | (protection_roc_9_1d < 80.0)
+        (protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 35.0) | rsi_14_1h_lt_30 | rsi_14_4h_lt_50 | roc_9_1d_lt_80
       )
       # 1h & 4h & 1d down move, 1d still not low enough, 1d downtrend
       & (
@@ -10298,7 +10300,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h high
       & (
@@ -10376,7 +10378,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 40.0)
         | (protection_aroonu_14_1d < 70.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1h & 1d down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 1h still high
       & (
@@ -10407,7 +10409,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -20.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 5m & 15m & 1h & 4h down move, 15m downtrend, 4h high, 1d overbought
       & (
@@ -10448,7 +10450,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 50.0)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h < 20.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1h & 4h down move, 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
@@ -10576,7 +10578,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
         | (protection_roc_9_4h > -40.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 4h & 1d down move, 1h still high, 4h high, 1d downtrend
       & (
@@ -10901,7 +10903,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -10.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1d red with top wick, 15m & 1h down move, 1h downtrend, 1h high
       & (
@@ -10922,7 +10924,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1d P&D, 15m & 1h & 4h down move, 1h & 4h still not low enough, 1h & 4h downtrend, 1d overbought
       & (
@@ -11087,7 +11089,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1d green with top wick, 15m down move, 15m & 1h still high, 4h high & overbought
       & (
@@ -11130,7 +11132,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1d green, 15m & 4h down move, 4h still high, 4h & 1d overbought
       & (
@@ -11139,7 +11141,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | rsi_14_4h_lt_50
         | (protection_roc_9_4h < 40.0)
-        | (protection_roc_9_1d < 100.0)
+        | roc_9_1d_lt_100
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 1h & 4h still high, 4h high
       & (
@@ -11167,7 +11169,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 50.0)
         | (protection_rsi_3_4h > 40.0)
         | rsi_14_4h_lt_40
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 1d green, 15m & 4h down move, 15m & 1h & 4h still high, 15m high, 4h & 1d overbought
       & (
@@ -11179,7 +11181,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_roc_9_4h < 30.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 4h top wick, 15m down move, 15m still not low enough, 1h & 4h still high, 4h overbought
       & (
@@ -11211,7 +11213,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_cmf_20_15m > -0.2)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_1d < 80.0)
+        | roc_9_1d_lt_80
       )
       # 1d top wick, 4h down move, 4h still high, 1d overbought
       & (
@@ -11219,7 +11221,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_14_4h < 45.0)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_roc_9_1d < 200.0)
+        | roc_9_1d_lt_200
       )
       # 1d top wick, 15m & 1h & 4h down move, 15m & 1h downtrend, 4h still high
       & (


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Hoist long protection high ROC 1d comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
