### PR TITLE
Reuse X7 long protection ROC 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4570,6 +4570,22 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_cmf_20_1d = df["CMF_20_1d"].to_numpy(copy=False)
     protection_roc_9_15m = df["ROC_9_15m"].to_numpy(copy=False)
     protection_roc_9_1h = df["ROC_9_1h"].to_numpy(copy=False)
+    # Reuse long protection ROC 1h comparison masks
+    roc_9_1h_lt_10 = protection_roc_9_1h < 10.0
+    roc_9_1h_lt_15 = protection_roc_9_1h < 15.0
+    roc_9_1h_lt_20 = protection_roc_9_1h < 20.0
+    roc_9_1h_lt_30 = protection_roc_9_1h < 30.0
+    roc_9_1h_lt_40 = protection_roc_9_1h < 40.0
+    roc_9_1h_lt_50 = protection_roc_9_1h < 50.0
+    roc_9_1h_lt_70 = protection_roc_9_1h < 70.0
+    roc_9_1h_lt_80 = protection_roc_9_1h < 80.0
+    roc_9_1h_gt_neg_10 = protection_roc_9_1h > -10.0
+    roc_9_1h_gt_neg_15 = protection_roc_9_1h > -15.0
+    roc_9_1h_gt_neg_20 = protection_roc_9_1h > -20.0
+    roc_9_1h_gt_neg_25 = protection_roc_9_1h > -25.0
+    roc_9_1h_gt_neg_30 = protection_roc_9_1h > -30.0
+    roc_9_1h_gt_neg_50 = protection_roc_9_1h > -50.0
+    roc_9_1h_gt_neg_60 = protection_roc_9_1h > -60.0
     protection_cmf_20_1h = df["CMF_20_1h"].to_numpy(copy=False)
     protection_cmf_20_4h = df["CMF_20_4h"].to_numpy(copy=False)
     protection_aroonu_14_1d = df["AROONU_14_1d"].to_numpy(copy=False)
@@ -4841,7 +4857,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_roc_9_15m > -10.0)
-        | (protection_roc_9_1h > -15.0)
+        | roc_9_1h_gt_neg_15
       )
       # 15m & 1h & 4h down move, 15m downtrend, 1h still high, 4h still not low enough
       & (
@@ -4998,7 +5014,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_roc_9_15m > -15.0)
-        | (protection_roc_9_1h > -15.0)
+        | roc_9_1h_gt_neg_15
       )
       # 15m & 1h & 4h down move, 15m & 1h downtrend, 15m & 4h still not low enough
       & (
@@ -5037,7 +5053,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_1d > 30.0)
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m still not low enough
       & (
@@ -5347,7 +5363,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 75.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 1h & 4h still high, 15m downtrend, 1h still high
@@ -5379,7 +5395,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 4h overbought
       & (
@@ -5402,7 +5418,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.15)
         | (protection_cmf_20_1h > -0.15)
         | (protection_cmf_20_4h > -0.15)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h > -20.0)
       )
       # 15m & 1h & 4h down move, 4h still high, 15m & 1h & 4h downtrend
@@ -5442,7 +5458,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.30)
         | (protection_cmf_20_4h > -0.30)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_roc_9_1h > -15.0)
+        | roc_9_1h_gt_neg_15
       )
       # 15m & 1h & 4h down move, 1h & 4h still not low enough, 15m still high
       & (
@@ -5471,7 +5487,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 20.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h high
       & (
@@ -5527,7 +5543,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_roc_9_15m > -10.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1d overbought
       & (
@@ -5789,7 +5805,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_1h < 25.0)
         | (protection_aroonu_14_4h < 25.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 1h & 1d down move, 1h still not low enough, 4h high & overbought
@@ -5801,7 +5817,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h & 1d down move, 15m still not low enough, 1h & 4h still high, 1h high, 4h overbought
@@ -6041,7 +6057,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high, 1h overbought
@@ -6055,7 +6071,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
       )
       # 15m & 1h & 4h down move, 1h & 4h downtrend, 15m still high, 1h high
       & (
@@ -6133,7 +6149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 4h & 1d down move, 15m high, 15m & 4h still high
@@ -6173,7 +6189,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 30.0)
+        | roc_9_1h_lt_30
         | (protection_roc_9_4h < 80.0)
       )
       # 15m down move, 15m & 1h & 4h still high, 15m still high, 4h high, 4h overbought
@@ -6197,7 +6213,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h > -35.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h high, 15m still not low enough
@@ -6268,7 +6284,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 45.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h > -30.0)
+        | roc_9_1h_gt_neg_30
       )
       # 15m & 1h & 4h down move, 4h high, 1d overbought
       & (
@@ -6332,7 +6348,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_4h < 60.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h high
       & (
@@ -6403,7 +6419,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 1h & 4h downtrend
@@ -6437,7 +6453,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h > -15.0)
       )
       # 15m & 1h & 4h down move, 1h still high, 4h high, 4h & 1d overbought
