### PR TITLE
Reuse X7 long protection low STOCHRSI 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4565,6 +4565,11 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_roc_9_1d = df["ROC_9_1d"].to_numpy(copy=False)
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
+    # Reuse long protection low STOCHRSI 1h comparison masks
+    stochrsi_k_1h_lt_15 = protection_stochrsik_14_14_3_3_1h < 15.0
+    stochrsi_k_1h_lt_20 = protection_stochrsik_14_14_3_3_1h < 20.0
+    stochrsi_k_1h_lt_30 = protection_stochrsik_14_14_3_3_1h < 30.0
+    stochrsi_k_1h_lt_40 = protection_stochrsik_14_14_3_3_1h < 40.0
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
     protection_roc_9_4h = df["ROC_9_4h"].to_numpy(copy=False)
     protection_cmf_20_1d = df["CMF_20_1d"].to_numpy(copy=False)
@@ -4868,7 +4873,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend, 4h overbought
       & (
@@ -4887,7 +4892,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 4h still high, 1h downtrend, 4h still high
@@ -4928,7 +4933,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
       )
       # 15m & 1h & 4h & 1d down move, 1h still high, 1h & 4h still not low enough
       & (
@@ -4956,7 +4961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
       )
       # 15m & 4h down move, 1h & 4h still high, 15m still not low enough, 1h still high
       & (
@@ -5115,7 +5120,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 55.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -5125,7 +5130,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 1h & 4h downtrend
@@ -5583,7 +5588,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h high, 1d overbought
       & (
@@ -5614,7 +5619,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 25.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still high
@@ -5704,7 +5709,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 4h overbought
@@ -5740,7 +5745,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low, 4h still high, 15m & 1h downtrend, 4h not low, 4h downtrend
@@ -5877,7 +5882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h high & overbought
@@ -5972,7 +5977,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m stil not low enough, 1h & 4h still high, 15m & 4h still high, 1d overbought
@@ -6152,7 +6157,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 20.0)
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_roc_9_4h > -25.0)
         | (protection_roc_9_1d > -50.0)
       )
@@ -6185,7 +6190,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
       )
@@ -6320,7 +6325,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m downtrend, 4h high, 1h downtrend
       & (
@@ -6436,7 +6441,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -15.0)
       )
@@ -6665,7 +6670,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h > -10.0)
@@ -6681,7 +6686,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 4h downtrend, 1h high, 4h downtrend
@@ -6704,7 +6709,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1d < 40.0)
         | (protection_cmf_20_1h > -0.15)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
         | (protection_roc_9_1d > -25.0)
       )
@@ -6752,7 +6757,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 20.0)
       )
@@ -6766,7 +6771,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h high, 4h overbought
@@ -6882,7 +6887,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 10.0)
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
         | (protection_roc_9_1h > -15.0)
         | (protection_roc_9_4h > -15.0)
@@ -6920,7 +6925,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
       )
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h high, 4h downtrend
       & (
@@ -7082,7 +7087,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 45.0)
         | (protection_cmf_20_15m > -0.40)
         | (protection_aroonu_14_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 15.0)
+        | stochrsi_k_1h_lt_15
         | (protection_stochrsik_14_14_3_3_4h < 15.0)
         | (protection_cci_20_1h < -350.0)
         | (protection_cci_20_4h < -200.0)
@@ -7158,7 +7163,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
@@ -7312,7 +7317,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1h high, 4h downtrend
@@ -7394,7 +7399,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 40.0)
       )
@@ -7431,7 +7436,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 1h & 4h & 1d down move, 1d still high, 1h still high, 4h high
@@ -7543,7 +7548,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 40.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -7641,7 +7646,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high, 4h overbought
@@ -7781,7 +7786,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h down move, 15m & 1h still high, 4h high, 1h & 4h high, 1h overbought
@@ -7942,7 +7947,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -7986,7 +7991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_4h < 75.0)
       )
@@ -8068,7 +8073,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1d > -0.20)
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -15.0)
       )
@@ -8175,7 +8180,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
@@ -8333,7 +8338,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 4h overbought
@@ -8521,7 +8526,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 4h overbought
@@ -8670,7 +8675,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 3.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 4h down move, 15m & 1h high, 4h downtrend
@@ -8730,7 +8735,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 25.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -30.0)
@@ -8793,7 +8798,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.0)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
       # 15m down move, 15m & 1h & 4h still high, 15m & 1h & 4h high, 1h & 4h high, 4h overbought
@@ -8819,7 +8824,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
       )
       # 15m down move, 15m still high, 1h >& 4h high, 15m & 1h & 4h high, 4h overbought
       & (
@@ -8830,7 +8835,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -8874,7 +8879,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_4h > -0.30)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enugh, 4h still high, 15m still high, 1h & 4h downtrend
@@ -8901,7 +8906,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 20.0)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_1h > -15.0)
       )
@@ -9063,7 +9068,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 1h & 4h downtrend, 15m & 1h high
@@ -9483,7 +9488,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 20.0)
       )
@@ -9578,7 +9583,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
@@ -9657,7 +9662,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 1h & 4h high, 1h overbought
@@ -10326,7 +10331,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
       )
       # 1h & 4h down move, 1h & 4h still not low enough, 15m high, 1h & 4h downtrend
       & (
@@ -10348,14 +10353,14 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_roc_9_1h > -10.0)
       )
       # 1h & 4h down move, 1h still not low enough, 4h downtrend
       & (
         (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 3.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_roc_9_4h > -25.0)
       )
       # 1h & 4h down move, 1h & 4h downtrend, 1h high, 4h downtrend
@@ -10387,14 +10392,14 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
       )
       # 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d downtrend
       & (
         (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -30.0)
       )
@@ -10546,7 +10551,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_4h > 5.0)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.20)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
       # 4h down mnove, 15m & 1h & 4h downtrend, 15m high, 4h downtrend
@@ -10636,7 +10641,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 30.0)
+        | stochrsi_k_1h_lt_30
         | (protection_roc_9_4h > -30.0)
         | (protection_roc_9_1d > -50.0)
       )
@@ -10911,7 +10916,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 25.0)
         | (protection_cmf_20_1h > -0.2)
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
       )
       # 1d P&D, 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
@@ -11243,7 +11248,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 20.0)
+        | stochrsi_k_1h_lt_20
       )
       # 1d top wick, 15m down move, 15m stil high, 1h & 4h high, 4h overbought
       & (
@@ -11401,7 +11406,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_6_1d * 0.25))
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1d > 15.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
         | (protection_roc_9_4h > -25.0)
       )
@@ -11459,7 +11464,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # drop in last 20 days, 15m & 1h & 1d down move, 15m still not low enough, 1h high
@@ -11511,7 +11516,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 40.0)
+        | stochrsi_k_1h_lt_40
       )
     )
     df["global_protections_long_pump"] = True


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection low STOCHRSI 1h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
