### PR TITLE
Hoist X7 long protection RSI-3 1d masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4551,6 +4551,21 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_rsi_3_1h = df["RSI_3_1h"].to_numpy(copy=False)
     protection_rsi_3_4h = df["RSI_3_4h"].to_numpy(copy=False)
     protection_rsi_3_1d = df["RSI_3_1d"].to_numpy(copy=False)
+    # Hoist long protection RSI-3 1d comparison masks
+    rsi_3_1d_gt_3 = protection_rsi_3_1d > 3.0
+    rsi_3_1d_gt_5 = protection_rsi_3_1d > 5.0
+    rsi_3_1d_gt_10 = protection_rsi_3_1d > 10.0
+    rsi_3_1d_gt_15 = protection_rsi_3_1d > 15.0
+    rsi_3_1d_gt_20 = protection_rsi_3_1d > 20.0
+    rsi_3_1d_gt_25 = protection_rsi_3_1d > 25.0
+    rsi_3_1d_gt_30 = protection_rsi_3_1d > 30.0
+    rsi_3_1d_gt_35 = protection_rsi_3_1d > 35.0
+    rsi_3_1d_gt_40 = protection_rsi_3_1d > 40.0
+    rsi_3_1d_gt_45 = protection_rsi_3_1d > 45.0
+    rsi_3_1d_gt_50 = protection_rsi_3_1d > 50.0
+    rsi_3_1d_gt_55 = protection_rsi_3_1d > 55.0
+    rsi_3_1d_gt_60 = protection_rsi_3_1d > 60.0
+    rsi_3_1d_gt_65 = protection_rsi_3_1d > 65.0
     protection_rsi_14_1h = df["RSI_14_1h"].to_numpy(copy=False)
     protection_rsi_14_4h = df["RSI_14_4h"].to_numpy(copy=False)
     protection_rsi_14_1d = df["RSI_14_1d"].to_numpy(copy=False)
@@ -4641,7 +4656,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_rsi_3_1d > 20.0)
+        | rsi_3_1d_gt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 30.0)
@@ -4652,7 +4667,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 1.0)
         | (protection_rsi_3_4h > 10.0)
-        | (protection_rsi_3_1d > 35.0)
+        | rsi_3_1d_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -4728,7 +4743,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3 > 5.0)
         | (protection_rsi_3_4h > 10.0)
-        | (protection_rsi_3_1d > 15.0)
+        | rsi_3_1d_gt_15
         | (protection_aroonu_14_15m < 60.0)
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
       )
@@ -4787,7 +4802,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3 > 10.0)
         | rsi_3_15m_gt_25
         | (protection_rsi_3_1h > 65.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_1d > -0.20)
@@ -4935,7 +4950,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 3.0)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | (protection_aroonu_14_1h < 50.0)
         | (protection_cci_20_1h < -250.0)
         | (protection_cci_20_4h < -250.0)
@@ -5034,7 +5049,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_cmf_20_15m > -0.20)
         | (protection_stochrsik_14_14_3_3_15m < 10.0)
         | (protection_roc_9_1h > -10.0)
@@ -5063,7 +5078,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 40.0)
+        | rsi_3_1d_gt_40
         | (protection_cmf_20_15m > -0.30)
         | (protection_roc_9_1d < 100.0)
       )
@@ -5112,7 +5127,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_3_1d > 55.0)
+        | rsi_3_1d_gt_55
         | (protection_cmf_20_15m > -0.30)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_1h < 20.0)
@@ -5213,7 +5228,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 5.0)
+        | rsi_3_1d_gt_5
         | (protection_cmf_20_15m > -0.40)
       )
       # 15m & 1h down move, 15m still not low enough, 1h still high, 4h high, 15m still high, 4h overbought
@@ -5654,7 +5669,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_roc_9_1d < 50.0)
@@ -5772,7 +5787,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -5796,7 +5811,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
         | (protection_aroonu_14_1h < 40.0)
