### PR TITLE
Hoist X7 long protection high STOCHRSI 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4565,6 +4565,13 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_roc_9_1d = df["ROC_9_1d"].to_numpy(copy=False)
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
+    # Hoist long protection high STOCHRSI 1h comparison masks
+    stochrsi_k_1h_lt_50 = protection_stochrsik_14_14_3_3_1h < 50.0
+    stochrsi_k_1h_lt_60 = protection_stochrsik_14_14_3_3_1h < 60.0
+    stochrsi_k_1h_lt_70 = protection_stochrsik_14_14_3_3_1h < 70.0
+    stochrsi_k_1h_lt_80 = protection_stochrsik_14_14_3_3_1h < 80.0
+    stochrsi_k_1h_lt_85 = protection_stochrsik_14_14_3_3_1h < 85.0
+    stochrsi_k_1h_lt_90 = protection_stochrsik_14_14_3_3_1h < 90.0
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
     protection_roc_9_4h = df["ROC_9_4h"].to_numpy(copy=False)
     protection_cmf_20_1d = df["CMF_20_1d"].to_numpy(copy=False)
@@ -4687,7 +4694,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # 5m & 15m & 1h & 4h down move, 4h high
       & (
@@ -4722,7 +4729,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 5m & 4h & 1d down move, 15m high
       & (
@@ -4791,7 +4798,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.20)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -15.0)
       )
@@ -4965,7 +4972,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 25.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m down move, 15m & 1h high
       & (
@@ -4973,7 +4980,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 90.0)
+        | stochrsi_k_1h_lt_90
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still not low enough, 4h downtrend
       & (
@@ -5105,7 +5112,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 1h still high, 1h & 4h still not low enough, 4h overbought
       & (
@@ -5304,7 +5311,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 1d overbought
       & (
@@ -5324,7 +5331,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_1d < 60.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m still not low enough
@@ -5389,7 +5396,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h & 4h downtrend
@@ -5680,7 +5687,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h stil high, 1h & 4h downtrend, 1h & 4h still not low
@@ -5914,7 +5921,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h still high, 1d downtrend
       & (
@@ -5925,7 +5932,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 10.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -50.0)
       )
@@ -5997,7 +6004,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h still high
       & (
@@ -6065,7 +6072,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.0)
         | (protection_cmf_20_4h > -0.4)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 90.0)
+        | stochrsi_k_1h_lt_90
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
       & (
@@ -6114,7 +6121,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.0)
         | (protection_cmf_20_4h > -0.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
       )
       # 15m & 1h down move, 15m & 4h high, 4h overbought
       & (
@@ -6391,7 +6398,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 1d down move, 15m & 1h still not low enough, 4h high, 1d downtrend, 4h overbought
@@ -6578,7 +6585,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1d downtrend
@@ -6637,7 +6644,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 30.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_cci_20_1h < -250.0)
         | (protection_cci_20_4h < -250.0)
         | (protection_roc_9_4h > -15.0)
@@ -6690,7 +6697,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_4h > -0.10)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h & 1d still high, 1h downtrend, 1d downtrend
@@ -6717,7 +6724,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h downtrend, 15m & 4h still not low, 1h high
       & (
@@ -6730,7 +6737,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.25)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # 15m ^ 1h down move, 15m & 1h & 4h still not low enough, 1h & 4h high, 1h overbought
       & (
@@ -6739,7 +6746,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_1h < 10.0)
       )
@@ -6779,7 +6786,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 10.0)
       )
@@ -6907,7 +6914,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_aroonu_14_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 90.0)
+        | stochrsi_k_1h_lt_90
         | (protection_roc_9_1h < 10.0)
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend
@@ -6934,12 +6941,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 4h down move, 1h high & overbought
-      & (
-        (rsi_3_15m_gt_15)
-        | (protection_rsi_3_4h > 45.0)
-        | (protection_stochrsik_14_14_3_3_1h < 90.0)
-        | (protection_roc_9_1h < 10.0)
-      )
+      & ((rsi_3_15m_gt_15) | (protection_rsi_3_4h > 45.0) | stochrsi_k_1h_lt_90 | (protection_roc_9_1h < 10.0))
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
         (rsi_3_15m_gt_15)
