### PR TITLE
Reuse X7 entry AROON 4h threshold mask

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12641,6 +12641,8 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_4h = df["RSI_3_4h"]
     roc_9_1d = df["ROC_9_1d"]
     aroonu_14_4h = df["AROONU_14_4h"]
+    # Reused entry AROON 4h threshold mask
+    aroonu_14_4h_lt_70 = aroonu_14_4h < 70.0
     roc_9_4h = df["ROC_9_4h"]
     aroonu_14_1h = df["AROONU_14_1h"]
     stochrsi_k_4h = df["STOCHRSIk_14_14_3_3_4h"]
@@ -12729,13 +12731,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 15m still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m down move, 15m high
             & ((rsi_3 > 3.0) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h downtrend, 1h high
             & ((rsi_3_15m > 1.0) | (df["CMF_20_1h"] > -0.1) | (aroonu_14_1h < 70.0))
             # 15m & 1h & 4h down move
@@ -12775,7 +12777,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_15m > -20.0))
+            & ((rsi_3_15m > 3.0) | aroonu_14_4h_lt_70 | (roc_9_15m > -20.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h overbought
@@ -12787,7 +12789,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d < 40.0))
             # 5m & 1h down move, 1h overbought
@@ -12901,7 +12903,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 40.0))
             # 1h & 1d down move, 1d downtrend
@@ -12947,7 +12949,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 20.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h high & overbought
@@ -13013,7 +13015,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 45.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 60.0))
             # 1d down move, 1h high, 1d downtrend
@@ -13220,7 +13222,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high, 15m downtrend
             & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (df["CMF_20_15m"] > -0.35))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 3.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 3.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
             # 15m & 1h & 4h down move
@@ -13336,11 +13338,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 20.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m sill high, 4h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 4h high, 1d downtrend
@@ -13432,11 +13434,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 50.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 50.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high & overbought
@@ -13470,7 +13472,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 15m still high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h high
@@ -13528,7 +13530,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1d high
@@ -13574,7 +13576,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (df["CMF_20_4h"] > -0.50))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -13682,7 +13684,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d downtrend
@@ -13702,15 +13704,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d overbought
@@ -13764,7 +13766,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
             # 4h high & overbought
-            & ((aroonu_14_4h < 70.0) | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 4h high, 1h & 4h overbought
@@ -13863,7 +13865,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
@@ -13885,7 +13887,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 15m still high, 4h high
@@ -13913,7 +13915,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1d down move, 1h still high
@@ -13929,7 +13931,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 15m down move, 15m high, 4h downtrend
@@ -13947,7 +13949,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 1h high, 1d overbought
@@ -13981,7 +13983,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 15m down move, 1h high, 1d overbought
@@ -14001,7 +14003,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 40.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1d high, 15m high
             & ((rsi_3_15m > 30.0) | (df["RSI_14_1d"] < 70.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 15m high, 1d downtrend
@@ -14013,7 +14015,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 60.0))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
@@ -14043,7 +14045,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 4h downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 10.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
             # 1h & 4h down move, 15m high
@@ -14093,7 +14095,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70)
             # 1h down move, 15m & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 1h & 4h high
@@ -14117,7 +14119,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h still high, 1d overbought
@@ -14251,9 +14253,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
@@ -14325,7 +14327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1h high
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
             # 4h down move, 1d high, 4h overbought
@@ -14337,7 +14339,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h high & overbought
@@ -14345,7 +14347,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h > 60.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d overbought
@@ -14399,9 +14401,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h downtrend, 4h overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_1h > -10.0) | (roc_9_4h < 40.0))
             # 15m high, 4h high & overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 10.0))
+            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 10.0))
             # 15m high, 15m & 4h overbought
             & ((aroonu_14_15m < 60.0) | (roc_9_15m < 10.0) | (roc_9_4h < 20.0))
             # 15m high, 4h downtrend
@@ -14409,11 +14411,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h high
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h & 1d high
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
             # 15m & 4h high, 4h overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 15m & 4h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 15m high, 4h downtrend, 1d overbought