@@ -5808,7 +5823,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -5862,7 +5877,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_3_1d > 15.0)
+        | rsi_3_1d_gt_15
         | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 35.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -5873,7 +5888,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_3_1d > 35.0)
+        | rsi_3_1d_gt_35
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6140,7 +6155,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_3_1d > 20.0)
+        | rsi_3_1d_gt_20
         | (protection_aroonu_14_15m < 70.0)
         | (protection_stochrsik_14_14_3_3_15m < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -6149,7 +6164,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_10)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_rsi_3_1d > 20.0)
+        | rsi_3_1d_gt_20
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
@@ -6216,7 +6231,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_cmf_20_1h > -0.10)
@@ -6229,7 +6244,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
         | (protection_cmf_20_4h > -0.30)
@@ -6240,7 +6255,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | (protection_cmf_20_15m > -0.20)
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_4h < 70.0)
@@ -6251,7 +6266,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_3_1d > 40.0)
+        | rsi_3_1d_gt_40
         | (protection_rsi_14_15m > 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.25)
@@ -6374,7 +6389,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 25.0)
         | rsi_3_4h_gt_60
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -6398,7 +6413,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | (protection_rsi_14_4h < 60.0)
@@ -6421,7 +6436,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_rsi_14_15m < 25.0)
         | (protection_rsi_14_1h < 25.0)
         | (protection_rsi_14_4h < 25.0)
@@ -6536,7 +6551,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_3_1d > 40.0)
+        | rsi_3_1d_gt_40
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6634,7 +6649,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
@@ -6647,7 +6662,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_rsi_14_1h < 35.0)
         | (protection_rsi_14_4h < 35.0)
         | (protection_cmf_20_15m > -0.30)
@@ -6787,7 +6802,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 55.0)
-        | (protection_rsi_3_1d > 55.0)
+        | rsi_3_1d_gt_55
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -6824,7 +6839,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -6891,7 +6906,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_15)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | (protection_rsi_14_15m > 25.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -6966,7 +6981,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1d down move, 15m still not low enough, 1h & 4h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1d > 5.0)
+        | rsi_3_1d_gt_5
         | rsi_14_15m_lt_30
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
@@ -6974,7 +6989,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1d down move, 15m still not low enough, 1h & 4h high
       & (
         (rsi_3_15m_gt_15)
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_15m_lt_30
         | (protection_rsi_14_1h < 60.0)
         | (protection_rsi_14_4h < 60.0)
@@ -7079,7 +7094,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | (protection_cmf_20_15m > -0.40)
         | (protection_aroonu_14_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_1h < 15.0)
@@ -7103,7 +7118,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 20.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 30.0)
         | (protection_cmf_20_1d > -0.20)
@@ -7138,7 +7153,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | rsi_14_4h_lt_30
         | (protection_rsi_14_1d < 50.0)
         | (protection_cmf_20_1d > -0.0)
@@ -7153,7 +7168,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
         | (protection_cmf_20_15m > -0.40)
@@ -7272,7 +7287,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_1d > 55.0)
+        | rsi_3_1d_gt_55
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
         | (protection_cmf_20_15m > -0.3)
@@ -7283,7 +7298,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
         | (protection_stochrsik_14_14_3_3_1h < 50.0)
         | (protection_roc_9_4h > -70.0)
@@ -7293,7 +7308,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 40.0)
+        | rsi_3_1d_gt_40
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -7439,7 +7454,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | (protection_mfi_14_1d < 50.0)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_aroonu_14_4h < 85.0)
@@ -7449,7 +7464,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 35.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_3_1d > 55.0)
+        | rsi_3_1d_gt_55
         | (protection_rsi_14_15m < 25.0)
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -7623,7 +7638,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -7660,7 +7675,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -7857,7 +7872,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_20)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8052,7 +8067,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 55.0)
+        | rsi_3_1d_gt_55
         | (protection_rsi_14_15m < 25.0)
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -8063,7 +8078,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1d > -0.20)
@@ -8099,7 +8114,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
@@ -8111,7 +8126,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_cmf_20_15m > -0.30)
         | (protection_cmf_20_1h > -0.40)
         | (protection_cmf_20_4h > -0.40)
