### PR TITLE
Hoist X7 long protection high STOCHRSI 15m masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4558,6 +4558,12 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_cci_20_4h = df["CCI_20_4h"].to_numpy(copy=False)
     protection_rsi_14_15m = df["RSI_14_15m"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_15m = df["STOCHRSIk_14_14_3_3_15m"].to_numpy(copy=False)
+    # Hoist long protection high STOCHRSI 15m comparison masks
+    stochrsi_k_15m_lt_50 = protection_stochrsik_14_14_3_3_15m < 50.0
+    stochrsi_k_15m_lt_60 = protection_stochrsik_14_14_3_3_15m < 60.0
+    stochrsi_k_15m_lt_70 = protection_stochrsik_14_14_3_3_15m < 70.0
+    stochrsi_k_15m_lt_80 = protection_stochrsik_14_14_3_3_15m < 80.0
+    stochrsi_k_15m_lt_90 = protection_stochrsik_14_14_3_3_15m < 90.0
     protection_stochrsik_14_14_3_3_1d = df["STOCHRSIk_14_14_3_3_1d"].to_numpy(copy=False)
     protection_aroonu_14_15m = df["AROONU_14_15m"].to_numpy(copy=False)
     protection_cmf_20_15m = df["CMF_20_15m"].to_numpy(copy=False)
@@ -4666,7 +4672,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h still high
       & (
@@ -4709,7 +4715,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 5m & 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h still high
@@ -4730,7 +4736,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 10.0)
         | (protection_rsi_3_1d > 15.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 5m & 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h stil high, 15m & 4h high
       & (
@@ -4741,7 +4747,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_stochrsik_14_14_3_3_15m < 60.0)
+        | stochrsi_k_15m_lt_60
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 5m & 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high
@@ -4755,7 +4761,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 5m & 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m high
       & (
@@ -4767,7 +4773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 60.0)
+        | stochrsi_k_15m_lt_60
       )
       # 5m & 15m & 1h down move, 15m & 1h still high, 4h high, 15m still not low enough, 5h overbought
       & (
@@ -4805,7 +4811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 60.0)
+        | stochrsi_k_15m_lt_60
       )
       # 5m & 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m & 4h high
       & (
@@ -4972,7 +4978,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 90.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still not low enough, 4h downtrend
@@ -5026,7 +5032,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 10.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 15m still not low enough, 1h downtrend
@@ -5284,7 +5290,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h high
       & (
@@ -5432,7 +5438,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.40)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 1h & 4h down move, 1h & 4h downtrend, 1h still high, 1h downtrend
       & (
@@ -5461,7 +5467,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 1h & 15m still high, 1h downtrend
@@ -5470,7 +5476,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_1h > -10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h high
@@ -5625,7 +5631,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h downtrend, 1d overbought
       & (
@@ -6816,7 +6822,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -6867,12 +6873,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_1h < 15.0)
       )
       # 15m & 4h down move, 15m high, 4h downtrend
-      & (
-        (rsi_3_15m_gt_15)
-        | (protection_rsi_3_4h > 3.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
-        | (protection_roc_9_4h > -15.0)
-      )
+      & ((rsi_3_15m_gt_15) | (protection_rsi_3_4h > 3.0) | stochrsi_k_15m_lt_70 | (protection_roc_9_4h > -15.0))
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h downtrend
       & (
         (rsi_3_15m_gt_15)
@@ -6960,7 +6961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1d down move, 15m still not low enough, 1h & 4h high
@@ -7284,7 +7285,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 30.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_4h > -70.0)
       )
@@ -7678,7 +7679,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 15m still high, 1h & 4h high
@@ -7735,7 +7736,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_4h > -40.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h high, 4h & 1d overbought
@@ -7863,7 +7864,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 15m still high, 1h high, 4h downtrend
       & (
@@ -8103,7 +8104,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h downtrend, 4h downtrend
@@ -8419,7 +8420,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 1h & 4h, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m & 4h high
@@ -8691,7 +8692,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 4h & 1d down move, 15m high, 1d overbought
       & (
@@ -8842,7 +8843,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_4h < 25.0)
       )
       # 15m down move, 15m still high, 1h & 4h high, 1d downtrend, 4h overbought
@@ -8887,7 +8888,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 10.0)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -9099,7 +9100,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15h & 4h high
@@ -9112,7 +9113,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 1h & 4h down move, 15m high
       & (
@@ -9120,7 +9121,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h high
       & (
@@ -9190,7 +9191,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 15m & 4h still high, 4h overbought
       & (
@@ -9304,7 +9305,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_15m < 80.0)
+        | stochrsi_k_15m_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h high, 4h downtrend
       & (
@@ -9406,7 +9407,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high
@@ -9439,7 +9440,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 4h down move, 15m & 1h & 4h stil high, 14m & 4h high
       & (
@@ -9450,7 +9451,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 1d overbought
@@ -9604,7 +9605,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_1d < 40.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 1h still high, 4h high
@@ -9635,7 +9636,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 90.0)
+        | stochrsi_k_15m_lt_90
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m high, 1d overbought
       & (
@@ -9656,7 +9657,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_15m < 60.0)
+        | stochrsi_k_15m_lt_60
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
@@ -9682,7 +9683,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
@@ -9707,7 +9708,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 90.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h downtrend, 15m high
@@ -9720,7 +9721,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still not low enough, 4h & 1h still high, 1d overbought
       & (
@@ -9749,7 +9750,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_4h > 10.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -9783,7 +9784,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h downtrend
       & (
@@ -9842,7 +9843,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 15m & 1h & 4h & 1d down move, 1d downtrend, 4h still not low enough, 15m still high, 1h downtrend
       & (
@@ -9852,7 +9853,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 45.0)
         | (protection_cmf_20_1d > -0.40)
         | (protection_aroonu_14_4h < 30.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_1h > -25.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h high
@@ -9906,7 +9907,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_15m < 60.0)
+        | stochrsi_k_15m_lt_60
         | (protection_roc_9_1h > -30.0)
         | (protection_roc_9_4h > -40.0)
       )
@@ -10026,7 +10027,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
@@ -10120,7 +10121,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still high, 4h high & overbought
@@ -10153,7 +10154,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 60.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_15m < 20.0)
       )
@@ -10204,7 +10205,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 15m & 1h down move, 15m & 1h & 4h high, 1h & 4h overbought
       & (
@@ -10219,7 +10220,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h < 70.0)
       )
       # 1h & 4h down move, 15m high
-      & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | (protection_stochrsik_14_14_3_3_15m < 50.0))
+      & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | stochrsi_k_15m_lt_50)
       # 1h & 4h down move, 4h still not low enough
       & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | (protection_aroonu_14_4h < 20.0))
       # 1h & 4h down move, 15m still not low enough, 4h downtrend