@@ -14512,7 +14514,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high, 4h overbought
@@ -14542,13 +14544,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
@@ -14560,7 +14562,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d downtrend
@@ -14652,7 +14654,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high & overbought
@@ -14710,7 +14712,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -14724,9 +14726,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h still high, 4h & 1d downtrend
@@ -14910,7 +14912,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1h still high
@@ -14918,7 +14920,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d downtrend
@@ -15038,7 +15040,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d overbought
@@ -15058,7 +15060,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h & 1d high, 1d overbought
@@ -15187,7 +15189,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 30.0))
             # 15m & 4h down move, 1d downtrend
@@ -15287,7 +15289,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
@@ -15325,7 +15327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
@@ -15363,7 +15365,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
@@ -15377,9 +15379,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 25.0))
             # 15m down move, 4h high, 1h overbought
@@ -15421,13 +15423,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m down move, 1d high, 4h downtrend
@@ -15473,7 +15475,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
@@ -15529,11 +15531,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h still high
@@ -15575,7 +15577,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 4h overbought
@@ -15593,7 +15595,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h & 1d down move
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 1d still high, 1d downtrend
@@ -15607,9 +15609,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 35.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -15689,7 +15691,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
@@ -15731,7 +15733,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
@@ -15747,13 +15749,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
@@ -15771,11 +15773,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
             # 1d down move, 4h downtrend, 4h high
-            & ((rsi_3_1d > 20.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1d > 20.0) | (df["CMF_20_4h"] > -0.25) | aroonu_14_4h_lt_70)
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
@@ -15809,9 +15811,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 15.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h high, 4h overbought, 1d downtrend
@@ -16022,7 +16024,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1d down move, 1h high, 1d overbought
@@ -16174,7 +16176,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1d downtrend
@@ -16300,7 +16302,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 4h high
@@ -16334,7 +16336,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -16352,7 +16354,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (df["CMF_20_1h"] > -0.30))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 1h down move, 1d high, 1h downtrend
@@ -16422,7 +16424,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1h still high
@@ -16540,7 +16542,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
@@ -16582,7 +16584,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_4h > 3.0) | aroonu_14_4h_lt_70 | (roc_9_1h > -40.0))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d still high
@@ -16772,7 +16774,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h still high
@@ -16812,7 +16814,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still not low enough, 1d downtrend
@@ -16836,7 +16838,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 4h high
@@ -16878,7 +16880,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
@@ -16900,13 +16902,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
@@ -16980,19 +16982,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h overbought
@@ -17016,7 +17018,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (df["CMF_20_4h"] > -0.40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h overbought
@@ -17186,9 +17188,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h overbought, 1d downtrend
@@ -17232,9 +17234,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d downtrend
             & ((aroonu_14_4h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 1d high, 4h & 1d overbought
@@ -17319,7 +17321,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
@@ -17369,7 +17371,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1h still high
@@ -17439,7 +17441,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m still high, 1d downtrend
@@ -17471,7 +17473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 15m down move. 15m still high, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m & 4h high
@@ -17481,7 +17483,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
@@ -17539,7 +17541,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h & 1d downtrend
@@ -17625,7 +17627,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h downtrend
@@ -17828,7 +17830,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
@@ -17870,7 +17872,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h & 1d downtrend
@@ -17890,7 +17892,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1h > -25.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h still high
@@ -18016,13 +18018,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 60.0))
             # 4h downtrend, 4h high
-            & ((df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((df["CMF_20_4h"] > -0.50) | aroonu_14_4h_lt_70)
             # 1h & 1d high, 4h downtrend
             & ((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h still high, 1h & 4h downtrend
@@ -18143,11 +18145,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 50.0))
           # 15m & 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
           # 15m down move, 4h high & overbought
@@ -18215,7 +18217,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
           # 1h down move, 4h high
@@ -18283,9 +18285,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
           # 4h high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 80.0))
           # 4h high, 1h & 1d downtrend
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h high, 1h & 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high & overbought
@@ -18404,7 +18406,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h < 10.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1h & 4h down move, 1d high
@@ -18426,7 +18428,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1d still high
           long_entry_logic.append((rsi_3_1h > 5.0) | (stochrsi_k_1d < 50.0))
           # 1h & 4h down move, 4h still not low enough
@@ -18440,7 +18442,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 50.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 40.0))
           # 1h & 1d down move, 4h still not low enough
@@ -18508,7 +18510,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_14_15m"] < 30.0) | (stochrsi_k_4h < 60.0))
           # 1h & 4h down move, 4h still high
@@ -18520,7 +18522,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
           # 1h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -30.0))
           # 1h down move, 4h high
@@ -18530,7 +18532,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 4h high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.30))
+          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (df["CMF_20_4h"] > -0.30))
           # 1h down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1h down move, 1h high, 1d overbought
