### PR TITLE
Reduce X7 entry ROC 1d threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12640,6 +12640,9 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_15m = df["RSI_3_15m"]
     rsi_3_4h = df["RSI_3_4h"]
     roc_9_1d = df["ROC_9_1d"]
+    # Reused entry ROC 1d threshold masks
+    roc_9_1d_lt_50 = roc_9_1d < 50.0
+    roc_9_1d_gt_neg_50 = roc_9_1d > -50.0
     aroonu_14_4h = df["AROONU_14_4h"]
     roc_9_4h = df["ROC_9_4h"]
     aroonu_14_1h = df["AROONU_14_1h"]
@@ -12765,7 +12768,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m downtrend
@@ -12853,7 +12856,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -25.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 1d overbought
@@ -12933,7 +12936,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
             # 1h down mve, 4h high, 1d overbought
@@ -13009,7 +13012,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 45.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h high, 1d overbought
@@ -13027,7 +13030,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h still high, 1d overbought
             & ((rsi_3_1d > 50.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d overbought
             & ((df["RSI_3_change_pct_1h"] > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m & 1h & 4h downtrend
@@ -13043,13 +13046,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought, 1d downtrend
             & ((aroonu_14_1h < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1d > -40.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 90.0) | (roc_9_1h > -10.0) | (roc_9_4h > -20.0))
             # 1d high, 4h & 1d overbought
@@ -13222,7 +13225,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 3.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 3.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 4h still high
@@ -13290,7 +13293,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | roc_9_1d_gt_neg_50)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h still high
@@ -13430,9 +13433,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
@@ -13490,7 +13493,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d still high
@@ -13540,7 +13543,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
@@ -13672,7 +13675,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h down move, 4h still high, 1d overbought
@@ -13686,7 +13689,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 35.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h high, 1d overbought
@@ -13694,7 +13697,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 40.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
@@ -13726,7 +13729,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h overbought, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (roc_9_1h < 20.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 15.0) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
@@ -13742,11 +13745,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | roc_9_1d_lt_50)
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -40.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4high, 1d downtrend
@@ -13780,7 +13783,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d overbought
             & ((stochrsi_k_15m < 70.0) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h downtrend
@@ -13851,7 +13854,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h still high
@@ -13891,7 +13894,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h high, 1d overbought
@@ -13931,7 +13934,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -40.0))
             # 15m down move, 15m high, 4h overbought
@@ -13943,7 +13946,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
@@ -13995,7 +13998,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h high
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_4h < 50.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1d overbought
@@ -14017,7 +14020,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m high, 4h overbought
@@ -14027,7 +14030,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 200.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 15m high, 1h downtrend
@@ -14073,7 +14076,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 1h still high 1d overbought
@@ -14105,9 +14108,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 70.0))
             # 1h & 4h down move, 4h high
@@ -14115,7 +14118,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h still high, 4h high
@@ -14131,7 +14134,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (df["CMF_20_1d"] > -0.20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 15m high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 4h overbought
@@ -14217,7 +14220,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m high
             & ((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 55.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 55.0) | roc_9_1d_lt_50)
             # 4h down move, 15m & 4h still high
             & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 15m high, 1d high
@@ -14245,7 +14248,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
@@ -14257,7 +14260,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
             # 4h & 1d down move, 1d overbought
@@ -14271,7 +14274,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still high, 1h high
@@ -14287,7 +14290,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h & 4h high
@@ -14349,19 +14352,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 15m still high, 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -60.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
             # 1d down move, 4h & 1d downtrend
@@ -14393,7 +14396,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1d > 40.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 15m still high, 4h high, 1d overbought
             & ((aroonu_14_15m < 50.0) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
             # 15m still high, 1h downtrend, 4h overbought
@@ -14419,7 +14422,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h high, 1d high & overbought
@@ -14443,7 +14446,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 15m & 1h high, 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 15m & 1d high
             & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d < 90.0))
             # 1h high, 4h & 1d downtrend
@@ -14528,7 +14531,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 1d overbought
@@ -14552,7 +14555,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0))
             # 15m & 1h down move, 1h still high