@@ -8251,7 +8266,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_1d > 65.0)
+        | rsi_3_1d_gt_65
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_50
@@ -8277,7 +8292,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 35.0)
-        | (protection_rsi_3_1d > 35.0)
+        | rsi_3_1d_gt_35
         | (protection_cmf_20_4h > -0.1)
         | (protection_cmf_20_1d > -0.1)
         | (protection_aroonu_14_1h < 75.0)
@@ -8463,7 +8478,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 45.0)
-        | (protection_rsi_3_1d > 55.0)
+        | rsi_3_1d_gt_55
         | rsi_14_15m_lt_40
         | (protection_rsi_14_1h < 45.0)
         | (protection_rsi_14_4h < 45.0)
@@ -8502,7 +8517,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
@@ -8686,7 +8701,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_3_1d > 15.0)
+        | rsi_3_1d_gt_15
         | rsi_14_15m_lt_40
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
@@ -8697,7 +8712,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_15m_gt_25)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_aroonu_14_15m < 60.0)
         | (protection_roc_9_1d < 50.0)
       )
@@ -8785,7 +8800,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1d down move, 1h & 4h still not low enough, 1h & 4h downtrend, 4h still high
       & (
         (rsi_3_15m_gt_25)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_mfi_14_1h < 40.0)
@@ -8922,7 +8937,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_rsi_14_15m < 25.0)
         | (protection_rsi_14_1h < 25.0)
         | (protection_rsi_14_4h < 25.0)
@@ -8950,7 +8965,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -8976,7 +8991,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_30)
         | rsi_3_1h_gt_30
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -9163,7 +9178,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | (protection_aroonu_14_15m < 60.0)
         | (protection_aroonu_14_1h < 85.0)
         | (protection_aroonu_14_4h < 100.0)
@@ -9174,7 +9189,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9290,7 +9305,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (rsi_3_15m_gt_30)
         | (protection_rsi_3_1h > 55.0)
         | (protection_rsi_3_4h > 55.0)
-        | (protection_rsi_3_1d > 55.0)
+        | rsi_3_1d_gt_55
         | (protection_cmf_20_15m > -0.25)
         | (protection_cmf_20_4h > -0.20)
         | (protection_aroonu_14_15m < 60.0)
@@ -9560,7 +9575,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 35.0)
         | (protection_rsi_3_1h > 45.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -9849,7 +9864,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 40.0)
         | (protection_rsi_3_4h > 45.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | (protection_cmf_20_1d > -0.40)
         | (protection_aroonu_14_4h < 30.0)
         | (protection_stochrsik_14_14_3_3_15m < 50.0)
@@ -9935,7 +9950,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 40.0)
         | (protection_rsi_3_1h > 50.0)
         | rsi_3_4h_gt_60
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_15m_lt_40
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -10021,7 +10036,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 15m & 1d down move, 15m & 1h & 4h stil high, 4h high, 15m & 1h & 4h still high
       & (
         (protection_rsi_3_15m > 40.0)
-        | (protection_rsi_3_1d > 20.0)
+        | rsi_3_1d_gt_20
         | (protection_rsi_14_15m < 50.0)
         | rsi_14_1h_lt_50
         | rsi_14_4h_lt_50
@@ -10116,7 +10131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_rsi_3_15m > 45.0)
         | (protection_rsi_3_1h > 50.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
@@ -10243,7 +10258,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 5.0)
         | (protection_rsi_3_4h > 5.0)
-        | (protection_rsi_3_1d > 10.0)
+        | rsi_3_1d_gt_10
         | (protection_aroonu_14_1d < 25.0)
         | (protection_roc_9_1d > -30.0)
       )
@@ -10321,7 +10336,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 15.0)
         | (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_3_1d > 15.0)