@@ -18643,7 +18645,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m down move, 1d high & overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m & 1h & 4h down move
@@ -18711,7 +18713,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m still not low enough, 1d downtrend
@@ -18757,7 +18759,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high
@@ -18823,7 +18825,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
@@ -18889,7 +18891,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1h > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
             # 4h down move, 1h still not low enough, 1d downtrend
@@ -19044,7 +19046,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -25.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
@@ -19070,7 +19072,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1d still high
@@ -19078,7 +19080,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough
             & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 20.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -19136,7 +19138,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
@@ -19172,9 +19174,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (df["CMF_20_4h"] > -0.50))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 4h still high
@@ -19188,7 +19190,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (df["CMF_20_4h"] > -0.40))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 4h overbought
@@ -19256,7 +19258,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
@@ -19290,9 +19292,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1d high, 4h downtrend, 1d overbought
@@ -19694,7 +19696,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1h & 4h still high
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
             # 4h dowqn move, 4h still high, 1d downtrend
@@ -19704,7 +19706,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
@@ -19714,7 +19716,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d overbought
@@ -19742,7 +19744,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h high
             & ((aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 15m still high, 4h high & overbought
-            & ((aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m still high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
             # 1h still high, 4h & 1d downtrend
@@ -19762,7 +19764,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 1d high, 4h downtrend
             & ((aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
             # 4h high, 1h & 1d downtrend
-            & ((aroonu_14_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
             # 4h & 1d high, 4h overbought
@@ -19861,7 +19863,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_15m > 3.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
           # 15m & 1h & 1d down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 20.0))
           # 15m down move, 1h still not low enough, 1d high
@@ -19973,7 +19975,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h > -20.0))
           # 1h & 4h down move, 4h downtrend
@@ -20033,7 +20035,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m 4h still high
           long_entry_logic.append((rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 50.0))
           # 4h & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h still high
           long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
           # 4h down move, 4h still high
@@ -20088,7 +20090,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 70.0) | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
+            aroonu_14_4h_lt_70 | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
@@ -20162,7 +20164,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h down move, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
           # 5m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 5m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0))
           # 5m down move, 15m still high, 1h high
@@ -20198,7 +20200,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
           # 15m& 4h down move, 15m still high
@@ -20218,7 +20220,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
           # 15m & 1d down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 15m still not low enough, 1h high
@@ -20350,17 +20352,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 70.0))
           # 1h down move, 1d still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -50.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
           # 1h & 4h down move, 4h high
@@ -20420,7 +20422,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high, 1d overbought
           long_entry_logic.append((aroonu_14_15m < 80.0) | (roc_9_1d < 50.0))
           # 15m & 4h high
-          long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((aroonu_14_15m < 90.0) | aroonu_14_4h_lt_70)
           # 15m & 1h high
           long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_1h < 90.0))
           # 1h still high, 4h high & overbought
@@ -20434,7 +20436,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
           # 1d high, 4h & 1d overbought
@@ -20459,7 +20461,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 70.0) | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
+            aroonu_14_4h_lt_70 | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
@@ -20552,11 +20554,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d overbought
@@ -20586,9 +20588,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 50.0))
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_15m < 30.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h high, 4h downtrend
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
           # 4h down move, 4h still high, 1d downtrend
@@ -20630,7 +20632,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h high, 1h & 1d overbought
           long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
           # 1d high, 4h & 1d overbought