@@ -14744,7 +14747,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h high, 1h & 1d overbought
@@ -14756,7 +14759,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 20.0) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h & 1d overbought
@@ -14812,7 +14815,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -14850,7 +14853,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1h downtrend
@@ -14896,7 +14899,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1d high, 1d downtrend
@@ -14938,9 +14941,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d over
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h & 4h high
@@ -14960,7 +14963,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h overbought
@@ -14972,7 +14975,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1h overbought
@@ -15563,7 +15566,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 20.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
@@ -15613,7 +15616,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 35.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 35.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1h high
@@ -15629,7 +15632,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -15.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h overbought
@@ -15787,7 +15790,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
@@ -15803,7 +15806,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 50.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h &1d overbought
             & ((aroonu_14_1h < 85.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
@@ -15819,13 +15822,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
             # 1d high, 1d downtrend
             & ((aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
             # 15m still not low enough, 4h high, 1d overbought
@@ -15839,7 +15842,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 50.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
             # 1h high & overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 4h high, 1h & 4h overbought
@@ -15849,7 +15852,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 4h high, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 4h high, 1h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
@@ -15902,7 +15905,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 15m down move, 1d high, 1d downtrend
@@ -15976,7 +15979,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
@@ -16052,7 +16055,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 4h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 15m downtrend
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -40.0))
             # 1h & 4h high, 1h overbought
@@ -16276,7 +16279,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h downtrend, 4h overbought
@@ -16286,13 +16289,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0))
             # 15m &4h down move, 4h still high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 4h downtrend
@@ -16364,9 +16367,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_4h > -25.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1h high
@@ -16412,7 +16415,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d < 90.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 10.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h downtrend
@@ -16476,7 +16479,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h overbought
@@ -16494,7 +16497,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h still high, 1d overbought
@@ -16504,7 +16507,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 4h overbought
             & ((rsi_3_1h > 25.0) | (roc_9_15m > -25.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h & 1d downtrend
-            & ((rsi_3_1h > 25.0) | (roc_9_1h > -50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_1h > -50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h overbought
@@ -16528,7 +16531,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high, 4h downtrend
@@ -16590,7 +16593,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
@@ -16624,7 +16627,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
             # 4h down move, 1d high & overbought
@@ -16678,7 +16681,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
@@ -16694,13 +16697,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1h < 50.0))
             # 1d still high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -50.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h overbought
@@ -16816,7 +16819,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h high, 1d downtrend
@@ -16988,7 +16991,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high & overbought
@@ -17002,7 +17005,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 80.0))
             # 1h & 4h down move, 4h high
@@ -17014,7 +17017,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
             # 1h down move, 4h high & overbought
@@ -17046,7 +17049,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 60.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h high & overbought
@@ -17110,7 +17113,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (df["RSI_14_1d"] < 50.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -17515,7 +17518,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (roc_9_1h > -30.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
@@ -17597,7 +17600,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 20.0) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
@@ -17695,7 +17698,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -17928,7 +17931,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 10.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17938,7 +17941,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 4h high & overbought
@@ -17948,7 +17951,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
@@ -17996,7 +17999,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 4h down move, 4h still high, 1d overbought
@@ -18030,7 +18033,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h downtrend
             & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0))
             # 1h & 1d high, 1d overbought
@@ -18062,7 +18065,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h still high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
+            & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
@@ -18147,7 +18150,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | roc_9_1d_lt_50)
           # 15m & 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
           # 15m down move, 4h high & overbought
@@ -18189,7 +18192,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
           # 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
           # 1h & 4h down move, 4h still high
@@ -18233,7 +18236,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (stochrsi_k_1d < 80.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | roc_9_1d_lt_50)
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 1h & 4h high
@@ -18438,7 +18441,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | roc_9_1d_lt_50)
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
           # 1h & 4h down move, 4h still high
@@ -18460,7 +18463,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | roc_9_1d_lt_50)
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 1d high
@@ -18476,7 +18479,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_lt_50)
           # 1h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h down move, 1d high & overbought
