### PR TITLE
Reuse X7 long protection low STOCHRSI 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4566,6 +4566,13 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_aroonu_14_1h = df["AROONU_14_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_1h = df["STOCHRSIk_14_14_3_3_1h"].to_numpy(copy=False)
     protection_stochrsik_14_14_3_3_4h = df["STOCHRSIk_14_14_3_3_4h"].to_numpy(copy=False)
+    # Reuse long protection low STOCHRSI 4h comparison masks
+    stochrsi_k_4h_lt_10 = protection_stochrsik_14_14_3_3_4h < 10.0
+    stochrsi_k_4h_lt_15 = protection_stochrsik_14_14_3_3_4h < 15.0
+    stochrsi_k_4h_lt_20 = protection_stochrsik_14_14_3_3_4h < 20.0
+    stochrsi_k_4h_lt_30 = protection_stochrsik_14_14_3_3_4h < 30.0
+    stochrsi_k_4h_lt_40 = protection_stochrsik_14_14_3_3_4h < 40.0
+    stochrsi_k_4h_lt_50 = protection_stochrsik_14_14_3_3_4h < 50.0
     protection_roc_9_4h = df["ROC_9_4h"].to_numpy(copy=False)
     protection_cmf_20_1d = df["CMF_20_1d"].to_numpy(copy=False)
     protection_roc_9_15m = df["ROC_9_15m"].to_numpy(copy=False)
@@ -4792,7 +4799,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -15.0)
       )
       # 5m & 15m & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 4h high
@@ -4818,7 +4825,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 5m & 15m & 1h down move, 15m still high, 1h & 4h high, 4h high & overbought
       & (
@@ -4850,7 +4857,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
       )
       # 15m & 1h & 4h down move, 15m downtrend, 1h & 4h still not low enough
       & (
@@ -4888,7 +4895,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
       )
       # 15m & 1h & 4h down move, 4h still high, 1h downtrend, 4h still high
       & (
@@ -5008,7 +5015,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 20.0)
+        | stochrsi_k_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m still not low enough
       & (
@@ -5027,7 +5034,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 10.0)
+        | stochrsi_k_4h_lt_10
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 15m still not low enough, 1h downtrend
       & (
@@ -5076,7 +5083,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
-        | (protection_stochrsik_14_14_3_3_4h < 20.0)
+        | stochrsi_k_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 1h still not low enugh, 4h still high
       & (
@@ -5096,7 +5103,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.40)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 1h still high
       & (
@@ -5116,7 +5123,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 20.0)
+        | stochrsi_k_4h_lt_20
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h down move, 1h & 4h still not low enough, 4h high
@@ -5161,7 +5168,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m still high
       & (
@@ -5262,7 +5269,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h high, 1h high, 4h overbought
       & (
@@ -5462,7 +5469,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.25)
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 20.0)
+        | stochrsi_k_4h_lt_20
       )
       # 15m & 1h & 4h down move, 1h & 15m still high, 1h downtrend
       & (
@@ -5615,7 +5622,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 25.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still high
       & (
@@ -5667,7 +5674,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high
@@ -5681,7 +5688,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h stil high, 1h & 4h downtrend, 1h & 4h still not low
       & (
@@ -5741,7 +5748,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low, 4h still high, 15m & 1h downtrend, 4h not low, 4h downtrend
       & (
@@ -5926,7 +5933,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 10.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -50.0)
       )
       # 15m & 1h down move, 4h still high, 15m downtrend, 1h & 1d high
@@ -5973,7 +5980,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m stil not low enough, 1h & 4h still high, 15m & 4h still high, 1d overbought
       & (
@@ -6009,7 +6016,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 14h & 1d overbought
       & (
@@ -6143,7 +6150,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 20.0)
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 4h & 1d down move, 15m & 1h still not low enough, 1h still high, 4h & 1d downtrend
       & (
@@ -6186,7 +6193,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend
@@ -6379,7 +6386,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d < 30.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1d overbought
@@ -6579,7 +6586,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h high, 1d downtrend
       & (
@@ -6666,7 +6673,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h > -10.0)
       )
@@ -6705,7 +6712,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.15)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
         | (protection_roc_9_1d > -25.0)
       )
       # 15m down move, 15m still not low enough, 1h & 4h still high, 15m still high, 1h high
@@ -6883,7 +6890,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 20.0)
+        | stochrsi_k_4h_lt_20
         | (protection_roc_9_1h > -15.0)
         | (protection_roc_9_4h > -15.0)
       )
@@ -7083,7 +7090,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.40)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 15.0)
-        | (protection_stochrsik_14_14_3_3_4h < 15.0)
+        | stochrsi_k_4h_lt_15
         | (protection_cci_20_1h < -350.0)
         | (protection_cci_20_4h < -200.0)
       )