@@ -20748,7 +20750,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_70)
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1h still high
@@ -20762,7 +20764,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (df["RSI_14_1h"] < 40.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
           # 15m down move, 15m still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 20.0) | (roc_9_1d < 80.0))
           # 1h & 4h down move
@@ -20770,7 +20772,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0))
           # 1h & 4h down move, 4h still high
@@ -20816,7 +20818,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | aroonu_14_4h_lt_70)
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 90.0))
           # 1h down move, 1h & 1d high
@@ -20884,7 +20886,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
           # 4h & 1d high,1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
           # 1d red, 4h down move, 1h still high
           long_entry_logic.append((df["change_pct_1d"] > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # pump, drop but not yet near the previous lows
@@ -21083,7 +21085,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 1h still high
@@ -21093,11 +21095,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
@@ -21179,7 +21181,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 1d down move, 1h still not low enough
@@ -21247,7 +21249,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high , 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 4h high
@@ -21291,7 +21293,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d high
@@ -21327,7 +21329,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m & 4h high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d downtrend
@@ -21503,7 +21505,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
@@ -21635,7 +21637,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -21679,7 +21681,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 15m high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 4h still high
@@ -21693,7 +21695,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 1d high & overbought
@@ -21717,7 +21719,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d downtrend
@@ -21892,7 +21894,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1h still high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h high
@@ -21926,7 +21928,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 1d overbought
@@ -21972,7 +21974,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
@@ -21982,7 +21984,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h high, 1d downtrend
@@ -22051,7 +22053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 20.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
             # 15m & 1h down move, 15m still high
@@ -22073,7 +22075,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h high
@@ -22129,7 +22131,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
             # 1h & 1d down move, 1d high
@@ -22173,7 +22175,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["RSI_14_1d"] < 80.0))
             # 1h down move, 1h & 4h high
@@ -22231,7 +22233,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -22299,7 +22301,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 4h still not low enough
@@ -22331,7 +22333,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 15m high, 4h high
@@ -22389,7 +22391,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 4h still high
@@ -22457,7 +22459,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 60.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 20.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 15m high
             & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 90.0))
             # 4h down move, 1d high & overbought
@@ -22485,7 +22487,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1d > 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
@@ -22521,7 +22523,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m high
           long_entry_logic.append((rsi_3 > 15.0) | (aroonu_14_15m < 80.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m high
@@ -22630,7 +22632,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h & 1d high
@@ -22672,13 +22674,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still not low enough
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
           # 4h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h < 50.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m & 1d high
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 80.0) | (aroonu_14_4h < 40.0))
           # 4h down move, 15m still high, 1h high
@@ -22688,7 +22690,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 60.0))
           # 4h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 70.0) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 15m still high, 1d high & overbought
@@ -22704,9 +22706,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high, 1d overbought
           long_entry_logic.append((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
           # 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_4h < 40.0))
           # 4h high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
           # 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1d high & overbought
@@ -22714,7 +22716,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high, 1h still high
           long_entry_logic.append((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 40.0))
           # 15m & 4h high
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((stochrsi_k_15m < 70.0) | aroonu_14_4h_lt_70)
           # 15m high, 1d overbought
           long_entry_logic.append((stochrsi_k_15m < 70.0) | (roc_9_1d < 10.0))
           # 15m high, 1h still not low enough
@@ -22788,7 +22790,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
@@ -22810,11 +22812,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 3h down move, 1d high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 1d high
@@ -22876,7 +22878,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 20.0))
             # 1h & 4h high
@@ -23125,7 +23127,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1d high
@@ -23135,7 +23137,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 4h still high
             & ((rsi_3_1h > 25.0) | (df["CMF_20_15m"] > -0.4) | (aroonu_14_4h < 50.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.25) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
@@ -23241,7 +23243,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h high, 1d overbought
@@ -23251,13 +23253,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 20.0))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 100.0))
             # 4h & 1d down move, 4h high, 1d overbought


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for entry AROON 4h threshold mask inside X7 `populate_entry_trend`.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact already-used Series comparison expressions are bound once and reused in the same function.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_entry_trend`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_entry_trend` call. It does not change formulas, thresholds, condition order, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