@@ -18597,7 +18600,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
-            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
+            roc_9_1d_lt_50 | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
@@ -18665,7 +18668,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1h still high
@@ -18809,7 +18812,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 10.0) | (roc_9_4h > -10.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d overbought
@@ -18821,7 +18824,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
@@ -18891,7 +18894,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18901,11 +18904,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
@@ -18937,7 +18940,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d high, 1h & 4h downtrend
@@ -19064,7 +19067,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m stil high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 40.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -19166,7 +19169,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 4h & 1d high
@@ -19420,7 +19423,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
@@ -19462,7 +19465,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h stil high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
             # 1h ^ 4h down move, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1h downtrend
@@ -19492,7 +19495,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0))
             # 1h, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19524,7 +19527,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend
             & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 20.0))
             # 1h down move, 1d overbought
@@ -19608,7 +19611,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 50.0))
             # 4h down move, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
@@ -19700,7 +19703,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h dowqn move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
@@ -19710,7 +19713,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
@@ -19764,7 +19767,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 1d downtrend
             & ((aroonu_14_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 4h high, 1h & 4h overbought
@@ -20100,10 +20103,10 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
-            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
+            roc_9_1d_lt_50 | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
           )
           # big drop in last 6 hours, 1d overbought
-          long_entry_logic.append((close > (df["high_max_6_1h"] * 0.65)) | (roc_9_1d < 50.0))
+          long_entry_logic.append((close > (df["high_max_6_1h"] * 0.65)) | roc_9_1d_lt_50)
           # big drop in last 4 hours, 4h still not low enough
           long_entry_logic.append((close > (df["high_max_24_4h"] * 0.50)) | (stochrsi_k_4h < 30.0))
           # big drop in the last 4 days, 4h down move
@@ -20260,7 +20263,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (stochrsi_k_4h < 60.0))
           # 15m down move, 4h still high 1d overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | roc_9_1d_lt_50)
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 30.0))
           # 15m & 1h down move, 4h high
@@ -20314,7 +20317,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 60.0))
           # 15m down move, 15m high, 4h still high
@@ -20358,7 +20361,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | roc_9_1d_gt_neg_50)
           # 1h down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d overbought
@@ -20418,7 +20421,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h high
           long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h < 70.0))
           # 15m high, 1d overbought
-          long_entry_logic.append((aroonu_14_15m < 80.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
           # 15m & 4h high
           long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_4h < 70.0))
           # 15m & 1h high
@@ -20438,7 +20441,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h high, 4h & 1d overbought
@@ -20463,7 +20466,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
-            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
+            roc_9_1d_lt_50 | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
           )
           # big drop in the last 4 days, 4h down move
           long_entry_logic.append((close > (df["high_max_24_4h"] * 0.20)) | (rsi_3_4h > 20.0))
@@ -20634,7 +20637,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 15m still high, 1h high
           long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_1h < 90.0))
           # 15m still high, 1d high
@@ -20808,7 +20811,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | roc_9_1d_lt_50)
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 1d down move, 1d high
@@ -20830,13 +20833,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & dh down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 30.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
           # 1h down move, 1h still not low enough, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0) | (roc_9_4h > -20.0))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
           # 1h down move, 4h high & overbought
@@ -20860,7 +20863,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
           # 4h down move, 1h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h high
@@ -20876,7 +20879,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1d down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 20.0))
           # 1h & 4h high, 4h overbought
@@ -20884,7 +20887,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
           # 4h & 1d high,1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
           # 1d red, 4h down move, 1h still high
           long_entry_logic.append((df["change_pct_1d"] > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # pump, drop but not yet near the previous lows
@@ -21077,7 +21080,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | roc_9_1d_lt_50)
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 15m high
@@ -21369,13 +21372,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0) | roc_9_1d_lt_50)
             # 1h & 1d high, 1d overbought
             & ((aroonu_14_1h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
             # 4h & 1d overbought
@@ -21487,7 +21490,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | roc_9_1d_lt_50)
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d high
@@ -21519,7 +21522,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | roc_9_1d_lt_50)
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m & 1d down move, 4h high
@@ -21561,7 +21564,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
             # 15m down move, 1d high, 1h overbought
             & ((rsi_3_15m > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
             # 1h & 4h down move, 1d still high
@@ -21609,7 +21612,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
@@ -21741,7 +21744,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high, 4h downtrend
@@ -21916,7 +21919,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
@@ -22053,7 +22056,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1d overbought
@@ -22359,7 +22362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h still not low enough
@@ -22387,7 +22390,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
             # 1h & 4h down move, 4h high
@@ -22553,7 +22556,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 50.0))
           # 15m down move, 15m still not low enough, 4h still high