@@ -6553,7 +6569,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h high & overbought, 1d overbought
@@ -6601,7 +6617,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1d downtrend, 1h & 4h high, 1d overbought
@@ -6667,7 +6683,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_4h > -10.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h still high, 4h high
@@ -6741,7 +6757,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h overbought
       & (
@@ -6864,7 +6880,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 90.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 15.0)
+        | roc_9_1h_lt_15
       )
       # 15m & 4h down move, 15m high, 4h downtrend
       & (
@@ -6884,7 +6900,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.20)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 20.0)
-        | (protection_roc_9_1h > -15.0)
+        | roc_9_1h_gt_neg_15
         | (protection_roc_9_4h > -15.0)
       )
       # 15m & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m & 1d downtrend
@@ -6908,7 +6924,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
       )
       # 15m & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h downtrend
       & (
@@ -6935,10 +6951,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 15m & 4h down move, 1h high & overbought
       & (
-        (rsi_3_15m_gt_15)
-        | (protection_rsi_3_4h > 45.0)
-        | (protection_stochrsik_14_14_3_3_1h < 90.0)
-        | (protection_roc_9_1h < 10.0)
+        (rsi_3_15m_gt_15) | (protection_rsi_3_4h > 45.0) | (protection_stochrsik_14_14_3_3_1h < 90.0) | roc_9_1h_lt_10
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h high, 1h & 4h overbought
       & (
@@ -6948,7 +6961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h overbought
@@ -7020,7 +7033,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_roc_9_1h < 40.0)
+        | roc_9_1h_lt_40
         | (protection_roc_9_4h > -50.0)
         | (protection_roc_9_1d > -50.0)
       )
@@ -7031,7 +7044,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 70.0)
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
-        | (protection_roc_9_1h < 40.0)
+        | roc_9_1h_lt_40
         | (protection_roc_9_1d < 100.0)
       )
       # 15m down move, 15m still not low enough, 1h & 4h high, 4h & 1d overbought
@@ -7055,16 +7068,11 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 20.0)
       )
       # 15m down move, 15m high, 1h & 4h overbought
-      & (
-        (rsi_3_15m_gt_15)
-        | (protection_aroonu_14_15m < 75.0)
-        | (protection_roc_9_1h < 50.0)
-        | (protection_roc_9_4h < 80.0)
-      )
+      & ((rsi_3_15m_gt_15) | (protection_aroonu_14_15m < 75.0) | roc_9_1h_lt_50 | (protection_roc_9_4h < 80.0))
       # 15m & 1h & 4h down move, 1h still high, 15m still not low enough, 4h downtrend
       & (
         (rsi_3_15m_gt_20)
@@ -7205,7 +7213,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h > -10.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -7298,7 +7306,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_aroonu_14_4h < 40.0)
-        | (protection_roc_9_1h > -15.0)
+        | roc_9_1h_gt_neg_15
         | (protection_roc_9_4h > -30.0)
         | (protection_roc_9_1d < 40.0)
       )
@@ -7511,7 +7519,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 30.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 4h downtrend, 15m & 1h still high, 4h downtrend
@@ -7700,7 +7708,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_1d < 200.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 1h high & overbought
@@ -7713,7 +7721,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 85.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 15m & 1h high
       & (
@@ -7757,7 +7765,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_4h < 70.0)
-        | (protection_roc_9_1h < 40.0)
+        | roc_9_1h_lt_40
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m & 1h & 4h high
@@ -7793,7 +7801,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_1h < 15.0)
+        | roc_9_1h_lt_15
       )
       # 15m & 1h down move, 15m still high, 1h high & overbought
       & (
@@ -7802,7 +7810,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_50
         | (protection_aroonu_14_1h < 70.0)
-        | (protection_roc_9_1h < 80.0)
+        | roc_9_1h_lt_80
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high & overbought
       & (
@@ -7976,7 +7984,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_1h < 50.0)
+        | roc_9_1h_lt_50
         | (protection_roc_9_4h < 50.0)
       )
       # 15m down move, 15m still high, 1h & 4h high, 4h overbought