+        | rsi_3_1d_gt_15
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.10)
@@ -10371,7 +10386,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 40.0)
-        | (protection_rsi_3_1d > 60.0)
+        | rsi_3_1d_gt_60
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_aroonu_14_4h < 40.0)
@@ -10381,7 +10396,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 1d down move, 15m & 1h & 4h still not low enough, 15m & 1h downtrend, 1h still high
       & (
         (protection_rsi_3_1h > 20.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_rsi_14_15m < 10.0)
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_30
@@ -10393,7 +10408,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_stochrsik_14_14_3_3_1h < 30.0)
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -30.0)
@@ -10432,7 +10447,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (rsi_3_1h_gt_30)
         | (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 5.0)
+        | rsi_3_1d_gt_5
         | rsi_14_15m_lt_20
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -10466,7 +10481,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 1h & 1d down move, 1h & 4h & 1d still high, 1h & 4h high, 4h overbought
       & (
         (protection_rsi_3_1h > 60.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | rsi_14_1h_lt_50
         | (protection_rsi_14_4h < 60.0)
         | (protection_mfi_14_1d < 50.0)
@@ -10526,7 +10541,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h & 1d down move, 15m still not low enough, 4h downtrend
       & (
         (protection_rsi_3_4h > 5.0)
-        | (protection_rsi_3_1d > 5.0)
+        | rsi_3_1d_gt_5
         | (protection_stochrsik_14_14_3_3_15m < 20.0)
         | (protection_roc_9_4h > -40.0)
       )
@@ -10571,7 +10586,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h & 1d down move, 15m & 1h still not low enough, 4h still high, 4h downtrend, 1d overbought
       & (
         (protection_rsi_3_4h > 15.0)
-        | (protection_rsi_3_1d > 65.0)
+        | rsi_3_1d_gt_65
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | rsi_14_4h_lt_40
@@ -10581,7 +10596,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h & 1d down move, 1h still high, 4h high, 1d downtrend
       & (
         (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 50.0)
@@ -10600,7 +10615,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # 4h & 1d down move, 15m & 1h & 4h still not low enough, 4h downtrend, 1h still high, 4h downtrend
       & (
         (protection_rsi_3_4h > 30.0)
-        | (protection_rsi_3_1d > 40.0)
+        | rsi_3_1d_gt_40
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_rsi_14_4h < 20.0)
@@ -10632,7 +10647,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1d down move, 15m & 1h still not low enough, 4h & 1d downtrend
       & (
-        (protection_rsi_3_1d > 3.0)
+        rsi_3_1d_gt_3
         | rsi_14_15m_lt_20
         | (protection_rsi_14_1h < 20.0)
         | (protection_stochrsik_14_14_3_3_15m < 30.0)
@@ -10642,7 +10657,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1d down move, 1h & 4h still not low enough, 1h still high & overbought, 1d downtrend
       & (
-        (protection_rsi_3_1d > 3.0)
+        rsi_3_1d_gt_3
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
         | (protection_aroonu_14_1h < 50.0)
@@ -10652,7 +10667,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1d down move, 15m & 1h & 4h still not low enough, 15m still not low enough, 1h high
       & (
-        (protection_rsi_3_1d > 5.0)
+        rsi_3_1d_gt_5
         | rsi_14_15m_lt_30
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_30
@@ -10661,31 +10676,26 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
       )
       # 1d down move, 15m still not low enough, 1h high, 1d downtrend
-      & (
-        (protection_rsi_3_1d > 5.0)
-        | rsi_14_15m_lt_30
-        | (protection_stochrsik_14_14_3_3_1h < 80.0)
-        | (protection_roc_2_1d > -40.0)
-      )
+      & (rsi_3_1d_gt_5 | rsi_14_15m_lt_30 | (protection_stochrsik_14_14_3_3_1h < 80.0) | (protection_roc_2_1d > -40.0))
       # 1d down move, 15m high, 1h & 4h downtrend
       & (
-        (protection_rsi_3_1d > 5.0)
+        rsi_3_1d_gt_5
         | (protection_stochrsik_14_14_3_3_15m < 70.0)
         | (protection_roc_9_1h > -60.0)
         | (protection_roc_9_4h > -60.0)
       )
       # 1d down move, 1h still high, 4h high
-      & ((protection_rsi_3_1d > 5.0) | (protection_aroonu_14_1h < 40.0) | (protection_aroonu_14_4h < 70.0))
+      & (rsi_3_1d_gt_5 | (protection_aroonu_14_1h < 40.0) | (protection_aroonu_14_4h < 70.0))
       # 1d down move, 4h high, 1h & 4h downtrend
       & (
-        (protection_rsi_3_1d > 5.0)
+        rsi_3_1d_gt_5
         | (protection_stochrsik_14_14_3_3_4h < 70.0)
         | (protection_roc_9_1h > -10.0)
         | (protection_roc_9_4h > -10.0)
       )
       # 1d down move, 1h high & overbought, 4h & 1d downtrend
       & (
-        (protection_rsi_3_1d > 10.0)
+        rsi_3_1d_gt_10
         | (protection_stochrsik_14_14_3_3_1h < 80.0)
         | (protection_roc_9_1h < 10.0)
         | (protection_roc_9_4h > -40.0)
@@ -10693,7 +10703,7 @@ class NostalgiaForInfinityX7(IStrategy):
       )
       # 1d down move, 1h & 4h still high, 1h & 4h downtrend, 1h & 4h high, 1d downtrend
       & (
-        (protection_rsi_3_1d > 10.0)
+        rsi_3_1d_gt_10
         | rsi_14_1h_lt_40
         | rsi_14_4h_lt_40
         | (protection_cmf_20_1h > -0.40)
@@ -10818,7 +10828,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_change_pct_1d > -20.0)
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 50.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_rsi_14_1d < 40.0)
@@ -10855,7 +10865,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 10.0)
-        | (protection_rsi_3_1d > 40.0)
+        | rsi_3_1d_gt_40
         | rsi_14_4h_lt_30
       )
       # 1d P&D, 15m & 1h down move, 1h still not low enough, 4h still high, 15m downtrend, 1h still high
@@ -10955,7 +10965,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_top_wick_pct_1d < 10.0)
         | rsi_3_15m_gt_15
         | rsi_3_1h_gt_30
-        | (protection_rsi_3_1d > 65.0)
+        | rsi_3_1d_gt_65
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_50
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
@@ -11275,7 +11285,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_15
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 45.0)
+        | rsi_3_1d_gt_45
         | (protection_roc_9_1d < 20.0)
       )
       # pump, drop in lays days, 1h & 4h down move, 1h & 4h still not low enough, 1d overbought
