### PR TITLE
Hoist X7 long protection CMF 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4571,6 +4571,18 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_roc_9_15m = df["ROC_9_15m"].to_numpy(copy=False)
     protection_roc_9_1h = df["ROC_9_1h"].to_numpy(copy=False)
     protection_cmf_20_1h = df["CMF_20_1h"].to_numpy(copy=False)
+    # Hoist long protection CMF 1h comparison masks
+    cmf_20_1h_gt_neg_0 = protection_cmf_20_1h > -0.0
+    cmf_20_1h_gt_neg_010 = protection_cmf_20_1h > -0.10
+    cmf_20_1h_gt_neg_015 = protection_cmf_20_1h > -0.15
+    cmf_20_1h_gt_neg_020 = protection_cmf_20_1h > -0.20
+    cmf_20_1h_gt_neg_02 = protection_cmf_20_1h > -0.2
+    cmf_20_1h_gt_neg_025 = protection_cmf_20_1h > -0.25
+    cmf_20_1h_gt_neg_030 = protection_cmf_20_1h > -0.30
+    cmf_20_1h_gt_neg_03 = protection_cmf_20_1h > -0.3
+    cmf_20_1h_gt_neg_040 = protection_cmf_20_1h > -0.40
+    cmf_20_1h_gt_neg_04 = protection_cmf_20_1h > -0.4
+    cmf_20_1h_gt_neg_05 = protection_cmf_20_1h > -0.5
     protection_cmf_20_4h = df["CMF_20_4h"].to_numpy(copy=False)
     protection_aroonu_14_1d = df["AROONU_14_1d"].to_numpy(copy=False)
     protection_mfi_14_1d = df["MFI_14_1d"].to_numpy(copy=False)
@@ -4886,7 +4898,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
@@ -4896,7 +4908,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 45.0)
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_aroonu_14_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m downtrend
@@ -4926,7 +4938,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
       )
@@ -4981,7 +4993,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.15)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.15)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 20.0)
@@ -4993,7 +5005,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -5006,7 +5018,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
@@ -5016,7 +5028,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.40)
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 5m & 1h & 4h down move, 1h & 4h downtrend, 15m still high, 4h still not low enough
@@ -5024,7 +5036,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 10.0)
@@ -5045,7 +5057,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_cmf_20_4h > -0.30)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
@@ -5055,7 +5067,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_aroonu_14_15m < 50.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 1d overbought
@@ -5073,7 +5085,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.15)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
@@ -5084,7 +5096,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -5095,7 +5107,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_14_1h < 20.0)
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 1h still high
@@ -5104,7 +5116,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 1h still high, 1h & 4h still not low enough, 4h overbought
@@ -5136,7 +5148,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_cmf_20_4h > -0.15)
       )
       # 15m & 1h & 4h down move, 1h & 4h stil not low enough, 15m & 1h & 4h downtrend, 1h still high
@@ -5147,7 +5159,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
       )
@@ -5400,7 +5412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 10.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_15m > -0.15)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.15)
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -20.0)
@@ -5412,7 +5424,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h still high
@@ -5421,7 +5433,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.15)
         | (protection_aroonu_14_4h < 40.0)
       )
@@ -5431,7 +5443,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h downtrend, 1h still high, 1h downtrend
@@ -5439,7 +5451,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_roc_9_1h > -15.0)
@@ -5459,7 +5471,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
@@ -5479,7 +5491,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 70.0)
       )
@@ -5502,7 +5514,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 4h still high, 4h downtrend
@@ -5514,7 +5526,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.15)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_aroonu_14_4h < 40.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -5569,7 +5581,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 1h & 4h downtrend, 1h still not low enough
@@ -5581,7 +5593,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
       )
@@ -5600,7 +5612,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 55.0)
         | rsi_14_4h_lt_50
-        | (protection_cmf_20_1h > -0.4)
+        | cmf_20_1h_gt_neg_04
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
@@ -5611,7 +5623,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 25.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -5623,7 +5635,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_cmf_20_4h > -0.30)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
@@ -5634,7 +5646,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_aroonu_14_4h < 50.0)
         | (protection_cci_20_1h < -200.0)
         | (protection_cci_20_4h < -0.0)
