### PR TITLE
Reduce X7 long protection CMF 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4572,6 +4572,20 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_roc_9_1h = df["ROC_9_1h"].to_numpy(copy=False)
     protection_cmf_20_1h = df["CMF_20_1h"].to_numpy(copy=False)
     protection_cmf_20_4h = df["CMF_20_4h"].to_numpy(copy=False)
+    # Reduce long protection CMF 4h comparison masks
+    cmf_20_4h_gt_neg_0 = protection_cmf_20_4h > -0.0
+    cmf_20_4h_gt_neg_010 = protection_cmf_20_4h > -0.10
+    cmf_20_4h_gt_neg_01 = protection_cmf_20_4h > -0.1
+    cmf_20_4h_gt_neg_015 = protection_cmf_20_4h > -0.15
+    cmf_20_4h_gt_neg_020 = protection_cmf_20_4h > -0.20
+    cmf_20_4h_gt_neg_02 = protection_cmf_20_4h > -0.2
+    cmf_20_4h_gt_neg_025 = protection_cmf_20_4h > -0.25
+    cmf_20_4h_gt_neg_030 = protection_cmf_20_4h > -0.30
+    cmf_20_4h_gt_neg_03 = protection_cmf_20_4h > -0.3
+    cmf_20_4h_gt_neg_035 = protection_cmf_20_4h > -0.35
+    cmf_20_4h_gt_neg_040 = protection_cmf_20_4h > -0.40
+    cmf_20_4h_gt_neg_04 = protection_cmf_20_4h > -0.4
+    cmf_20_4h_gt_neg_05 = protection_cmf_20_4h > -0.5
     protection_aroonu_14_1d = df["AROONU_14_1d"].to_numpy(copy=False)
     protection_mfi_14_1d = df["MFI_14_1d"].to_numpy(copy=False)
     protection_roc_2_1d = df["ROC_2_1d"].to_numpy(copy=False)
@@ -4927,7 +4941,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
       )
       # 15m & 1h & 4h & 1d down move, 1h still high, 1h & 4h still not low enough
@@ -4945,7 +4959,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 30.0)
       )
@@ -4982,7 +4996,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.15)
+        | cmf_20_4h_gt_neg_015
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 20.0)
         | (protection_roc_9_4h > -20.0)
@@ -4994,7 +5008,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_roc_9_15m > -15.0)
@@ -5025,7 +5039,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 10.0)
       )
@@ -5046,7 +5060,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m still high
@@ -5074,7 +5088,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
@@ -5085,7 +5099,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 50.0)
       )
@@ -5137,7 +5151,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_cmf_20_4h > -0.15)
+        | cmf_20_4h_gt_neg_015
       )
       # 15m & 1h & 4h down move, 1h & 4h stil not low enough, 15m & 1h & 4h downtrend, 1h still high
       & (
@@ -5148,7 +5162,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_1h < 50.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 4h still not low enough, 15m & 4h still not low
@@ -5159,7 +5173,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
@@ -5242,7 +5256,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 1h high, 4h downtrend
@@ -5401,7 +5415,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.15)
+        | cmf_20_4h_gt_neg_015
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -5413,7 +5427,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h still high
       & (
@@ -5422,7 +5436,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.15)
+        | cmf_20_4h_gt_neg_015
         | (protection_aroonu_14_4h < 40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m still high
@@ -5440,7 +5454,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 15.0)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_1h < 50.0)
         | (protection_roc_9_1h > -15.0)
       )
@@ -5460,7 +5474,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
       )
@@ -5480,7 +5494,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_4h < 70.0)
       )
       # 15m & 1h & 4h down move, 4h still not low enough, 1h still high, 4h high
@@ -5582,7 +5596,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h high, 1d overbought
@@ -5612,7 +5626,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_15m < 25.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
@@ -5624,7 +5638,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h downtrend, 1d overbought
@@ -5692,7 +5706,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 30.0)
       )
@@ -5739,7 +5753,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
@@ -5786,7 +5800,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_1h < 25.0)
         | (protection_aroonu_14_4h < 25.0)
         | (protection_roc_9_1h > -10.0)
@@ -5913,7 +5927,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h still high, 1d downtrend
@@ -5971,7 +5985,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
@@ -5996,7 +6010,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h still high
@@ -6007,7 +6021,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
@@ -6053,7 +6067,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_4h < 80.0)
         | (protection_roc_9_1h < 10.0)
       )
@@ -6063,7 +6077,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_1h > -0.0)
-        | (protection_cmf_20_4h > -0.4)
+        | cmf_20_4h_gt_neg_04
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
       )
@@ -6112,7 +6126,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.0)
-        | (protection_cmf_20_4h > -0.0)
+        | cmf_20_4h_gt_neg_0
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
       )