@@ -11283,7 +11293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (((protection_high_max_12_1d - protection_low_min_12_1d) / protection_low_min_12_1d) < 3.0)
         | (protection_close > (protection_high_max_24_4h * 0.70))
         | (protection_rsi_3_1h > 15.0)
-        | (protection_rsi_3_1d > 50.0)
+        | rsi_3_1d_gt_50
         | rsi_14_1h_lt_30
         | rsi_14_4h_lt_40
         | (protection_roc_9_1d < 20.0)
@@ -11354,7 +11364,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 40.0)
         | rsi_3_4h_gt_60
-        | (protection_rsi_3_1d > 10.0)
+        | rsi_3_1d_gt_10
         | (protection_stochrsik_14_14_3_3_4h < 80.0)
       )
       # drop in last 6 days, 15m & 1h & 4h & 1d down move, 1d high, 4h downtrend
@@ -11363,7 +11373,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | (protection_rsi_3_15m > 5.0)
         | (protection_rsi_3_1h > 25.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_aroonu_14_1d < 80.0)
         | (protection_roc_9_4h > -40.0)
       )
@@ -11371,7 +11381,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_24_4h * 0.35))
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1d > 30.0)
+        | rsi_3_1d_gt_30
         | (protection_aroonu_14_15m < 25.0)
         | (protection_aroonu_14_1h < 40.0)
         | (protection_aroonu_14_1d < 80.0)