@@ -7998,7 +8006,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 50.0)
+        | roc_9_1h_lt_50
         | (protection_roc_9_4h < 50.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 4h overbought
@@ -8319,7 +8327,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 90.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 90.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 60.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h & 4h downtrend
@@ -8568,7 +8576,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 100.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_4h < 10.0)
       )
       # 15m & 1h down move, 15m still not low enough, 1h & 4h still high, 1h & 4h downtrend, 4h high & overbought
@@ -8602,7 +8610,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_1d > -30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h high, 4h downtrend
@@ -8660,7 +8668,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 50.0)
         | (protection_roc_9_1d < 250.0)
       )
@@ -8732,7 +8740,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 1d overbought
@@ -8756,7 +8764,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 50.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 4h high, 4h & 1d overbought
       & (
@@ -8861,7 +8869,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 80.0)
         | (protection_aroonu_14_1h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 90.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_4h < 20.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 15m & 4h downtrend, 1h & 4h still not low enough
@@ -8888,7 +8896,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 10.0)
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h > -30.0)
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still not low enough, 1h downtrend
@@ -8903,7 +8911,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 30.0)
-        | (protection_roc_9_1h > -15.0)
+        | roc_9_1h_gt_neg_15
       )
       # 15m & 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 15m & 1h & 4h downtrend
       & (
@@ -8914,7 +8922,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.35)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h > -15.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 1h & 4h still not low enough, 15m still high, 1h & 4h & 1d downtrend
@@ -8927,7 +8935,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 25.0)
         | (protection_rsi_14_4h < 25.0)
         | (protection_aroonu_14_15m < 40.0)
-        | (protection_roc_9_1h > -15.0)
+        | roc_9_1h_gt_neg_15
         | (protection_roc_9_4h > -15.0)
         | (protection_roc_9_1d > -15.0)
       )
@@ -9282,7 +9290,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 60.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_1d < 80.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m & 4h downtrend, 15m & 1h high
@@ -9365,7 +9373,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 60.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h < 50.0)
+        | roc_9_1h_lt_50
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h down move, 15m still high, 1h & 4h high, 4h overbought
@@ -9428,7 +9436,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 75.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 40.0)
+        | roc_9_1h_lt_40
         | (protection_roc_9_4h < 40.0)
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m high
@@ -9671,7 +9679,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 80.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h still high, 15m still high, 4h overbought
       & (
@@ -9742,7 +9750,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_15m < 50.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
       )
       # 15m & 4h down move, 15m & 1h high, 4h downtrend
       & (
@@ -9807,7 +9815,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 100.0)
         | (protection_stochrsik_14_14_3_3_1h < 60.0)
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
         | (protection_roc_9_4h < 20.0)
       )
       # 15m down move, 15m & 1h still high, 4h high, 15m downtrend, 15m high, 1h & 4h overbought
@@ -9818,7 +9826,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_cmf_20_15m > -0.10)
         | (protection_aroonu_14_15m < 70.0)
-        | (protection_roc_9_1h < 15.0)
+        | roc_9_1h_lt_15
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 4h high & overbought
@@ -9853,7 +9861,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1d > -0.40)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
-        | (protection_roc_9_1h > -25.0)
+        | roc_9_1h_gt_neg_25
       )
       # 15m & 1h & 4h down move, 15m & 1h & 4h downtrend, 4h high
       & (
@@ -9907,7 +9915,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_15m < 60.0)
-        | (protection_roc_9_1h > -30.0)
+        | roc_9_1h_gt_neg_30
         | (protection_roc_9_4h > -40.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m & 1h high
@@ -9993,7 +10001,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 85.0)
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
       )
       # 15m &4h down move, 15m & 1h & 4h still high, 15m still high, 1h high, 15m & 1h overbought
       & (
@@ -10005,7 +10013,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_15m < 40.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_roc_9_15m < 10.0)
-        | (protection_roc_9_1h < 40.0)
+        | roc_9_1h_lt_40
       )
       # 15m & 4h down move, 15m & 1h & 4h still high, 15m & 1h high, 1h overbought
       & (
@@ -10016,7 +10024,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
-        | (protection_roc_9_1h < 20.0)
+        | roc_9_1h_lt_20
       )
       # 15m & 1d down move, 15m & 1h & 4h stil high, 4h high, 15m & 1h & 4h still high
       & (
@@ -10048,7 +10056,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 70.0)
+        | roc_9_1h_lt_70
         | (protection_roc_9_4h < 80.0)
       )
       # 15m down move, 15m & 1h & 4h still high, 15m & 1h & 4h high