@@ -6220,7 +6234,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_4h < 40.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -6232,7 +6246,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 50.0)
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_1h < 20.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m downtrend, 15m & 4h high, 1d downtrend
@@ -6256,7 +6270,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.0)
+        | cmf_20_4h_gt_neg_0
         | (protection_aroonu_14_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h high, 1h downtrend
@@ -6354,7 +6368,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.40)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 70.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 1h still high, 4h high
@@ -6414,7 +6428,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high 4h & 1d downtrend
       & (
@@ -6652,7 +6666,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 35.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_cci_20_1h < -200.0)
         | (protection_cci_20_4h < -200.0)
         | (protection_roc_9_1d > -25.0)
@@ -6689,7 +6703,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -6881,7 +6895,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 10.0)
         | (protection_rsi_14_4h < 10.0)
         | (protection_cmf_20_15m > -0.10)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
         | (protection_roc_9_1h > -15.0)
@@ -7120,7 +7134,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 70.0)
         | (protection_cci_20_1h < -200.0)
         | (protection_cci_20_4h < -200.0)
@@ -7194,7 +7208,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_roc_9_1d < 50.0)
       )
       # 15m & 1h & 4h down move, 1h still not low enough, 4h still high, 1h high, 1h & 4h downtrend, 1d overbought
@@ -7233,7 +7247,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.15)
+        | cmf_20_4h_gt_neg_015
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 15m & 4h high
@@ -7323,7 +7337,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_roc_9_4h > -40.0)
       )
@@ -7428,7 +7442,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 40.0)
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -7521,7 +7535,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -7552,7 +7566,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_cmf_20_4h > -0.40)
+        | cmf_20_4h_gt_neg_040
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -7564,7 +7578,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_4h > -0.40)
+        | cmf_20_4h_gt_neg_040
         | (protection_aroonu_14_15m < 60.0)
         | (protection_roc_9_4h > -20.0)
         | (protection_roc_9_1d > -50.0)
@@ -7722,7 +7736,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 55.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
       )
@@ -8114,7 +8128,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 30.0)
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.40)
-        | (protection_cmf_20_4h > -0.40)
+        | cmf_20_4h_gt_neg_040
         | (protection_roc_9_4h > -40.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h still high, 1d overbought
@@ -8278,7 +8292,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_1d > 35.0)
-        | (protection_cmf_20_4h > -0.1)
+        | cmf_20_4h_gt_neg_01
         | (protection_cmf_20_1d > -0.1)
         | (protection_aroonu_14_1h < 75.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -8293,7 +8307,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 80.0)
       )
@@ -8331,7 +8345,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.15)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
@@ -8417,7 +8431,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_roc_9_4h > -30.0)
@@ -8506,7 +8520,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_1d < 30.0)
       )
@@ -8579,7 +8593,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_4h < 30.0)
@@ -8635,7 +8649,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1h > 60.0)
         | (protection_rsi_14_15m < 50.0)
         | rsi_14_1h_lt_50
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -8689,7 +8703,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 15.0)
         | rsi_14_15m_lt_40
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
       )
@@ -8720,7 +8734,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 40.0)
@@ -8791,7 +8805,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_mfi_14_1h < 40.0)
         | (protection_mfi_14_4h < 50.0)
         | (protection_cmf_20_1h > -0.0)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
@@ -8873,7 +8887,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_15m > -0.30)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
       )
@@ -8940,7 +8954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
         | (protection_roc_9_4h > -20.0)
@@ -8980,7 +8994,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_aroonu_14_1d < 90.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still not low enough, 4h high & overbought
@@ -9074,7 +9088,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
       )
@@ -9292,7 +9306,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 55.0)
         | (protection_rsi_3_1d > 55.0)
         | (protection_cmf_20_15m > -0.25)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
       )
@@ -9315,7 +9329,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -9341,7 +9355,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
       )
@@ -9404,7 +9418,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -9718,7 +9732,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
@@ -9780,7 +9794,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.25)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -9862,7 +9876,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 45.0)
         | (protection_cmf_20_15m > -0.40)
         | (protection_cmf_20_1h > -0.40)
-        | (protection_cmf_20_4h > -0.40)
+        | cmf_20_4h_gt_neg_040
         | (protection_aroonu_14_4h < 75.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 4h high & overbought
@@ -9951,7 +9965,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_cmf_20_4h > -0.15)
+        | cmf_20_4h_gt_neg_015
         | (protection_aroonu_14_4h < 50.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -9977,7 +9991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_15m < 20.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_roc_9_4h < 10.0)
@@ -10083,7 +10097,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
       )
@@ -10095,7 +10109,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_cmf_20_1d > -0.30)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
@@ -10166,7 +10180,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_cmf_20_4h > -0.35)
+        | cmf_20_4h_gt_neg_035
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -10223,7 +10237,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 4h down move, 4h still not low enough
       & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 3.0) | (protection_aroonu_14_4h < 20.0))
       # 1h & 4h down move, 15m still not low enough, 4h downtrend