@@ -11382,7 +11392,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_24_4h * 0.25))
         | (protection_rsi_3_1h > 20.0)
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | (protection_aroonu_14_1h < 50.0)
         | (protection_roc_9_1h > -20.0)
         | (protection_roc_9_4h > -35.0)
@@ -11390,7 +11400,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 4 days, 1d down move, 1h & 4h downtrend, 15m & 4h downtrend
       & (
         (protection_close > (protection_high_max_24_4h * 0.25))
-        | (protection_rsi_3_1d > 15.0)
+        | rsi_3_1d_gt_15
         | (protection_cmf_20_1h > -0.20)
         | (protection_cmf_20_4h > -0.20)
         | (protection_roc_9_15m > -15.0)
@@ -11400,7 +11410,7 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_6_1d * 0.25))
         | rsi_3_15m_gt_15
-        | (protection_rsi_3_1d > 15.0)
+        | rsi_3_1d_gt_15
         | (protection_stochrsik_14_14_3_3_1h < 40.0)
         | (protection_stochrsik_14_14_3_3_4h < 60.0)
         | (protection_roc_9_4h > -25.0)
@@ -11421,13 +11431,13 @@ class NostalgiaForInfinityX7(IStrategy):
       & (
         (protection_close > (protection_high_max_24_4h * 0.15))
         | (protection_rsi_3_4h > 25.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | (protection_stochrsik_14_14_3_3_1h < 70.0)
       )
       # drop in last 4 days, 1d down move, 1d downtrendm 1h still high, 1d downtrend
       & (
         (protection_close > (protection_high_max_24_4h * 0.15))
-        | (protection_rsi_3_1d > 20.0)
+        | rsi_3_1d_gt_20
         | (protection_cmf_20_1d > -0.30)
         | (protection_aroonu_14_1h < 50.0)
         | (protection_roc_2_1d > -40.0)
@@ -11435,7 +11445,7 @@ class NostalgiaForInfinityX7(IStrategy):
       # drop in last 6 days, 1d down move, 1h & 4h & 1d downtrend, 1d still high, 4h downtrend
       & (
         (protection_close > (protection_high_max_6_1d * 0.15))
-        | (protection_rsi_3_1d > 20.0)
+        | rsi_3_1d_gt_20
         | (protection_cmf_20_1h > -0.10)
         | (protection_cmf_20_4h > -0.40)
         | (protection_cmf_20_1d > -0.50)
@@ -11448,7 +11458,7 @@ class NostalgiaForInfinityX7(IStrategy):
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 10.0)
         | (protection_rsi_3_4h > 35.0)
-        | (protection_rsi_3_1d > 35.0)
+        | rsi_3_1d_gt_35
         | (protection_stochrsik_14_14_3_3_4h < 50.0)
         | (protection_roc_9_1d > -40.0)
       )
@@ -11467,7 +11477,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_20_1d * 0.05))
         | rsi_3_15m_gt_10
         | (protection_rsi_3_1h > 25.0)
-        | (protection_rsi_3_1d > 25.0)
+        | rsi_3_1d_gt_25
         | (protection_aroonu_14_15m < 30.0)
         | (protection_aroonu_14_1h < 80.0)
       )
@@ -11476,7 +11486,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (protection_close > (protection_high_max_20_1d * 0.01))
         | (protection_rsi_3_1h > 45.0)
         | rsi_3_4h_gt_60
-        | (protection_rsi_3_1d > 15.0)
+        | rsi_3_1d_gt_15
         | (protection_rsi_14_1h < 15.0)
         | (protection_rsi_14_4h < 20.0)
         | (protection_cmf_20_1h > -0.0)


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for Hoist long protection RSI-3 1d comparison masks inside X7 long global protections.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact `protection_*` comparison expressions are bound once and reused inside `populate_indicators`.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_indicators`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_indicators` call. It does not change any formulas, thresholds, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
