### PR TITLE
Reuse X7 entry RSI-3 1h threshold mask

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12637,6 +12637,8 @@ class NostalgiaForInfinityX7(IStrategy):
     df.loc[:, "enter_long"] = 0
     df.loc[:, "enter_short"] = 0
     rsi_3_1h = df["RSI_3_1h"]
+    # Reused entry RSI-3 1h threshold mask
+    rsi_3_1h_gt_20 = rsi_3_1h > 20.0
     rsi_3_15m = df["RSI_3_15m"]
     rsi_3_4h = df["RSI_3_4h"]
     roc_9_1d = df["ROC_9_1d"]
@@ -12749,9 +12751,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h & 1d down move
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h still high
@@ -12819,9 +12821,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (rsi_14_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (rsi_14_4h < 80.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h < 80.0))
             # 15m & 4h down move, 1h high
@@ -12861,7 +12863,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (df["RSI_14_15m"] < 50.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m & 1h high
@@ -12943,17 +12945,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (roc_9_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (roc_9_4h < 80.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 90.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15n downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_15m > -20.0))
             # 1h down move, 1h still high, 1d overbought
@@ -13075,7 +13077,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, 1d downtrend
             & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.0))
             # 1d green with top wick, 1h down move
-            & ((df["change_pct_1d"] < 20.0) | (df["top_wick_pct_1d"] < 15.0) | (rsi_3_1h > 20.0))
+            & ((df["change_pct_1d"] < 20.0) | (df["top_wick_pct_1d"] < 15.0) | rsi_3_1h_gt_20)
             # 1d green with top wick, 4h high
             & ((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 25.0) | (aroonu_14_4h < 80.0))
             # 1d green, 1h down move, 1d downtrend
@@ -13085,7 +13087,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last hour, 15m downtrend
             & ((close > (df["close_max_12"] * 0.65)) | (df["CMF_20_15m"] > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
-            & ((close > (df["high_max_6_1h"] * 0.60)) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0))
+            & ((close > (df["high_max_6_1h"] * 0.60)) | rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0))
             # big drop in the last 24 hours,  1h still high
             & ((close > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 4 days, 1h high
@@ -13112,7 +13114,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1d high
@@ -13178,11 +13180,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h high
@@ -13284,7 +13286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 75.0))
             # 15m & 1h down move, 4h still high
@@ -13348,7 +13350,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (df["CMF_20_1h"] > -0.30))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 4h high
@@ -13394,9 +13396,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_4h < 50.0))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 80.0))
             # 15m & 1h down move, 4h high
@@ -13548,23 +13550,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d downtrend
@@ -14057,11 +14059,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1d still high
@@ -14504,7 +14506,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0))
             # 5m & 1h down move, 1h still high
@@ -14544,7 +14546,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
@@ -14566,7 +14568,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high, 1h overbought
@@ -14644,9 +14646,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h still high, 1d overbought
@@ -14786,7 +14788,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 15m still high
@@ -14910,11 +14912,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
@@ -15137,7 +15139,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (roc_9_1d > -30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 4h still high
@@ -15177,9 +15179,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d still high
             & ((rsi_3 > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
             # 15m & 1h & 4h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1h still not low enough
@@ -15233,11 +15235,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h still not low enough
             & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 4h high
@@ -15321,7 +15323,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (df["CMF_20_1h"] > -0.30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
@@ -15391,7 +15393,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h overbought
@@ -15559,17 +15561,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 15m high
@@ -15888,7 +15890,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
@@ -15954,21 +15956,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought, 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 50.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 50.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 40.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
             # 1h down move, 4h high & overbought
@@ -16128,7 +16130,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1d still high
@@ -16206,7 +16208,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 20.0))
             # 15m & 1h down move, 1d overbought
@@ -16252,7 +16254,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1d down move, 4h high
@@ -16284,9 +16286,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_1d < 50.0))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0))
             # 15m &4h down move, 4h still high
@@ -16458,31 +16460,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (roc_9_4h < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d > -50.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_1d > -50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 15m still high, 1h high
@@ -16784,9 +16786,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 4h still high
@@ -16802,7 +16804,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h high
@@ -16954,29 +16956,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
@@ -17323,7 +17325,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 1d high
@@ -17365,7 +17367,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 70.0))
             # 15m & 1h down move, 4h high
@@ -17407,13 +17409,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 15m & 1h down move, 4h high
@@ -17467,9 +17469,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
             # 15m down move. 15m still high, 1h high
@@ -17497,7 +17499,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1d down move, 4h high
@@ -17589,15 +17591,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
@@ -17800,7 +17802,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 15m downtrend
@@ -17952,13 +17954,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 1h & 4h down ove, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h & 1d high
@@ -18121,7 +18123,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 1d down move
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 10.0))
           # 15m & 1h down move, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
           # 15m & 1h down move, 1h high
@@ -18207,11 +18209,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_4h < 90.0))
           # 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
           # 1h & 4h down move, 4h high
@@ -18337,7 +18339,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 20 days, 1h down move
           long_entry_logic.append((close > (df["high_max_20_1d"] * 0.25)) | (rsi_3_1h > 15.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_1h > 20.0))