@@ -22563,7 +22566,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 50.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 15m still high, 4h high
@@ -22726,7 +22729,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d overbought
           long_entry_logic.append((roc_9_4h < 40.0) | (roc_9_1d < 40.0))
           # 1d green with top wick, 1d overbought
-          long_entry_logic.append((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 25.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 25.0) | roc_9_1d_lt_50)
 
           # Logic
           long_entry_logic.append(df["RSI_14"] < 50.0)
@@ -22820,7 +22823,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1d overbought
@@ -22836,9 +22839,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 45.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 45.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move,  4h high, 1d overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 150.0))
             # 4h down move, 1d high
@@ -22860,9 +22863,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1d down move, 1h high
             & ((rsi_3_1d > 3.0) | (stochrsi_k_1h < 70.0))
             # 1d down move, 15m still high
@@ -23030,7 +23033,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d high
@@ -23243,13 +23246,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 1d high, 4h overbought
@@ -23456,7 +23459,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (aroonu_14_4h > 70.0))
           # 15m up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
           # 15m up move, 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h up move, 1h still not high enough
@@ -23542,9 +23545,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d still not high enough
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1d > 70.0))
           # 1h up move, 4h low, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_4h > 20.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_4h > 20.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still low, 1d uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 60.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 60.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still not high enough, 1d low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_1d > 30.0))
           # 1h up move, 4h low, 1h uptrend
@@ -23880,9 +23883,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h still high, 1d strong downtrend
           short_entry_logic.append((rsi_3_15m < 80.0) | (df["AROOND_14_1h"] < 25.0) | (df["MFI_14_1d"] < 90.0))
           # 15m down move, 1h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0) | roc_9_1d_lt_50)
           # 15m down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 15m & 4h down move, 1d downtrend
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (roc_9_1d > -70.0))
           # 15m down move, 15m not low enough, 1h overbought