-      & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 5.0) | rsi_14_15m_lt_30 | (protection_cmf_20_4h > -0.30))
+      & ((protection_rsi_3_1h > 3.0) | (protection_rsi_3_4h > 5.0) | rsi_14_15m_lt_30 | cmf_20_4h_gt_neg_030)
       # 1h & 4h down move, 1h downtrend, 4h still high
       & (
         (protection_rsi_3_1h > 3.0)
@@ -10252,7 +10266,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 10.0)
         | (protection_cmf_20_1h > -0.5)
-        | (protection_cmf_20_4h > -0.5)
+        | cmf_20_4h_gt_neg_05
       )
       # 1h & 4h down move, 15m & 1h & 4h downtrend, 1h & 4h still high
       & (
@@ -10260,7 +10274,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 50.0)
       )
@@ -10306,7 +10320,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_15m > -0.0)
         | (protection_cmf_20_1h > -0.30)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_aroonu_14_1h < 60.0)
       )
       # 1h & 4h down move, 1h & 4h downtrend, 1h high
@@ -10314,7 +10328,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 20.0)
         | (protection_cmf_20_1h > -0.40)
-        | (protection_cmf_20_4h > -0.40)
+        | cmf_20_4h_gt_neg_040
         | (protection_aroonu_14_1h < 60.0)
       )
       # 1h & 4h & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 1h still not low enough
@@ -10325,7 +10339,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
       )
       # 1h & 4h down move, 1h & 4h still not low enough, 15m high, 1h & 4h downtrend
@@ -10346,7 +10360,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_roc_9_1h > -10.0)
@@ -10363,7 +10377,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 30.0)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_4h > -30.0)
       )
@@ -10415,7 +10429,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_cmf_20_15m > -0.5)
         | (protection_cmf_20_1h > -0.3)
-        | (protection_cmf_20_4h > -0.3)
+        | cmf_20_4h_gt_neg_03
         | (protection_aroonu_14_1h < 50.0)
       )
       # 1h & 4h down move, 1h & 4h high, 4h overbought
@@ -10480,14 +10494,14 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 3.0)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_aroonu_14_1h < 30.0)
       )
       # 4h down move, 1h & 4h downtrend, 1h & 4h & 1d downtrend
       & (
         (protection_rsi_3_4h > 3.0)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.35)
+        | cmf_20_4h_gt_neg_035
         | (protection_cci_20_change_pct_4h > 0.0)
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -25.0)
@@ -10504,7 +10518,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 3.0)
         | (protection_cmf_20_1h > -0.25)
-        | (protection_cmf_20_4h > -0.30)
+        | cmf_20_4h_gt_neg_030
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
       # 4h down move, 15m & 1h high
@@ -10537,7 +10551,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
       )
@@ -10545,7 +10559,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_4h > 5.0)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_4h < 40.0)
       )
@@ -10554,7 +10568,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_4h > 10.0)
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
         | (protection_roc_9_4h > -30.0)
@@ -10604,7 +10618,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_cmf_20_4h > -0.25)
+        | cmf_20_4h_gt_neg_025
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_4h > -60.0)
       )
@@ -10697,7 +10711,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.40)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
         | (protection_roc_9_1d > -40.0)
@@ -10707,7 +10721,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_14_15m < 50.0)
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
-        | (protection_cmf_20_4h > -0.2)
+        | cmf_20_4h_gt_neg_02
         | (protection_roc_9_4h < 250.0)
       )
       # 4h red, 15m & 1h & 4h down move, 1h & 4h still high, 4h high
@@ -11308,7 +11322,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_4h_gt_60
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_roc_9_4h > -15.0)
         | (protection_roc_9_1d > -25.0)
       )
@@ -11392,7 +11406,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_24_4h * 0.25))
         | (protection_rsi_3_1d > 15.0)
         | (protection_cmf_20_1h > -0.20)
-        | (protection_cmf_20_4h > -0.20)
+        | cmf_20_4h_gt_neg_020
         | (protection_roc_9_15m > -15.0)
         | (protection_roc_9_4h > -20.0)
       )
@@ -11413,7 +11427,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | (protection_cmf_20_15m > -0.10)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.40)
+        | cmf_20_4h_gt_neg_040
         | (protection_cmf_20_1d > -0.50)
         | (protection_aroonu_14_1h < 30.0)
       )
@@ -11437,7 +11451,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_6_1d * 0.15))
         | (protection_rsi_3_1d > 20.0)
         | (protection_cmf_20_1h > -0.10)
-        | (protection_cmf_20_4h > -0.40)
+        | cmf_20_4h_gt_neg_040
         | (protection_cmf_20_1d > -0.50)
         | (protection_aroonu_14_1d < 50.0)
         | (protection_roc_9_4h > -30.0)
@@ -11480,7 +11494,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 15.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.0)
-        | (protection_cmf_20_4h > -0.10)
+        | cmf_20_4h_gt_neg_010
         | (protection_cmf_20_1d > -0.40)
         | (protection_cci_20_1h < -150.0)
         | (protection_cci_20_4h < -200.0)


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Reduce long protection CMF 4h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