@@ -10334,7 +10335,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 20.0)
-        | (protection_stochrsik_14_14_3_3_15m < 80.0)
+        | stochrsi_k_15m_lt_80
         | (protection_roc_9_1h > -30.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -10505,7 +10506,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_4h > 3.0)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 4h down move, 15m & 1h high
       & ((protection_rsi_3_4h > 3.0) | (protection_aroonu_14_15m < 60.0) | (protection_aroonu_14_1h < 90.0))
@@ -10514,12 +10515,12 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_4h > 3.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
       )
       # 4h down move, 15m & 1h high, 4h downtrend
       & (
         (protection_rsi_3_4h > 3.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -10556,7 +10557,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
         | (protection_roc_9_4h > -30.0)
       )
       # 4h down move, 15m & 1h & 4h still high, 15m high
@@ -10566,7 +10567,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
       )
       # 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 4h downtrend, 1d overbought
       & (
@@ -10594,7 +10595,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_roc_9_4h > -50.0)
       )
       # 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1h still high, 4h downtrend
@@ -10616,7 +10617,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 30.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -10624,7 +10625,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_15m < 80.0)
-        | (protection_stochrsik_14_14_3_3_15m < 50.0)
+        | stochrsi_k_15m_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
@@ -10670,7 +10671,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d down move, 15m high, 1h & 4h downtrend
       & (
         (protection_rsi_3_1d > 5.0)
-        | (protection_stochrsik_14_14_3_3_15m < 70.0)
+        | stochrsi_k_15m_lt_70
         | (protection_roc_9_1h > -60.0)
         | (protection_roc_9_4h > -60.0)
       )


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Hoist long protection high STOCHRSI 15m comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
