### PR TITLE
Reuse X7 long protection low STOCHRSI 15m masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4558,6 +4558,11 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_cci_20_4h = df["CCI_20_4h"].to_numpy(copy=False)
     protection_rsi_14_15m = df["RSI_14_15m"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_15m = df["STOCHRSIk_14_14_3_3_15m"].to_numpy(copy=False)
+    # Reuse long protection low STOCHRSI 15m comparison masks
+    stochrsi_k_15m_lt_10 = protection_stochrsik_14_14_3_3_15m < 10.0
+    stochrsi_k_15m_lt_20 = protection_stochrsik_14_14_3_3_15m < 20.0
+    stochrsi_k_15m_lt_30 = protection_stochrsik_14_14_3_3_15m < 30.0
+    stochrsi_k_15m_lt_40 = protection_stochrsik_14_14_3_3_15m < 40.0
     protection_stochrsik_14_14_3_3_1d = df["STOCHRSIk_14_14_3_3_1d"].to_numpy(copy=False)
     protection_aroonu_14_15m = df["AROONU_14_15m"].to_numpy(copy=False)
     protection_cmf_20_15m = df["CMF_20_15m"].to_numpy(copy=False)
@@ -4656,7 +4661,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1d < 50.0)
       )
       # 5m down move, 15m & 1h & 4h still high, 15m high
@@ -4721,7 +4726,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 5m & 4h & 1d down move, 15m high
@@ -4779,7 +4784,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_roc_9_4h < 80.0)
       )
       # 5m & 15m & 1h & 1d down move, 1h & 4h still high, 1d downtrend
@@ -4817,7 +4822,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 5m & 15m & 1h down move, 15m still high, 1h & 4h high, 4h high & overbought
@@ -4830,7 +4835,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -4867,7 +4872,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend, 4h overbought
@@ -4996,7 +5001,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_roc_9_15m > -15.0)
         | (protection_roc_9_1h > -15.0)
       )
@@ -5007,7 +5012,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m still not low enough
@@ -5017,7 +5022,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.40)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
       )
       # 5m & 1h & 4h down move, 1h & 4h downtrend, 15m still high, 4h still not low enough
       & (
@@ -5036,7 +5041,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_stochrsik_14_14_3_3_15m < 10.0)
+        | stochrsi_k_15m_lt_10
         | (protection_roc_9_1h > -10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still not low enough
@@ -5047,7 +5052,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m still high
       & (
@@ -5075,7 +5080,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_stochrsik_14_14_3_3_15m < 10.0)
+        | stochrsi_k_15m_lt_10
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h still not low enugh, 4h still high
@@ -5160,7 +5165,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m still high
@@ -5186,7 +5191,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 35.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1d < 90.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -5197,7 +5202,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
       )
       # 15m & 1h down move, 1h & 4h high
       & (
@@ -5336,7 +5341,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h & 4h overbought
       & (
@@ -5451,7 +5456,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 30.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still high, 4h still not low enough
       & (
@@ -5503,7 +5508,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 4h still high, 4h downtrend
       & (
@@ -5570,7 +5575,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still not low enough
       & (
@@ -5865,7 +5870,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 15.0)
         | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 35.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 85.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1 & 4h still not low enough, 1h still high, 4h high
@@ -6142,7 +6147,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_rsi_3_1d > 20.0)
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 4h & 1d down move, 15m & 1h still not low enough, 1h still high, 4h & 1d downtrend
@@ -6184,7 +6189,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
@@ -6209,7 +6214,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
       )
       # 15m & 1h & 4h & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 4h still high
       & (
@@ -6435,7 +6440,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -15.0)
@@ -6680,7 +6685,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
@@ -6703,7 +6708,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_rsi_14_1d < 40.0)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_stochrsik_14_14_3_3_15m < 10.0)
+        | stochrsi_k_15m_lt_10
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
         | (protection_roc_9_1d > -25.0)