@@ -6968,7 +6970,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1d > 5.0)
         | rsi_14_15m_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1d down move, 15m still not low enough, 1h & 4h high
@@ -6981,7 +6983,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 15m down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 15m & 1h high
@@ -7053,7 +7055,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 20.0)
@@ -7265,7 +7267,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_1d < 150.0)
       )
       # 15m & 1h & 1d down move, 1h & 4h still high, 15m downtrend, 1d overbought
@@ -7285,7 +7287,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_4h > -70.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h still high, 1h & 4h downtrend, 1d overbought
@@ -7324,7 +7326,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_4h > -40.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m & 1h downtrend, 1h & 4h high, 4h & 1d overbought
@@ -7476,7 +7478,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 90.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -50.0)
       )
@@ -7524,7 +7526,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 1h & 4h down move, 15m downtrend, 15m still high, 1h overbought
@@ -7553,7 +7555,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_4h > -0.40)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 15m high, 4h & 1d downtrend
@@ -7628,7 +7630,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_4h > -25.0)
         | (protection_roc_9_1d > -30.0)
       )
@@ -7872,7 +7874,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -25.0)
       )
       # 15m & 4h down move, 15m & 1h still high, 4h downtrend
@@ -7880,7 +7882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_4h > -30.0)
       )
       # 15m &4d down move, 15m & 1h high, 4h downtrend
@@ -7888,7 +7890,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 4h down move, 4h still high, 4h downtrend, 1d overbought
@@ -7919,7 +7921,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m still high, 1h high, 4h overbought
@@ -8125,7 +8127,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_1d < 100.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h still high
@@ -8138,7 +8140,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 15m downtrend, 15m still not low enough
       & (
@@ -8243,7 +8245,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -40.0)
       )
@@ -8382,7 +8384,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high, 1d overbought
       & (
@@ -8480,7 +8482,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 60.0)
+        | stochrsi_k_1h_lt_60
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_1d > -50.0)
       )
@@ -8493,7 +8495,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 30.0)
       )
@@ -8590,7 +8592,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -25.0)
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 1h overbought, 1d downtrend
@@ -8612,7 +8614,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 60.0)
+        | stochrsi_k_1h_lt_60
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h > -15.0)
       )
@@ -8625,7 +8627,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
         | (protection_roc_9_4h < 60.0)
       )
@@ -8639,7 +8641,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # 15m & 1h down move, 1h & 4h high, 4h overbought
       & (
@@ -8679,7 +8681,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 10.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 4h & 1d down move, 15m still high, 1h & 4h downtrend
@@ -8709,7 +8711,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_4h > -25.0)
       )
       # 15m & 4h down move, 15m & 1h still not low enough, 4h still high,  1h & 4h downtrend, 15m & 1h & 4h still high
@@ -8755,7 +8757,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_1h < 10.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
@@ -8778,7 +8780,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -8805,7 +8807,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
       )
@@ -8860,7 +8862,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_aroonu_14_15m < 80.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 90.0)
+        | stochrsi_k_1h_lt_90
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h < 20.0)
       )
@@ -9132,7 +9134,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still low, 1h & 4h still high, 4h high & overbought
@@ -9329,7 +9331,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_4h < 25.0)
       )
@@ -9343,7 +9345,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m & 1h down move, 15m & 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
@@ -9394,7 +9396,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -50.0)
       )
       # 15m & 4h down move, 15m & 1h still high, 1h & 4h downtrend, 15m & 1h still high
@@ -9407,7 +9409,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high
       & (
@@ -9472,7 +9474,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 15m down move, 15m & 1h & 4h still high, 15m high, 15m & 1h still high, 4h high, 4h overbought
@@ -9553,7 +9555,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still high, 15m & 1h high, 1d overbought
       & (
@@ -9708,7 +9710,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 70.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h downtrend, 15m high
       & (
@@ -9732,7 +9734,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_1d < 150.0)
       )
       # 15m & 1h down move, 15m & 1h & 4h high, 1h overbought
@@ -9750,7 +9752,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 10.0)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 4h down move, 15m still high, 1h high, 15m & 1h high
@@ -9794,7 +9796,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_4h > -20.0)
       )
       # 15m down move, 15m still high, 1h & 4h high, 1h & 4h overbought