@@ -23902,7 +23905,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h stil high, 1d overbought
           short_entry_logic.append((rsi_3_15m < 85.0) | (df["AROOND_14_1h"] < 25.0) | (roc_9_1d > -80.0))
           # 15m down move, 1h high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | roc_9_1d_gt_neg_50)
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 4h still high
@@ -23914,9 +23917,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((df["RSI_3_change_pct_1h"] > -65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((df["RSI_3_change_pct_1h"] > -65.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1h still high
           short_entry_logic.append((rsi_3_4h < 90.0) | (df["ROC_2_1d"] < 20.0) | (stochrsi_k_1h > 50.0))
           # 15m still high, 1h down move, 4h high
@@ -23930,17 +23933,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h still high, 4h overbought
           short_entry_logic.append((df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_1h"] < 50.0) | (roc_9_4h > -40.0))
           # 15m still high, 1h down move, 1d downtrend
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h < 90.0) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
           short_entry_logic.append((stochrsi_k_1h > 50.0) | (df["UO_7_14_28_4h"] > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
-          short_entry_logic.append((df["AROOND_14_1h"] < 25.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((df["AROOND_14_1h"] < 25.0) | (roc_9_4h < 20.0) | roc_9_1d_lt_50)
           # 4h moving down, 1d P&D
-          short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | roc_9_1d_gt_neg_50)
           # 1d strong downtrend, 4h still high
-          short_entry_logic.append((df["ROC_2_1d"] < 20.0) | (roc_9_1d < 50.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((df["ROC_2_1d"] < 20.0) | roc_9_1d_lt_50 | (stochrsi_k_4h > 70.0))
           # 1d P&D, 1d overbought
-          short_entry_logic.append((df["ROC_2_1d"] < 10.0) | (roc_9_1d > -50.0) | (stochrsi_k_1h > 5.0))
+          short_entry_logic.append((df["ROC_2_1d"] < 10.0) | roc_9_1d_gt_neg_50 | (stochrsi_k_1h > 5.0))
           # 1h red, previous 1h green, 1h overbought
           short_entry_logic.append(
             (df["change_pct_1h"] < 1.0) | (df["change_pct_1h"].shift(12) > -5.0) | (df["RSI_14_1h"].shift(12) < 80.0)
@@ -24043,7 +24046,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h strong down move
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_14_change_pct_1h"] < 70.0))
           # 15m down move, 4h & 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
           # 15m down move, 1h strong down move, 4h stil high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h & 4h still high
@@ -24063,7 +24066,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h downtrend, 4h not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["CMF_20_4h"] > -0.25) | (stochrsi_k_4h > 70.0))
           # 1h down move, 4h high, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_14_4h > 40.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_14_4h > 40.0) | roc_9_1d_gt_neg_50)
           # 1h down move, 4h strong down move
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_4h"] < 40.0))
           # 1h & 4h down move, 4h still going down
@@ -24086,11 +24089,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h downtrend, 4h still high, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_4h > 70.0) | (roc_9_1d < 60.0))
           # 15m down move, 1h strong down move, 1d overbought
-          short_entry_logic.append((df["MFI_14_15m"] < 80.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((df["MFI_14_15m"] < 80.0) | (df["RSI_3_change_pct_1h"] < 80.0) | roc_9_1d_gt_neg_50)
           # 1h not low enough, 4h high, 1d strong downtrend
           short_entry_logic.append((stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((df["RSI_3_change_pct_1h"] < 65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((df["RSI_3_change_pct_1h"] < 65.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 15m strong down move, 1h still high
           short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 30.0))
           # 15m downtrend, 4h down move, 4h stil high
@@ -24100,10 +24103,10 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h P&D, 4h still high
           short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h > 30.0))
           # 1h downtrend, 4h down move, 1d downtrend
-          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h < 90.0) | roc_9_1d_lt_50)
           short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
           # 4h down move, 1d P&D
-          short_entry_logic.append((roc_9_4h < 20.0) | (df["ROC_2_1d"] < 20.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((roc_9_4h < 20.0) | (df["ROC_2_1d"] < 20.0) | roc_9_1d_gt_neg_50)
           # 1h P&D, 4h overbought
           short_entry_logic.append(
             (df["change_pct_1h"] < 2.0) | (df["change_pct_1h"].shift(12) > 2.0) | (rsi_14_4h > 20.0)
@@ -24162,7 +24165,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 90.0) | (stochrsi_k_15m > 70.0))
           # 15m & 4h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | roc_9_1d_lt_50)
           # 15m & 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 80.0) | (rsi_14_4h > 60.0))
           # 15m up move, 15m still not high enough, 4h still low
@@ -24315,7 +24318,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (df["UO_7_14_28_4h"] > 60.0) | (roc_9_4h < 20.0)
           )
           # 15m & 1h down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | roc_9_1d_lt_50)
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 55.0))
           # 15m down move, 15m still not low enough, 1h still high
@@ -24339,11 +24342,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h > 50.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h > 50.0) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h < 90.0) | (rsi_3_1d < 90.0) | (roc_9_1d < 60.0))
           # 4h overbought, 1h still high, 1d downtrend
-          short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h > 70.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h > 70.0) | roc_9_1d_lt_50)
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
             (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)


### PR DESCRIPTION
## Summary
- Reuses exact boolean comparison masks for entry ROC 1d threshold masks inside X7 `populate_entry_trend`.
- Branch is independent on latest upstream `main`.

## Safety
- Only exact already-used Series comparison expressions are bound once and reused in the same function.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- Touched function: `populate_entry_trend`.
- No v3 grind-entry code is touched.

## Backtest scope
Full backtesting was not required because this patch only reuses exact boolean masks for comparisons already evaluated in the same `populate_entry_trend` call. It does not change formulas, thresholds, condition order, or trading conditions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- validator AST undefined-local scan
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