@@ -6716,7 +6721,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h downtrend, 15m & 4h still not low, 1h high
@@ -6906,7 +6911,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
         | (protection_roc_9_1h < 10.0)
       )
@@ -6919,7 +6924,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h high, 4h downtrend
@@ -7071,7 +7076,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 5.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 1h & 4h still not low enough
@@ -7095,7 +7100,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.3)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h & 1d down move, 4h & 1d still not low enough, 1d downtrend, 1h & 4h still high, 1d downtrend
@@ -7430,7 +7435,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -7523,7 +7528,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -7542,7 +7547,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
         | (protection_roc_9_4h > -20.0)
@@ -7780,7 +7785,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 65.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -7812,7 +7817,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 75.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 100.0)
       )
@@ -8056,7 +8061,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m < 25.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_roc_9_1d < 30.0)
       )
       # 15m & 1h & 1d down move, 1h & 4h still high, 1d downtrend, 1h high, 1h & 4h still high, 1d downtrend
@@ -8161,7 +8166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -8209,7 +8214,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 4h & 1d overbought
       & (
@@ -8317,7 +8322,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 60.0)
@@ -8346,7 +8351,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
@@ -8404,7 +8409,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -8589,7 +8594,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -25.0)
       )
@@ -8611,7 +8616,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 60.0)
         | rsi_3_4h_gt_60
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 60.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h > -15.0)
@@ -8638,7 +8643,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # 15m & 1h down move, 1h & 4h high, 4h overbought
@@ -8669,7 +8674,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 3.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -8678,7 +8683,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 10.0)
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -8708,7 +8713,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_4h > -25.0)
       )
@@ -8729,7 +8734,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1h > -20.0)
@@ -8818,7 +8823,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.10)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
       # 15m down move, 15m still high, 1h >& 4h high, 15m & 1h & 4h high, 4h overbought
@@ -8900,7 +8905,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_1h > -15.0)
@@ -9003,7 +9008,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend, 15m & 4h high
@@ -9386,14 +9391,14 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
       )
       # 15m & 4h down move, 15m & 1h high, 4h downtrend
       & (
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -50.0)
       )
@@ -9482,7 +9487,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 20.0)
@@ -9507,7 +9512,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -50.0)
       )
@@ -9552,7 +9557,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still high, 15m & 1h high, 1d overbought
@@ -9793,7 +9798,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -9953,7 +9958,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_4h > -0.15)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -9991,7 +9996,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_1h < 20.0)
       )
@@ -10167,7 +10172,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.35)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
@@ -10497,7 +10502,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 3.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # 4h down move, 1h & 4h downtrend, 15m high
@@ -10527,7 +10532,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 5.0)
         | (protection_rsi_3_1d > 5.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_roc_9_4h > -40.0)
       )
       # 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 4h & 15m still not low enough
@@ -10539,7 +10544,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 30.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
       )
       # 4h down move, 1h & 4h downtrend, 1h still not low enough, 4h high
       & (
@@ -10635,7 +10640,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1d > 3.0)
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_roc_9_4h > -30.0)
         | (protection_roc_9_1d > -50.0)
@@ -10799,7 +10804,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_change_pct_1d.shift(288) < 20.0)
         | rsi_3_15m_gt_20
         | (protection_rsi_3_4h > 25.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 1d red, 15m & 1h & 4h down move, 1h still not low enough, 4h & 1d still high
@@ -10832,7 +10837,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_1d < 85.0)
-        | (protection_stochrsik_14_14_3_3_15m < 40.0)
+        | stochrsi_k_15m_lt_40
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 1d P&D, 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h still high
@@ -11060,7 +11065,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 30.0)
+        | stochrsi_k_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 20.0)
@@ -11242,7 +11247,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
       )
       # 1d top wick, 15m down move, 15m stil high, 1h & 4h high, 4h overbought
@@ -11510,7 +11515,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_25
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_stochrsik_14_14_3_3_15m < 20.0)
+        | stochrsi_k_15m_lt_20
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
     )


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection low STOCHRSI 15m comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