@@ -10108,7 +10116,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_4h < 80.0)
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
-        | (protection_roc_9_1h < 30.0)
+        | roc_9_1h_lt_30
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h & 4h & 1d down move, 15m still not low enough, 1h & 4h still high, 15m still high, 1d overbought
@@ -10144,7 +10152,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 70.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 90.0)
-        | (protection_roc_9_1h < 30.0)
+        | roc_9_1h_lt_30
         | (protection_roc_9_4h < 80.0)
       )
       # 15m & 1h down move, 15m still high, 1h high, 15m overbought
@@ -10190,7 +10198,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 80.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 40.0)
+        | roc_9_1h_lt_40
         | (protection_roc_9_4h < 100.0)
       )
       # 15m & 1h & 4h down move, 15m still not low enough, 1h & 4h still high, 15m downtrend, 15m & 4h high
@@ -10215,7 +10223,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_14_4h < 80.0)
         | (protection_aroonu_14_1h < 70.0)
         | (protection_aroonu_14_4h < 100.0)
-        | (protection_roc_9_1h < 30.0)
+        | roc_9_1h_lt_30
         | (protection_roc_9_4h < 70.0)
       )
       # 1h & 4h down move, 15m high
@@ -10288,7 +10296,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_4h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_15m > -10.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
       )
       # 1h & 4h down move, 15m & 1h still not low enough, 4h high, 1d overbought
       & (
@@ -10335,7 +10343,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_aroonu_14_1h < 20.0)
         | (protection_aroonu_14_4h < 20.0)
         | (protection_stochrsik_14_14_3_3_15m < 80.0)
-        | (protection_roc_9_1h > -30.0)
+        | roc_9_1h_gt_neg_30
         | (protection_roc_9_4h > -30.0)
       )
       # 1h & 4h down move, 15m & 1h still not low enough, 4h still high, 1h & 4h downtrend
@@ -10349,7 +10357,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_4h > -0.10)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
       )
       # 1h & 4h down move, 1h still not low enough, 4h downtrend
       & (
@@ -10405,7 +10413,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h > -20.0)
         | (protection_roc_9_1d < 80.0)
       )
@@ -10446,7 +10454,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_1h < 25.0)
         | (protection_aroonu_14_4h < 50.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h < 20.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -10458,7 +10466,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_4h < 25.0)
       )
       # 1h down move, 1h still high, 4h overbought
@@ -10489,7 +10497,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.35)
         | (protection_cci_20_change_pct_4h > 0.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h > -25.0)
         | (protection_roc_9_1d > -25.0)
       )
@@ -10647,7 +10655,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_1d > -30.0)
       )
       # 1d down move, 15m & 1h & 4h still not low enough, 15m still not low enough, 1h high
@@ -10671,7 +10679,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1d > 5.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
-        | (protection_roc_9_1h > -60.0)
+        | roc_9_1h_gt_neg_60
         | (protection_roc_9_4h > -60.0)
       )
       # 1d down move, 1h still high, 4h high
@@ -10680,14 +10688,14 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1d > 5.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h > -10.0)
       )
       # 1d down move, 1h high & overbought, 4h & 1d downtrend
       & (
         (protection_rsi_3_1d > 10.0)
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
-        | (protection_roc_9_1h < 10.0)
+        | roc_9_1h_lt_10
         | (protection_roc_9_4h > -40.0)
         | (protection_roc_9_1d > -40.0)
       )
@@ -10899,7 +10907,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
-        | (protection_roc_9_1h > -10.0)
+        | roc_9_1h_gt_neg_10
         | (protection_roc_9_4h > -10.0)
         | (protection_roc_9_1d < 100.0)
       )
@@ -10933,7 +10941,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 30.0)
         | (protection_aroonu_14_1h < 30.0)
         | (protection_aroonu_14_4h < 30.0)
-        | (protection_roc_9_1h > -25.0)
+        | roc_9_1h_gt_neg_25
         | (protection_roc_9_4h > -25.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -11335,7 +11343,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_12_1h * 0.35))
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 5.0)
-        | (protection_roc_9_1h > -50.0)
+        | roc_9_1h_gt_neg_50
         | (protection_roc_9_4h > -50.0)
       )
       # drop in last 4 days, 15m & 1h & 4h down move, 15m still not low enough, 1h still high, 4h overbought
@@ -11384,7 +11392,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_4h > 25.0)
         | (protection_rsi_3_1d > 25.0)
         | (protection_aroonu_14_1h < 50.0)
-        | (protection_roc_9_1h > -20.0)
+        | roc_9_1h_gt_neg_20
         | (protection_roc_9_4h > -35.0)
       )
       # drop in last 4 days, 1d down move, 1h & 4h downtrend, 15m & 4h downtrend


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for long protection ROC 1h comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