@@ -7108,7 +7115,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1d < 30.0)
         | (protection_cmf_20_1d > -0.20)
         | (protection_aroonu_14_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
         | (protection_roc_9_1d > -15.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 1h high
@@ -7159,7 +7166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 20.0)
+        | stochrsi_k_4h_lt_20
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h still high, 4h high & overbought
       & (
@@ -7313,7 +7320,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1h high, 4h downtrend
       & (
@@ -7395,7 +7402,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h down move, 1h still high, 1h & 4h high, 4h & 1d overbought
@@ -7477,7 +7484,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -50.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m still not lowenough, 1h high, 1d overbought
@@ -7544,7 +7551,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 1h & 4h down move, 4d downtrend, 1h high, 4h downtrend
@@ -7943,7 +7950,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 4h down move, 15m still high, 1h still high, 4h high & overbought
@@ -8069,7 +8076,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1d > -0.20)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -15.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h stil high, 4h high & overbought
@@ -8244,7 +8251,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -40.0)
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1d downtrend, 1h high, 1d overbought
@@ -8334,7 +8341,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h high, 4h overbought
       & (
@@ -8405,7 +8412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend, 15m high, 4h downtrend
@@ -8731,7 +8738,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -8779,7 +8786,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 4h still high
@@ -8794,7 +8801,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
       )
       # 15m down move, 15m & 1h & 4h still high, 15m & 1h & 4h high, 1h & 4h high, 4h overbought
       & (
@@ -8875,7 +8882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_4h > -0.30)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enugh, 4h still high, 15m still high, 1h & 4h downtrend
       & (
@@ -8902,7 +8909,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
         | (protection_roc_9_1h > -15.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 1h & 4h downtrend
@@ -8942,7 +8949,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high
@@ -9133,7 +9140,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m still low, 1h & 4h still high, 4h high & overbought
       & (
@@ -9508,7 +9515,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h high, 1d overbought
@@ -9658,7 +9665,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h stil high, 1h & 4h high, 1h overbought
       & (
@@ -9954,7 +9961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.15)
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 25.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
@@ -10028,7 +10035,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m down move, 15m & 1h still high, 4h high & overbought
       & (
@@ -10169,7 +10176,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.35)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 15m down move, 15m & 1h & 4h high, 15m & 1h high, 4h & 1d overbought
       & (
@@ -10395,7 +10402,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -30.0)
       )
       # 1h & 4h down move, 1h & 4h still not low enough, 4h still high, 1h & 4h downtrend, 1d overbought
@@ -10436,7 +10443,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
       )
       # 1h & 4h down move, 1h & 4h still high, 1h still not low enough, 4h still high, 1h downtrend, 4h & 1d overbought
       & (
@@ -10547,7 +10554,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
       )
       # 4h down mnove, 15m & 1h & 4h downtrend, 15m high, 4h downtrend
       & (
@@ -10617,7 +10624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 30.0)
+        | stochrsi_k_4h_lt_30
         | (protection_roc_9_1d < 50.0)
       )
       # 4h down move, 15m high, 15m & 1h & 4h high, 4h & 1d overbought
@@ -10800,7 +10807,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_20
         | (protection_rsi_3_4h > 25.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
       )
       # 1d red, 15m & 1h & 4h down move, 1h still not low enough, 4h & 1d still high
       & (
@@ -10810,7 +10817,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 50.0)
         | (protection_rsi_14_1h < 35.0)
         | rsi_14_4h_lt_40
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
         | (protection_stochrsik_14_14_3_3_1d < 50.0)
       )
       # 1d red, 1h & 4h & 1d down move, 1h still not low enough, 4h & 1d still high, 1d downtrend
@@ -10822,7 +10829,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_rsi_14_1d < 40.0)
-        | (protection_stochrsik_14_14_3_3_4h < 40.0)
+        | stochrsi_k_4h_lt_40
         | (protection_roc_9_1d > -20.0)
       )
       # 1d red, 15m & 1h & 4h down move, 1d high, 15m & 1h still high
@@ -10958,7 +10965,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 65.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d < 20.0)
       )
       # 1d green with top wick, 15m & 1h & 4h down move, 1h & 4h still high
@@ -11062,7 +11069,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -11189,7 +11196,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_4h < 50.0)
       )
       # 4h top wick, 15m & 1h down move, 15m & 1h still high, 1h & 4h high
@@ -11449,7 +11456,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 35.0)
         | (protection_rsi_3_1d > 35.0)
-        | (protection_stochrsik_14_14_3_3_4h < 50.0)
+        | stochrsi_k_4h_lt_50
         | (protection_roc_9_1d > -40.0)
       )
       # drop in last 12 days, 15m & 1h down move, 1h still not low enough, 4h high


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection low STOCHRSI 4h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