@@ -5691,7 +5703,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m < 10.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 30.0)
@@ -5738,7 +5750,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
@@ -5752,7 +5764,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_aroonu_14_4h < 20.0)
         | (protection_roc_9_4h > -10.0)
       )
@@ -5785,7 +5797,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 25.0)
         | (protection_aroonu_14_4h < 25.0)
@@ -5825,7 +5837,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 4h high, 4h & 1d overbought
       & (
@@ -5912,7 +5924,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
@@ -5970,7 +5982,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
@@ -5995,7 +6007,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.25)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
@@ -6052,7 +6064,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_1h < 10.0)
@@ -6062,7 +6074,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_cmf_20_1h > -0.0)
+        | cmf_20_1h_gt_neg_0
         | (protection_cmf_20_4h > -0.4)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
@@ -6111,7 +6123,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_1h > -0.0)
+        | cmf_20_1h_gt_neg_0
         | (protection_cmf_20_4h > -0.0)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
@@ -6219,7 +6231,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 25.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_roc_9_4h > -20.0)
@@ -6255,7 +6267,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m > 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.0)
         | (protection_aroonu_14_4h < 20.0)
       )
@@ -6353,7 +6365,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 70.0)
       )
@@ -6413,7 +6425,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high 4h & 1d downtrend
@@ -6651,7 +6663,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 35.0)
         | (protection_rsi_14_4h < 35.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_cmf_20_4h > -0.30)
         | (protection_cci_20_1h < -200.0)
         | (protection_cci_20_4h < -200.0)
@@ -6702,7 +6714,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_rsi_14_1d < 40.0)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
@@ -6727,7 +6739,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
@@ -6918,7 +6930,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
@@ -6991,7 +7003,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
       )
@@ -7119,7 +7131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_cci_20_1h < -200.0)
@@ -7157,7 +7169,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
@@ -7193,7 +7205,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_roc_9_1d < 50.0)
       )
@@ -7218,7 +7230,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -7232,7 +7244,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.15)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.15)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
@@ -7335,7 +7347,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 60.0)
         | (protection_roc_9_4h < 20.0)
@@ -7427,7 +7439,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -7677,7 +7689,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
@@ -7721,7 +7733,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
@@ -8113,7 +8125,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_rsi_3_1d > 30.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_cmf_20_4h > -0.40)
         | (protection_roc_9_4h > -40.0)
       )
@@ -8292,7 +8304,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 80.0)
@@ -8330,7 +8342,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_1h > -0.15)
+        | cmf_20_1h_gt_neg_015
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
@@ -8380,7 +8392,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
@@ -8416,7 +8428,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -8578,7 +8590,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -8688,7 +8700,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_rsi_3_1d > 15.0)
         | rsi_14_15m_lt_40
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -8719,7 +8731,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 30.0)
@@ -8790,7 +8802,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_mfi_14_1h < 40.0)
         | (protection_mfi_14_4h < 50.0)
-        | (protection_cmf_20_1h > -0.0)
+        | cmf_20_1h_gt_neg_0
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
@@ -8816,7 +8828,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_aroonu_14_4h < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -8939,7 +8951,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
@@ -9014,7 +9026,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 60.0)
       )
@@ -9073,7 +9085,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
@@ -9258,7 +9270,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 80.0)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 80.0)
       )
@@ -9314,7 +9326,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h > -20.0)
@@ -9403,7 +9415,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -9614,8 +9626,8 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.30)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
+        | cmf_20_1h_gt_neg_030
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 80.0)
       )
@@ -9779,7 +9791,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
@@ -9861,7 +9873,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 45.0)
         | (protection_cmf_20_15m > -0.40)
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_cmf_20_4h > -0.40)
         | (protection_aroonu_14_4h < 75.0)
       )
@@ -9976,7 +9988,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 70.0)
@@ -10082,7 +10094,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
@@ -10094,7 +10106,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_cmf_20_1d > -0.30)
         | (protection_aroonu_14_1h < 70.0)
@@ -10165,7 +10177,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.15)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_cmf_20_4h > -0.35)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -10228,7 +10240,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 3.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_aroonu_14_4h < 50.0)
       )
       # 1h & 4h down move, 1h still not low enough, 4h still high, 1d overbought