@@ -9805,7 +9807,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_stochrsik_14_14_3_3_1h < 60.0)
+        | stochrsi_k_1h_lt_60
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
         | (protection_roc_9_1h < 20.0)
         | (protection_roc_9_4h < 20.0)
@@ -9992,7 +9994,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_1h < 20.0)
       )
       # 15m &4h down move, 15m & 1h & 4h still high, 15m still high, 1h high, 15m & 1h overbought
@@ -10015,7 +10017,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
         | (protection_roc_9_1h < 20.0)
       )
       # 15m & 1d down move, 15m & 1h & 4h stil high, 4h high, 15m & 1h & 4h still high
@@ -10027,7 +10029,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m down move, 15m & 1h still high, 4h high & overbought
@@ -10154,7 +10156,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_15m < 20.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h & 4h still high
@@ -10168,7 +10170,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.35)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m down move, 15m & 1h & 4h high, 15m & 1h high, 4h & 1d overbought
@@ -10498,7 +10500,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_4h > 3.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # 4h down move, 1h & 4h downtrend, 15m high
       & (
@@ -10520,7 +10522,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 3.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_4h > -20.0)
       )
       # 4h & 1d down move, 15m still not low enough, 4h downtrend
@@ -10605,7 +10607,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_4h > -0.25)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_4h > -60.0)
       )
       # 4h down move, 15m & 1h & 4h still high, 15m high, 4h still not low enough, 1d overbought
@@ -10625,7 +10627,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_15m < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 30.0)
@@ -10646,7 +10648,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_1d > -30.0)
       )
@@ -10658,15 +10660,10 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
       )
       # 1d down move, 15m still not low enough, 1h high, 1d downtrend
-      & (
-        (protection_rsi_3_1d > 5.0)
-        | rsi_14_15m_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
-        | (protection_roc_2_1d > -40.0)
-      )
+      & ((protection_rsi_3_1d > 5.0) | rsi_14_15m_lt_30 | stochrsi_k_1h_lt_80 | (protection_roc_2_1d > -40.0))
       # 1d down move, 15m high, 1h & 4h downtrend
       & (
         (protection_rsi_3_1d > 5.0)
@@ -10686,7 +10683,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1d down move, 1h high & overbought, 4h & 1d downtrend
       & (
         (protection_rsi_3_1d > 10.0)
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
+        | stochrsi_k_1h_lt_80
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h > -40.0)
         | (protection_roc_9_1d > -40.0)
@@ -10790,7 +10787,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -40.0)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 10.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_4h > -35.0)
       )
       # 1d P&D, 15m & 4h down move, 15m & 4h still high
@@ -10833,7 +10830,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 55.0)
         | (protection_aroonu_14_1d < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
       )
       # 1d P&D, 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m & 4h still high
       & (
@@ -11061,7 +11058,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 50.0)
@@ -11129,7 +11126,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_15m > 50.0)
         | rsi_3_4h_gt_60
         | (protection_aroonu_14_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_roc_9_1d < 100.0)
       )
       # 1d green, 15m & 4h down move, 4h still high, 4h & 1d overbought
@@ -11188,7 +11185,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_stochrsik_14_14_3_3_1h < 50.0)
+        | stochrsi_k_1h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_4h < 50.0)
       )
@@ -11422,7 +11419,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_24_4h * 0.15))
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 25.0)
-        | (protection_stochrsik_14_14_3_3_1h < 70.0)
+        | stochrsi_k_1h_lt_70
       )
       # drop in last 4 days, 1d down move, 1d downtrendm 1h still high, 1d downtrend
       & (
@@ -11502,7 +11499,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_15
         | (protection_rsi_3_4h > 50.0)
         | (protection_aroonu_14_15m < 80.0)
-        | (protection_stochrsik_14_14_3_3_1h < 85.0)
+        | stochrsi_k_1h_lt_85
       )
       # drop in last 30 days, 15m & 1h & 4h down move, 15m still not low enough, 1h high
       & (


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Hoist long protection high STOCHRSI 1h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