+          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | rsi_3_1h_gt_20)
           # big drop in the last 20 days, 1d high, 1d downtrend
           long_entry_logic.append(
             (close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0)
@@ -18372,9 +18374,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (rsi_3_4h > 20.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d high
@@ -18390,21 +18392,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 90.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 60.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0))
           # 15m & 1h & 1d down move, 1h still not low enough, 1d high
           long_entry_logic.append(
-            (rsi_3_15m > 20.0)
-            | (rsi_3_1h > 20.0)
-            | (rsi_3_1d > 30.0)
-            | (df["RSI_14_1h"] < 30.0)
-            | (aroonu_14_1d < 80.0)
+            (rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (df["RSI_14_1h"] < 30.0) | (aroonu_14_1d < 80.0)
           )
           # 15m & 1h down move, 4h still high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_4h < 10.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 70.0))
           # 15m down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1h & 4h down move, 1d high
@@ -18484,27 +18482,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
           # 1h & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1d < 80.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 65.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_4h < 65.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 4h high
@@ -18608,7 +18606,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 2 days, 1d down move
           long_entry_logic.append((close > (df["high_max_12_4h"] * 0.30)) | (rsi_3_1d > 30.0))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.30)) | (rsi_3_1h > 20.0))
+          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.30)) | rsi_3_1h_gt_20)
           # big drop in the last 12 days, 4h still high
           long_entry_logic.append((close > (df["high_max_12_1d"] * 0.40)) | (stochrsi_k_4h < 50.0))
           # big drop in the last 20 days, 1h down move
@@ -18641,7 +18639,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
             # 5m down move, 1d high & overbought
@@ -18665,7 +18663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (roc_9_1d < 50.0))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1h still high
@@ -18685,7 +18683,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 3.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1h downtrend
@@ -18703,7 +18701,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_4h > -50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 4h overbought
@@ -18749,9 +18747,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 1h high
@@ -18825,11 +18823,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 1d high
@@ -18990,7 +18988,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 4h still not low enough
@@ -19140,29 +19138,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 85.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 85.0))
             # 1h down move, 1h still not low enough, 4h stil high
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 40.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d overbought
@@ -19338,7 +19336,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 15m still high
@@ -19400,7 +19398,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 15m down move, 1h high
@@ -19550,17 +19548,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 4h high
@@ -19891,7 +19889,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high & overbought
           long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 25.0))
           # 15m & 1h down move, 1h still high
@@ -19925,7 +19923,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
           # 15m & 1h down move, 1h still high
@@ -20001,9 +19999,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h down move, 1h still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 80.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 1d high
@@ -20188,9 +20186,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 30.0))
           # 15m & 1h down move, 1h still high
@@ -20262,7 +20260,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high 1d overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 50.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 30.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
           # 15m & 1h down move, 15m high
@@ -20346,7 +20344,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (df["CMF_20_4h"] > -0.40))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h high
@@ -20550,7 +20548,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h high & overbought
@@ -20704,11 +20702,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
           # 15m & 1h & 4h down move, 15m downtrend
-          long_entry_logic.append(
-            (rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (df["CMF_20_15m"] > -0.20)
-          )
+          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (df["CMF_20_15m"] > -0.20))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 4h still high
@@ -20720,7 +20716,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 4h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (roc_9_4h < 50.0))
           # 15m & 1h down move, 1h high
@@ -20746,7 +20742,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0))
           # 15m & 1h down move, 1h high
@@ -20808,17 +20804,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 70.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h still high, 1d downtrend
@@ -20999,7 +20995,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m > 3.0) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h & 4h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 15m still high
@@ -21049,9 +21045,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1d overbought
@@ -21211,19 +21207,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 15m still high, 1d high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 90.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h high
@@ -21461,7 +21457,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
@@ -21535,7 +21531,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 15m still high
@@ -21611,15 +21607,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
@@ -21870,7 +21866,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h high
@@ -21922,17 +21918,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h & 1d overbought
@@ -22057,7 +22053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 15m still high
@@ -22145,23 +22141,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 70.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
@@ -22319,7 +22315,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
@@ -22389,21 +22385,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d overbought
@@ -22758,7 +22754,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 15m & 1h down move, 4h high
-            ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 70.0))
+            ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (df["RSI_14_1h"] < 50.0))
             # 15m & 1d down move, 4h high
@@ -22774,9 +22770,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
             # 15m & 1h down nove, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
@@ -22814,7 +22810,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 1d high
@@ -22944,7 +22940,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
           long_entry_logic.append(df["protections_long_global"] == True)
 
-          long_entry_logic.append((rsi_3 > 10.0) & (rsi_3_15m > 10.0) & (rsi_3_1h > 20.0))
+          long_entry_logic.append((rsi_3 > 10.0) & (rsi_3_15m > 10.0) & rsi_3_1h_gt_20)
 
           long_entry_logic.append(
             # 5m & 15m & 4h down mnove, 4h high


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for entry RSI-3 1h threshold mask inside X7 `populate_entry_trend`.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact already-used Series comparison expressions are bound once and reused in the same function.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_entry_trend`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_entry_trend` call. It does not change formulas, thresholds, condition order, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