@@ -10251,7 +10263,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 10.0)
-        | (protection_cmf_20_1h > -0.5)
+        | cmf_20_1h_gt_neg_05
         | (protection_cmf_20_4h > -0.5)
       )
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still high
@@ -10259,7 +10271,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
@@ -10269,7 +10281,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.40)
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_roc_9_4h > -20.0)
       )
       # 1h & 4h down move, 1h still high, 4h high, 1d overbought
@@ -10305,7 +10317,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.0)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 60.0)
       )
@@ -10313,7 +10325,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_cmf_20_4h > -0.40)
         | (protection_aroonu_14_1h < 60.0)
       )
@@ -10324,7 +10336,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 15.0)
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
       )
@@ -10345,7 +10357,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -10362,7 +10374,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h > -30.0)
@@ -10386,7 +10398,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_1h > -0.30)
+        | cmf_20_1h_gt_neg_030
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
       # 1h & 4h & 1d down move, 1h still not low enough, 4h still high, 1d downtrend
@@ -10414,7 +10426,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.5)
-        | (protection_cmf_20_1h > -0.3)
+        | cmf_20_1h_gt_neg_03
         | (protection_cmf_20_4h > -0.3)
         | (protection_aroonu_14_1h < 50.0)
       )
@@ -10479,14 +10491,14 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h down move, 1h & 4h downtrend, 1h still not low enough
       & (
         (protection_rsi_3_4h > 3.0)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.25)
         | (protection_aroonu_14_1h < 30.0)
       )
       # 4h down move, 1h & 4h downtrend, 1h & 4h & 1d downtrend
       & (
         (protection_rsi_3_4h > 3.0)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.35)
         | (protection_cci_20_change_pct_4h > 0.0)
         | (protection_roc_9_1h > -20.0)
@@ -10503,7 +10515,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h down move, 1h & 4h downtrend, 15m high
       & (
         (protection_rsi_3_4h > 3.0)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_cmf_20_4h > -0.30)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
@@ -10536,7 +10548,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
@@ -10544,7 +10556,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h down move, 1h & 4h downtrend, 1h still not low enough, 4h high
       & (
         (protection_rsi_3_4h > 5.0)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
@@ -10553,7 +10565,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 10.0)
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
@@ -10696,7 +10708,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1d > 10.0)
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.40)
+        | cmf_20_1h_gt_neg_040
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -10909,7 +10921,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 10.0)
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
-        | (protection_cmf_20_1h > -0.2)
+        | cmf_20_1h_gt_neg_02
         | (protection_aroonu_14_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
       )
@@ -11228,7 +11240,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 50.0)
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_1h > -0.25)
+        | cmf_20_1h_gt_neg_025
         | (protection_aroonu_14_4h < 50.0)
       )
       # 1d top wick, 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high
@@ -11297,7 +11309,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_aroonu_14_1h < 70.0)
       )
       # pump, drop in last 6 days, 1h & 4h down move, 1h & 4h still not low enough, 4h downtrend, 4h & 1d downtrend
@@ -11391,7 +11403,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_24_4h * 0.25))
         | (protection_rsi_3_1d > 15.0)
-        | (protection_cmf_20_1h > -0.20)
+        | cmf_20_1h_gt_neg_020
         | (protection_cmf_20_4h > -0.20)
         | (protection_roc_9_15m > -15.0)
         | (protection_roc_9_4h > -20.0)
@@ -11412,7 +11424,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_1h_gt_30
         | rsi_14_15m_lt_30
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.40)
         | (protection_cmf_20_1d > -0.50)
         | (protection_aroonu_14_1h < 30.0)
@@ -11436,7 +11448,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_6_1d * 0.15))
         | (protection_rsi_3_1d > 20.0)
-        | (protection_cmf_20_1h > -0.10)
+        | cmf_20_1h_gt_neg_010
         | (protection_cmf_20_4h > -0.40)
         | (protection_cmf_20_1d > -0.50)
         | (protection_aroonu_14_1d < 50.0)
@@ -11479,7 +11491,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 15.0)
         | (protection_rsi_14_1h < 15.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_1h > -0.0)
+        | cmf_20_1h_gt_neg_0
         | (protection_cmf_20_4h > -0.10)
         | (protection_cmf_20_1d > -0.40)
         | (protection_cci_20_1h < -150.0)


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Hoist long protection CMF 1h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
