### PR TITLE
Consolidate X7 entry Series and masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12656,6 +12656,64 @@ class NostalgiaForInfinityX7(IStrategy):
     roc_9_15m = df["ROC_9_15m"]
     rsi_14_4h = df["RSI_14_4h"]
 
+    # Reused entry Series and comparison masks
+    aroond_14 = df["AROOND_14"]
+    aroond_14_15m = df["AROOND_14_15m"]
+    aroond_14_1h = df["AROOND_14_1h"]
+    aroond_14_4h = df["AROOND_14_4h"]
+    aroonu_14 = df["AROONU_14"]
+    bbb_20_2_0_1h = df["BBB_20_2.0_1h"]
+    cci_20_change_pct_1h = df["CCI_20_change_pct_1h"]
+    cci_20_change_pct_4h = df["CCI_20_change_pct_4h"]
+    change_pct_1d = df["change_pct_1d"]
+    change_pct_1h = df["change_pct_1h"]
+    change_pct_4h = df["change_pct_4h"]
+    close_max_12 = df["close_max_12"]
+    close_max_48 = df["close_max_48"]
+    cmf_20_15m = df["CMF_20_15m"]
+    cmf_20_1d = df["CMF_20_1d"]
+    cmf_20_1h = df["CMF_20_1h"]
+    cmf_20_4h = df["CMF_20_4h"]
+    ema_12 = df["EMA_12"]
+    ema_20 = df["EMA_20"]
+    ema_26 = df["EMA_26"]
+    ema_9 = df["EMA_9"]
+    high_max_12_1d = df["high_max_12_1d"]
+    high_max_12_4h = df["high_max_12_4h"]
+    high_max_20_1d = df["high_max_20_1d"]
+    high_max_24_4h = df["high_max_24_4h"]
+    high_max_30_1d = df["high_max_30_1d"]
+    high_max_6_1d = df["high_max_6_1d"]
+    high_max_6_4h = df["high_max_6_4h"]
+    low_min_12_1d = df["low_min_12_1d"]
+    low_min_24_4h = df["low_min_24_4h"]
+    mfi_14_15m = df["MFI_14_15m"]
+    mfi_14_1h = df["MFI_14_1h"]
+    num_empty_288 = df["num_empty_288"]
+    protections_long_global = df["protections_long_global"]
+    protections_short_global = df["protections_short_global"]
+    roc_2 = df["ROC_2"]
+    roc_9 = df["ROC_9"]
+    rsi_14 = df["RSI_14"]
+    rsi_14_15m = df["RSI_14_15m"]
+    rsi_14_1d = df["RSI_14_1d"]
+    rsi_14_1h = df["RSI_14_1h"]
+    rsi_20 = df["RSI_20"]
+    rsi_3_change_pct_1h = df["RSI_3_change_pct_1h"]
+    rsi_3_change_pct_4h = df["RSI_3_change_pct_4h"]
+    rsi_4 = df["RSI_4"]
+    sma_16 = df["SMA_16"]
+    sma_200 = df["SMA_200"]
+    stochrsi_k = df["STOCHRSIk_14_14_3_3"]
+    top_wick_pct_1d = df["top_wick_pct_1d"]
+    willr_14 = df["WILLR_14"]
+    aroonu_14_4h_lt_70 = aroonu_14_4h < 70.0
+    roc_9_1d_gt_neg_50 = roc_9_1d > -50.0
+    roc_9_1d_lt_50 = roc_9_1d < 50.0
+    rsi_3_15m_gt_3 = rsi_3_15m > 3.0
+    rsi_3_1h_gt_20 = rsi_3_1h > 20.0
+    rsi_3_4h_gt_20 = rsi_3_4h > 20.0
+
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
     current_free_slots = config["max_open_trades"]
@@ -12708,12 +12766,12 @@ class NostalgiaForInfinityX7(IStrategy):
         # Condition #1 - Normal mode (Long).
         if long_entry_condition_index == 1:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 15m & 1h down move
-            ((rsi_3 > 3.0) | (rsi_3_15m > 3.0) | (df["RSI_3_change_pct_1h"] > -50.0))
+            ((rsi_3 > 3.0) | rsi_3_15m_gt_3 | (rsi_3_change_pct_1h > -50.0))
             # 5m & 15m down move, 5h high
             & ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (rsi_14_4h < 60.0))
             # 5m & 15m down move, 4h high
@@ -12725,69 +12783,69 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
             # 5m & 1h down move, 15m still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m down move, 15m high
             & ((rsi_3 > 3.0) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h downtrend, 1h high
-            & ((rsi_3_15m > 1.0) | (df["CMF_20_1h"] > -0.1) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 1.0) | (cmf_20_1h > -0.1) | (aroonu_14_1h < 70.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h & 1d down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (df["CMF_20_15m"] > -0.40) | (roc_9_15m > -20.0))
+            & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.40) | (roc_9_15m > -20.0))
             # 15m down move, 15m still high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 40.0) | (roc_9_15m > -20.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 40.0) | (roc_9_15m > -20.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_15m > -20.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_15m > -20.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 15m down move, drop in last half hour, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (close > (df["close_max_6"] * 0.75)) | (roc_9_15m > -20.0))
+            & (rsi_3_15m_gt_3 | (close > (df["close_max_6"] * 0.75)) | (roc_9_15m > -20.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d < 40.0))
             # 5m & 1h down move, 1h overbought
@@ -12819,9 +12877,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (rsi_14_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (rsi_14_4h < 80.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h < 80.0))
             # 15m & 4h down move, 1h high
@@ -12841,7 +12899,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
             # 15m down move & downtrend, 4h high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.3) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high & overbought
@@ -12853,7 +12911,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -25.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 1d overbought
@@ -12861,9 +12919,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (df["RSI_14_15m"] < 50.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_14_15m < 50.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m & 1h high
@@ -12895,15 +12953,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.3))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.3))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (roc_9_1d < 40.0))
             # 1h & 1d down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h still high, 4h high
@@ -12919,7 +12977,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_14_4h < 75.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h overbought
@@ -12927,13 +12985,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
             # 1h down mve, 4h high, 1d overbought
@@ -12943,17 +13001,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (roc_9_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (roc_9_4h < 80.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 90.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15n downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_15m > -20.0))
             # 1h down move, 1h still high, 1d overbought
@@ -12969,7 +13027,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 40.0) | (df["CMF_20_1h"] > -0.25) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h > 40.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 15m downtrend
@@ -13005,15 +13063,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 45.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 60.0))
             # 1d down move, 1h high, 1d downtrend
@@ -13027,11 +13085,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h still high, 1d overbought
             & ((rsi_3_1d > 50.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d overbought
-            & ((df["RSI_3_change_pct_1h"] > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_change_pct_1h > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m & 1h & 4h downtrend
-            & ((df["CMF_20_15m"] > -0.3) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.3))
+            & ((cmf_20_15m > -0.3) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.3))
             # 15m high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_1d < 80.0))
             # 1h still high, 1h & 4h downtrend
@@ -13043,13 +13101,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought, 1d downtrend
             & ((aroonu_14_1h < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1d > -40.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 90.0) | (roc_9_1h > -10.0) | (roc_9_4h > -20.0))
             # 1d high, 4h & 1d overbought
@@ -13061,58 +13119,58 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -40.0))
             # 5m down move, 15m still not low enough, 1h high
-            & ((df["ROC_2"] > -10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
+            & ((roc_2 > -10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
             # 5m down move, 15m still high
-            & ((df["ROC_2"] > -10.0) | (aroonu_14_15m < 50.0))
+            & ((roc_2 > -10.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 15m & 1h down move, 15m still high
-            & ((df["ROC_9"] > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
+            & ((roc_9 > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 4h down move, 15m downtrend, 1h high
-            & ((df["ROC_9"] > -15.0) | (rsi_3_4h > 45.0) | (df["CMF_20_15m"] > -0.3) | (aroonu_14_1h < 60.0))
+            & ((roc_9 > -15.0) | (rsi_3_4h > 45.0) | (cmf_20_15m > -0.3) | (aroonu_14_1h < 60.0))
             # 1h downtrend, 4h high & overbought
             & ((roc_9_1h > -25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
             & ((roc_9_1h < 20.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
             # 1d P&D, 1d downtrend
-            & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.0))
+            & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.0))
             # 1d green with top wick, 1h down move
-            & ((df["change_pct_1d"] < 20.0) | (df["top_wick_pct_1d"] < 15.0) | (rsi_3_1h > 20.0))
+            & ((change_pct_1d < 20.0) | (top_wick_pct_1d < 15.0) | rsi_3_1h_gt_20)
             # 1d green with top wick, 4h high
-            & ((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 25.0) | (aroonu_14_4h < 80.0))
+            & ((change_pct_1d < 25.0) | (top_wick_pct_1d < 25.0) | (aroonu_14_4h < 80.0))
             # 1d green, 1h down move, 1d downtrend
-            & ((df["change_pct_1d"] < 40.0) | (rsi_3_1h > 25.0) | (df["CMF_20_1d"] > -0.2))
+            & ((change_pct_1d < 40.0) | (rsi_3_1h > 25.0) | (cmf_20_1d > -0.2))
             # 1d green with top wick, 4h overbought
-            & ((df["change_pct_1d"] < 50.0) | (df["top_wick_pct_1d"] < 30.0) | (roc_9_4h < 80.0))
+            & ((change_pct_1d < 50.0) | (top_wick_pct_1d < 30.0) | (roc_9_4h < 80.0))
             # big drop in the last hour, 15m downtrend
-            & ((close > (df["close_max_12"] * 0.65)) | (df["CMF_20_15m"] > -0.5))
+            & ((close > (close_max_12 * 0.65)) | (cmf_20_15m > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
-            & ((close > (df["high_max_6_1h"] * 0.60)) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0))
+            & ((close > (df["high_max_6_1h"] * 0.60)) | rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0))
             # big drop in the last 24 hours,  1h still high
             & ((close > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 4 days, 1h high
-            & ((close > (df["high_max_24_4h"] * 0.20)) | (aroonu_14_1h < 70.0))
+            & ((close > (high_max_24_4h * 0.20)) | (aroonu_14_1h < 70.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["EMA_26"] > df["EMA_12"])
-            & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.034))
-            & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
+            (ema_26 > ema_12)
+            & ((ema_26 - ema_12) > (df["open"] * 0.034))
+            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
             & (close < (df["BBL_20_2.0"] * 0.999))
           )
 
         # Condition #2 - Normal mode (Long).
         if long_entry_condition_index == 2:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
             ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1d high
@@ -13130,7 +13188,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1d down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (df["CMF_20_1d"] > -0.25))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high
@@ -13156,73 +13214,73 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 1.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (df["CMF_20_15m"] > -0.30))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (aroonu_14_15m < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d > -40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (df["CMF_20_15m"] > -0.40))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 60.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (rsi_14_4h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (rsi_14_4h < 30.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (df["CMF_20_4h"] > -0.35))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (cmf_20_4h > -0.35))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h still high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (df["CMF_20_15m"] > -0.35))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 3.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & (rsi_3_15m_gt_3 | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 4h still high
@@ -13234,7 +13292,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1d still high, 4h still high
-            & ((rsi_3_1d > 50.0) | (df["RSI_14_1d"] < 50.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1d > 50.0) | (rsi_14_1d < 50.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -13252,7 +13310,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (roc_9_1d < 10.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 40.0))
             # 15m & 1d down move, 15m still not low enough
@@ -13260,7 +13318,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m downtrend, 4h still not low enough
-            & ((rsi_3_15m > 5.0) | (df["CMF_20_15m"] > -0.30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m stil high, 1h still high
@@ -13284,13 +13342,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 75.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | roc_9_1d_gt_neg_50)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h still high
@@ -13316,7 +13374,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 1d high
@@ -13326,21 +13384,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (df["RSI_14_1d"] < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (rsi_14_1d < 40.0))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 20.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m sill high, 4h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 4h high, 1d downtrend
@@ -13348,7 +13406,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 4h high
@@ -13364,7 +13422,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1d down move, 4h high
@@ -13394,9 +13452,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_4h < 50.0))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 80.0))
             # 15m & 1h down move, 4h high
@@ -13406,7 +13464,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h & 4h high
@@ -13430,13 +13488,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high & overbought
@@ -13454,7 +13512,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 1.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -10.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
@@ -13464,13 +13522,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 15m still high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h high
@@ -13480,7 +13538,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h % 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (cmf_20_4h > -0.30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 15m high
@@ -13490,7 +13548,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d still high
@@ -13512,7 +13570,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 15m still high
@@ -13520,7 +13578,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d high
@@ -13528,7 +13586,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1d high
@@ -13540,7 +13598,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
@@ -13548,23 +13606,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d downtrend
@@ -13574,7 +13632,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -13664,29 +13722,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high. 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 35.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h high, 1d overbought
@@ -13694,7 +13752,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 40.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
@@ -13702,15 +13760,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d overbought
@@ -13726,7 +13784,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h overbought, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (roc_9_1h < 20.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 15.0) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
@@ -13738,15 +13796,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | roc_9_1d_lt_50)
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -40.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4high, 1d downtrend
@@ -13762,9 +13820,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 40.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h high & overbought
-            & ((aroonu_14_4h < 70.0) | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 4h high, 1h & 4h overbought
@@ -13780,7 +13838,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d overbought
             & ((stochrsi_k_15m < 70.0) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h downtrend
@@ -13794,28 +13852,28 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
           )
 
           # Logic
           long_entry_logic.append(
             # (df["RSI_3"] > 5.0)
-            (df["AROONU_14"] < 30.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
+            (aroonu_14 < 30.0)
+            & (stochrsi_k < 30.0)
             # & (rsi_3_15m > 5.0)
             & (aroonu_14_15m < 50.0)
-            & (close < (df["EMA_20"] * 0.948))
+            & (close < (ema_20 * 0.948))
           )
 
         # Condition #3 - Normal mode (Long).
         if long_entry_condition_index == 3:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 4h down move, 1h still high
@@ -13843,7 +13901,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
@@ -13851,7 +13909,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h still high
@@ -13863,17 +13921,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 15m & 1d down move, 15m high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 4h downtrend. 15m high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_4h"] > -0.30) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.30) | (aroonu_14_15m < 60.0))
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 15m high, 4h downtrend
@@ -13885,13 +13943,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h high, 1d overbought
@@ -13907,13 +13965,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 75.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1d down move, 1h still high
@@ -13929,9 +13987,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -40.0))
             # 15m down move, 15m high, 4h overbought
@@ -13943,11 +14001,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 1h high, 1d overbought
@@ -13981,7 +14039,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 15m down move, 1h high, 1d overbought
@@ -13995,29 +14053,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h high
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_4h < 50.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 40.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1d high, 15m high
-            & ((rsi_3_15m > 30.0) | (df["RSI_14_1d"] < 70.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 30.0) | (rsi_14_1d < 70.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 15m high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -40.0))
             # 15m down move, 15m high, 15m downtrend
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (cmf_20_15m > -0.30))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 70.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 60.0))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m high, 4h overbought
@@ -14027,7 +14085,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 200.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 15m high, 1h downtrend
@@ -14043,13 +14101,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 4h downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 10.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d overbought
@@ -14057,11 +14115,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1d still high
@@ -14073,7 +14131,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 1h still high 1d overbought
@@ -14093,7 +14151,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70)
             # 1h down move, 15m & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 1h & 4h high
@@ -14101,13 +14159,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 35.0) | (df["CMF_20_1h"] > -0.30) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 35.0) | (cmf_20_1h > -0.30) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 70.0))
             # 1h & 4h down move, 4h high
@@ -14115,9 +14173,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h still high, 1d overbought
@@ -14129,9 +14187,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (df["CMF_20_1d"] > -0.20))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 15m high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 4h overbought
@@ -14213,27 +14271,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 55.0) | (roc_9_1d < 50.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 55.0) | roc_9_1d_lt_50)
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 15m high, 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0) | (stochrsi_k_1d < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 80.0) | (roc_9_4h > -50.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still not low enough, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -10.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d high
@@ -14245,25 +14303,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 1d downtrend, 1d overbought
-            & ((rsi_3_4h > 30.0) | (df["CMF_20_1d"] > -0.30) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 30.0) | (cmf_20_1d > -0.30) | (roc_9_1d < 40.0))
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 1h high, 1d downtrend
@@ -14271,7 +14329,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still high, 1h high
@@ -14287,7 +14345,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h & 4h high
@@ -14325,7 +14383,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1h high
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
             # 4h down move, 1d high, 4h overbought
@@ -14337,7 +14395,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h high & overbought
@@ -14345,23 +14403,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h > 60.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 15m still high, 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -60.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
             # 1d down move, 4h & 1d downtrend
@@ -14393,15 +14451,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1d > 40.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 15m still high, 4h high, 1d overbought
             & ((aroonu_14_15m < 50.0) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
             # 15m still high, 1h downtrend, 4h overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_1h > -10.0) | (roc_9_4h < 40.0))
             # 15m high, 4h high & overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 10.0))
+            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 10.0))
             # 15m high, 15m & 4h overbought
             & ((aroonu_14_15m < 60.0) | (roc_9_15m < 10.0) | (roc_9_4h < 20.0))
             # 15m high, 4h downtrend
@@ -14409,17 +14467,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h high
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h & 1d high
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
             # 15m & 4h high, 4h overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 15m & 4h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 15m high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h high, 1d high & overbought
@@ -14443,7 +14501,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 15m & 1h high, 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 15m & 1d high
             & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d < 90.0))
             # 1h high, 4h & 1d downtrend
@@ -14457,44 +14515,44 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 4h & 1d downtrend
             & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 1d P&D, 4h downtrend
-            & ((df["change_pct_1d"] > -50.0) | (df["change_pct_1d"].shift(288) < 50.0) | (rsi_3_4h > 15.0))
+            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # 1d P&D, 15m high
-            & ((df["change_pct_1d"] > -20.0) | (df["change_pct_1d"].shift(288) < 20.0) | (aroonu_14_15m < 70.0))
+            & ((change_pct_1d > -20.0) | (change_pct_1d.shift(288) < 20.0) | (aroonu_14_15m < 70.0))
             # 1d red with top wick, 4h high
-            & ((df["change_pct_1d"] > -20.0) | (df["top_wick_pct_1d"] < 20.0) | (aroonu_14_4h < 80.0))
+            & ((change_pct_1d > -20.0) | (top_wick_pct_1d < 20.0) | (aroonu_14_4h < 80.0))
             # 1d red, previous 1d top wick, 15m high
-            & ((df["change_pct_1d"] > -10.0) | (df["top_wick_pct_1d"].shift(288) < 40.0) | (aroonu_14_15m < 70.0))
+            & ((change_pct_1d > -10.0) | (top_wick_pct_1d.shift(288) < 40.0) | (aroonu_14_15m < 70.0))
             # 1d green with top wick, 4h overbought
-            & ((df["change_pct_1d"] < 15.0) | (df["top_wick_pct_1d"] < 15.0) | (roc_9_4h < 20.0))
+            & ((change_pct_1d < 15.0) | (top_wick_pct_1d < 15.0) | (roc_9_4h < 20.0))
             # 1d green, 15m down move, 1h high
-            & ((df["change_pct_1d"] < 50.0) | (rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0))
+            & ((change_pct_1d < 50.0) | (rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0))
             # 1d green, 4h down move, 4h still high
-            & ((df["change_pct_1d"] < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+            & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
             # 1d top wick, 4h down move, 1d overbought
-            & ((df["top_wick_pct_1d"] < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_20"] < df["RSI_20"].shift(1))
-            & (df["RSI_4"] < 45.0)
-            & (df["RSI_14"] > 30.0)
-            & (df["AROONU_14"] < 20.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (close < df["SMA_16"] * 0.965)
+            (rsi_20 < rsi_20.shift(1))
+            & (rsi_4 < 45.0)
+            & (rsi_14 > 30.0)
+            & (aroonu_14 < 20.0)
+            & (stochrsi_k < 20.0)
+            & (close < sma_16 * 0.965)
             & (close < df["SMA_16_1h"] * 0.985)
           )
 
         # Condition #4 - Normal mode (Long).
         if long_entry_condition_index == 4:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
-            (rsi_3_15m > 3.0)
+            rsi_3_15m_gt_3
             # 5m & 1h down move, 1d still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1d < 40.0))
             # 5m & 1h & 4h down move
@@ -14504,7 +14562,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0))
             # 5m & 1h down move, 1h still high
@@ -14512,7 +14570,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high, 4h overbought
@@ -14528,7 +14586,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 1d overbought
@@ -14542,17 +14600,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0))
             # 15m & 1h down move, 1h still high
@@ -14560,13 +14618,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high, 1h overbought
@@ -14584,9 +14642,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (cmf_20_15m > -0.40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 15m still high
@@ -14602,7 +14660,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (df["CMF_20_1h"] > -0.40))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (cmf_20_1h > -0.40))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d overbought
@@ -14614,7 +14672,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h & 3h down move, 1d high
@@ -14644,15 +14702,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high & overbought
@@ -14710,23 +14768,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -10.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h still high, 4h & 1d downtrend
@@ -14742,9 +14800,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h high, 1h & 1d overbought
@@ -14756,37 +14814,34 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 20.0) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["AROONU_14"] < 25.0)
-            & (aroonu_14_15m < 25.0)
-            & (close < (df["EMA_9"] * 0.946))
-            & (close < (df["EMA_20"] * 0.960))
+            (aroonu_14 < 25.0) & (aroonu_14_15m < 25.0) & (close < (ema_9 * 0.946)) & (close < (ema_20 * 0.960))
           )
 
         # Condition #5 - Normal mode (Long).
         if long_entry_condition_index == 5:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             (rsi_3_15m > 20.0)
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 15m still high
@@ -14812,7 +14867,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -14850,11 +14905,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (roc_9_1h > -15.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 15m still high
@@ -14878,7 +14933,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m high, 4h downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -14890,13 +14945,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1d high, 1d downtrend
@@ -14910,15 +14965,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d downtrend
@@ -14938,9 +14993,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d over
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h & 4h high
@@ -14960,7 +15015,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h overbought
@@ -14972,7 +15027,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1h overbought
@@ -15004,7 +15059,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 15m downtrend, 1d high
-            & ((rsi_3_4h > 10.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h > 10.0) | (cmf_20_15m > -0.30) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
             # 4h down move, 15m high
@@ -15024,13 +15079,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1ddown move, 1d high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high. 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 1h high, 4h downtrend
@@ -15038,7 +15093,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d overbought
@@ -15050,15 +15105,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 4h downtrend
             & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h > -30.0))
             # 15m & 1h & 4h downtrend
-            & ((df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30) | (df["CMF_20_4h"] > -0.30))
+            & ((cmf_20_15m > -0.30) | (cmf_20_1h > -0.30) | (cmf_20_4h > -0.30))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m not low enough, 1h & 4h downtrend
             & ((aroonu_14_15m < 20.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h & 1d high, 1d overbought
@@ -15066,7 +15121,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
@@ -15102,30 +15157,30 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
-            & ((df["change_pct_1d"] > -50.0) | (df["change_pct_1d"].shift(288) < 50.0) | (rsi_3_4h > 15.0))
+            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
           )
 
           # Logic
           long_entry_logic.append(
             (rsi_3 < 50.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
-            & (df["EMA_26"] > df["EMA_12"])
-            & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.020))
-            & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
+            & (aroonu_14 < 25.0)
+            & (stochrsi_k < 30.0)
+            & (ema_26 > ema_12)
+            & ((ema_26 - ema_12) > (df["open"] * 0.020))
+            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
           )
 
         # Condition #6 - Normal mode (Long).
         if long_entry_condition_index == 6:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
@@ -15137,13 +15192,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (roc_9_1d > -30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 4h still high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0))
             # 5m & 4h & 1d down move
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 35.0))
+            & ((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 35.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 70.0))
             # 5m & 4h down move, 4h still high
@@ -15177,35 +15232,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d still high
             & ((rsi_3 > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 20.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 30.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (roc_9_1d > -10.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 20.0))
+            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 20.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (aroonu_14_15m < 25.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1d down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 55.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 55.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d downtrend, 1d high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h still high
@@ -15215,13 +15270,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0))
             # 15m & 1h & 4h down move, 15m downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (df["CMF_20_15m"] > -0.30))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
@@ -15233,11 +15288,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h still not low enough
             & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 4h high
@@ -15267,27 +15322,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
@@ -15299,9 +15354,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 20.0))
             # 15m down move, 15m downtrend, 4h still high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_15m"] > -0.40) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | (stochrsi_k_4h < 50.0))
             # 15m down move, 1h downtrend, 4h still high
-            & ((rsi_3_15m > 10.0) | (df["CMF_20_1h"] > -0.30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_1h > -0.30) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
@@ -15321,11 +15376,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
@@ -15337,9 +15392,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 4h high
@@ -15363,7 +15418,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
@@ -15377,9 +15432,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 25.0))
             # 15m down move, 4h high, 1h overbought
@@ -15391,7 +15446,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h overbought
@@ -15407,9 +15462,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h < 90.0))
             # 15m & 4h & 1d down move
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 1h high
@@ -15421,13 +15476,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m down move, 1d high, 4h downtrend
@@ -15441,7 +15496,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15 down move, 1h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 10.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 70.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 70.0) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
             # 15m & 1h down move, 1h still high
@@ -15473,7 +15528,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
@@ -15529,11 +15584,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h still high
@@ -15547,9 +15602,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h still high
@@ -15559,23 +15614,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 4h overbought
@@ -15585,7 +15640,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["RSI_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 4h high
@@ -15593,7 +15648,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h & 1d down move
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 1d still high, 1d downtrend
@@ -15607,13 +15662,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 35.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 35.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 35.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1h high
@@ -15629,7 +15684,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -15.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h overbought
@@ -15689,7 +15744,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
@@ -15699,23 +15754,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 80.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d high
@@ -15731,7 +15786,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
@@ -15747,13 +15802,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 60.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
@@ -15771,23 +15826,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
             # 1d down move, 4h downtrend, 4h high
-            & ((rsi_3_1d > 20.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1d > 20.0) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 4h downtrend, 4h high & over
-            & ((df["CMF_20_4h"] > -0.10) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
+            & ((cmf_20_4h > -0.10) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
             # 15m still high, 4h high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 15m still high, 4h high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
@@ -15803,15 +15858,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 50.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h &1d overbought
             & ((aroonu_14_1h < 85.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 15.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h high, 4h overbought, 1d downtrend
@@ -15819,13 +15874,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
             # 1d high, 1d downtrend
             & ((aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
             # 15m still not low enough, 4h high, 1d overbought
@@ -15839,7 +15894,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 50.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
             # 1h high & overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 4h high, 1h & 4h overbought
@@ -15849,7 +15904,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 4h high, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 4h high, 1h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
@@ -15857,30 +15912,30 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d hihg, 1h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
-            & ((df["change_pct_1d"] > -50.0) | (df["change_pct_1d"].shift(288) < 50.0) | (rsi_3_4h > 15.0))
+            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_20"] < df["RSI_20"].shift(1))
+            (rsi_20 < rsi_20.shift(1))
             & (rsi_3 < 46.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (aroonu_14 < 25.0)
+            & (stochrsi_k < 20.0)
             & (aroonu_14_15m < 50.0)
-            & (close < df["SMA_16"] * 0.960)
+            & (close < sma_16 * 0.960)
           )
 
         # Condition #21 - Pump mode (Long).
         if long_entry_condition_index == 21:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          # long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          # long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m down move, 4h high, 1h overbought
@@ -15888,7 +15943,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
@@ -15902,7 +15957,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 15m down move, 1d high, 1d downtrend
@@ -15918,7 +15973,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (df["CMF_20_4h"] > -0.25))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (cmf_20_4h > -0.25))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
             # 15m down move, 4h & 1d overbought
@@ -15954,21 +16009,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought, 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 50.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 50.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 40.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
             # 1h down move, 4h high & overbought
@@ -15976,7 +16031,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
@@ -16022,7 +16077,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1d down move, 1h high, 1d overbought
@@ -16030,7 +16085,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 65.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m not low enough, 1h high, 1d overbought
             & ((aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
@@ -16052,7 +16107,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 4h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 15m downtrend
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -40.0))
             # 1h & 4h high, 1h overbought
@@ -16060,7 +16115,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h overbought, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (df["CMF_20_4h"] > -0.30))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (cmf_20_4h > -0.30))
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 20.0))
             # 4h & 1d high, 4h overbought
@@ -16082,7 +16137,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h high, 4h overbought. 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0) | (df["CMF_20_1d"] > -0.25))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0) | (cmf_20_1d > -0.25))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h high & 4h & 1d overbought
@@ -16097,8 +16152,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            (aroonu_14 < 25.0)
+            & (stochrsi_k < 20.0)
             & (aroonu_14_15m < 50.0)
             & (close < df["EMA_16"] * 0.960)
             & (((df["EMA_50"] - df["EMA_200"]) / close * 100.0) > 6.0)
@@ -16107,64 +16162,64 @@ class NostalgiaForInfinityX7(IStrategy):
         # Condition #41 - Quick mode (Long).
         if long_entry_condition_index == 41:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          # long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          # long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 1d down move, 4h still high
             ((rsi_3 > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 75.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (aroonu_14_4h < 80.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h still high, 1d high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 80.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 3.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1d high
@@ -16174,13 +16229,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -70.0))
             # 15m down move, 1h & 4h high
@@ -16206,7 +16261,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 20.0))
             # 15m & 1h down move, 1d overbought
@@ -16240,7 +16295,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
@@ -16252,7 +16307,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1d down move, 4h high
@@ -16276,7 +16331,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h downtrend, 4h overbought
@@ -16284,15 +16339,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0))
             # 15m &4h down move, 4h still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 4h downtrend
@@ -16300,7 +16355,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 4h high
@@ -16328,13 +16383,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 15m & 1h downtrend
-            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.30) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.30) | (cmf_20_1h > -0.30))
             # 1h down move, 1h still high, 1h downtrend
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (roc_9_1h > -20.0))
             # 1h down move, 1h high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -16350,9 +16405,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (cmf_20_1h > -0.30))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 1h down move, 1d high, 1h downtrend
@@ -16364,9 +16419,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_4h > -25.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1h high
@@ -16384,9 +16439,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_15m > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1d high
@@ -16402,9 +16457,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (df["CMF_20_1h"] > -0.40))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (cmf_20_1h > -0.40))
             # 1h down move, 1d downtrend, 4h high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1d > -0.30) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
@@ -16412,7 +16467,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d < 90.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 10.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h downtrend
@@ -16420,25 +16475,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h downtrend, 1h still high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1h > -0.30) | (stochrsi_k_1h < 40.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (df["CMF_20_1h"] > -0.25))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (cmf_20_1h > -0.25))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d overbought
@@ -16458,31 +16513,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (roc_9_4h < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d > -50.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 15m still high, 1h high
@@ -16494,7 +16549,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h still high, 1d overbought
@@ -16504,7 +16559,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 4h overbought
             & ((rsi_3_1h > 25.0) | (roc_9_15m > -25.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h & 1d downtrend
-            & ((rsi_3_1h > 25.0) | (roc_9_1h > -50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_1h > -50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h overbought
@@ -16514,9 +16569,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 30.0) | (df["CMF_20_1h"] > -0.25) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1h > 30.0) | (cmf_20_1h > -0.25) | (stochrsi_k_1h < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 30.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 30.0) | (cmf_20_4h > -0.50) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
@@ -16528,7 +16583,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high, 4h downtrend
@@ -16540,7 +16595,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
@@ -16582,7 +16637,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_4h > 3.0) | aroonu_14_4h_lt_70 | (roc_9_1h > -40.0))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d still high
@@ -16590,7 +16645,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
@@ -16604,11 +16659,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high
@@ -16624,7 +16679,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
             # 4h down move, 1d high & overbought
@@ -16654,13 +16709,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m downtrend, 4h & 1d high
-            & ((df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((cmf_20_15m > -0.30) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h high, 1h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h & 4h high, 1h downtrend
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (df["CMF_20_1h"] > -0.30))
+            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (cmf_20_1h > -0.30))
             # 1h high, 4h high, 1h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
@@ -16678,7 +16733,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
@@ -16694,13 +16749,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1h < 50.0))
             # 1d still high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -50.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h overbought
@@ -16712,25 +16767,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
             # 1d P&D, 4h overbought
-            & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 30.0) | (roc_9_4h < 10.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 30.0) | (roc_9_4h < 10.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 > 5.0)
-            & (df["RSI_14"] < 36.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["AROOND_14"] > 75.0)
-            & (df["EMA_9"] < (df["EMA_26"] * 0.960))
+            (rsi_3 > 5.0) & (rsi_14 < 36.0) & (aroonu_14 < 25.0) & (aroond_14 > 75.0) & (ema_9 < (ema_26 * 0.960))
           )
 
         # Condition #42 - Quick mode (Long).
         if long_entry_condition_index == 42:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          # long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          # long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 1h down move, 1d still high
@@ -16738,27 +16789,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (roc_9_1h > -50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (roc_9_1h > -50.0))
             # 15m & 1h down move, 1d still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_1d < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1d < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m down move, 4h still high, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | rsi_3_4h_gt_20)
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
@@ -16772,7 +16823,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h still high
@@ -16784,9 +16835,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 4h still high
@@ -16794,29 +16845,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h high, 1d downtrend
@@ -16832,11 +16883,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 4h high
@@ -16876,11 +16927,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1d high
@@ -16890,23 +16941,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1d < 50.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (df["RSI_14_1d"] < 50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (rsi_14_1d < 50.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
@@ -16916,7 +16967,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 15m still high
@@ -16938,7 +16989,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -16954,45 +17005,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 60.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h overbought
@@ -17002,7 +17053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 80.0))
             # 1h & 4h down move, 4h high
@@ -17014,9 +17065,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h overbought
@@ -17046,7 +17097,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 60.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h high & overbought
@@ -17062,7 +17113,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
             # 4h down move, 1h downtrend, 4h still high
-            & ((rsi_3_4h > 3.0) | (df["CMF_20_1h"] > -0.30) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h > 3.0) | (cmf_20_1h > -0.30) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d downtrend
@@ -17108,9 +17159,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (df["RSI_14_1d"] < 50.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (rsi_14_1d < 50.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -17122,29 +17173,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 15.0) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 90.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d < 70.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_4h > -50.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 70.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 4h & 1d down move, 1d high
@@ -17186,9 +17237,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h overbought, 1d downtrend
@@ -17218,9 +17269,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h downtrend, 4h high
-            & ((df["CMF_20_1h"] > -0.40) | (df["CMF_20_4h"] > -0.40) | (aroonu_14_4h < 80.0))
+            & ((cmf_20_1h > -0.40) | (cmf_20_4h > -0.40) | (aroonu_14_4h < 80.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (aroonu_14_1d < 85.0))
+            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 15m & 1d high, 4h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d downtrend
@@ -17232,9 +17283,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d downtrend
             & ((aroonu_14_4h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 1d high, 4h & 1d overbought
@@ -17256,24 +17307,24 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 4h & 1d downtrend
             & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["WILLR_14"] < -50.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            (willr_14 < -50.0)
+            & (stochrsi_k < 20.0)
             & (df["WILLR_84_1h"] < -70.0)
             & (stochrsi_k_1h < 20.0)
-            & (df["BBB_20_2.0_1h"] > 16.0)
-            & (df["close_max_48"] >= (close * 1.10))
+            & (bbb_20_2_0_1h > 16.0)
+            & (close_max_48 >= (close * 1.10))
           )
 
         # Condition #43 - Quick mode (Long).
         if long_entry_condition_index == 43:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          # long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          # long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
@@ -17301,75 +17352,75 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h & 1d down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_1d > 25.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_1d"] < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 200.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_1d < 10.0))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
+            & (rsi_3_15m_gt_3 | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 3.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
+            & (rsi_3_15m_gt_3 | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1h still high
@@ -17379,9 +17430,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 15m & 1h still high
@@ -17407,13 +17458,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 15m & 1h down move, 4h high
@@ -17439,7 +17490,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m still high, 1d downtrend
@@ -17467,11 +17518,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 15m down move. 15m still high, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m & 4h high
@@ -17481,7 +17532,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
@@ -17497,7 +17548,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1d down move, 4h high
@@ -17515,7 +17566,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (roc_9_1h > -30.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
@@ -17523,7 +17574,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 1d overbought
@@ -17535,11 +17586,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h & 1d downtrend
@@ -17559,7 +17610,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
@@ -17575,7 +17626,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
@@ -17589,15 +17640,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -40.0) | (roc_9_1d < 50.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
@@ -17625,7 +17676,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h downtrend
@@ -17693,9 +17744,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -17713,7 +17764,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 4h downtrend, 1h & 4h high
-            & ((df["CMF_20_4h"] > -0.30) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((cmf_20_4h > -0.30) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m still high, 1h & 4h overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 15m & 1d high, 1d overbought
@@ -17765,60 +17816,60 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought, 1d downtrend
             & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_14"] < 40.0)
+            (rsi_14 < 40.0)
             & (df["MFI_14"] < 40.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["EMA_26"] > df["EMA_12"])
-            & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.024))
-            & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
-            & (close < (df["EMA_20"] * 0.960))
+            & (aroonu_14 < 25.0)
+            & (ema_26 > ema_12)
+            & ((ema_26 - ema_12) > (df["open"] * 0.024))
+            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & (close < (ema_20 * 0.960))
             & (close < (df["BBL_20_2.0"] * 0.999))
           )
 
         # Condition #44 - Quick mode (Long).
         if long_entry_condition_index == 44:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          # long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          # long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 1h & 4h down move
             ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_15m > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_15m > -30.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 40.0))
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 40.0) | (roc_9_1d < 70.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 100.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 100.0) | (roc_9_4h < 100.0))
             # 15m down move, 1h high
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 70.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 70.0) | (roc_9_15m > -30.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_15m > -30.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h downtrend
@@ -17828,7 +17879,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
@@ -17846,9 +17897,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0))
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 50.0))
             # 1h down move, 1h still high, 1h downtrend
@@ -17870,7 +17921,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h & 1d downtrend
@@ -17884,13 +17935,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1h > -25.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1h > -25.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h still high
@@ -17910,7 +17961,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 4h still high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_15m"] > -0.40))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (cmf_20_15m > -0.40))
             # 1h down move, 4h still high, 4h downtrend
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -17928,7 +17979,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 10.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17938,7 +17989,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 4h high & overbought
@@ -17948,17 +17999,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 20.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 1h & 4h down ove, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h & 1d high
@@ -17996,7 +18047,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 4h down move, 4h still high, 1d overbought
@@ -18016,13 +18067,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 60.0))
             # 4h downtrend, 4h high
-            & ((df["CMF_20_4h"] > -0.50) | (aroonu_14_4h < 70.0))
+            & ((cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h & 1d high, 4h downtrend
             & ((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h still high, 1h & 4h downtrend
@@ -18030,7 +18081,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
+            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h downtrend
             & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0))
             # 1h & 1d high, 1d overbought
@@ -18062,7 +18113,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h still high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d > -50.0))
+            & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
@@ -18076,7 +18127,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 1d overbought
             & ((roc_9_1h > -60.0) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -18093,23 +18144,23 @@ class NostalgiaForInfinityX7(IStrategy):
         # Condition #45 - Quick mode (Long).
         if long_entry_condition_index == 45:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           # 5m & 15m down move, 4h still high
           long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
           # 5m & 4h & 1d down move
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
           # 15m & 4h down move
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 35.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (rsi_14_4h < 35.0))
           # 15m down move, 4h still high, 15m downtrend
-          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_4h < 40.0) | (df["CMF_20_15m"] > -0.35))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
           # 15m & 1h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0))
           # 15m & 1h down move, 4h high
@@ -18121,7 +18172,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 1d down move
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 10.0))
           # 15m & 1h down move, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
           # 15m & 1h down move, 1h high
@@ -18143,11 +18194,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
           # 15m & 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
           # 15m down move, 4h high & overbought
@@ -18165,7 +18216,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0))
           # 1h & 4h down move, 4h still not low enough
@@ -18175,7 +18226,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
           # 1h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
           # 15m & 1d down move, 1d high
@@ -18189,15 +18240,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
           # 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 1h still high
@@ -18207,15 +18258,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_4h < 90.0))
           # 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
           # 1h down move, 4h high
@@ -18233,7 +18284,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (stochrsi_k_1d < 80.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | roc_9_1d_lt_50)
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 1h & 4h high
@@ -18249,13 +18300,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 10.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (df["RSI_14_1d"] < 50.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (rsi_14_1d < 50.0))
           # 4h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_1h < 30.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 1d high
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1d < 90.0))
           # 4h down move, 4h & 1d downtrend
@@ -18279,13 +18330,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h high & overbought
           long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
           # 15m still high, 1h & 4h high
-          long_entry_logic.append((df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_14_15m < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
           # 4h high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 80.0))
           # 4h high, 1h & 1d downtrend
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h high, 1h & 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high & overbought
@@ -18301,49 +18352,45 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 1d top wick, 4h still high
-          long_entry_logic.append((df["top_wick_pct_1d"] < 40.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((top_wick_pct_1d < 40.0) | (aroonu_14_4h < 50.0))
           # pump, 4h still high
+          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0) | (stochrsi_k_4h < 50.0))
+          # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0) | (stochrsi_k_4h < 50.0)
+            (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
+            | (close > (high_max_6_4h * 0.75))
+            | (close < (low_min_24_4h * 1.25))
           )
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (close > (df["high_max_6_4h"] * 0.75))
-            | (close < (df["low_min_24_4h"] * 1.25))
-          )
-          # pump, drop but not yet near the previous lows
-          long_entry_logic.append(
-            (((df["high_max_12_1d"] - df["low_min_12_1d"]) / df["low_min_12_1d"]) < 2.0)
-            | (close > (df["high_max_24_4h"] * 0.70))
-            | (close < (df["low_min_12_1d"] * 1.25))
+            (((high_max_12_1d - low_min_12_1d) / low_min_12_1d) < 2.0)
+            | (close > (high_max_24_4h * 0.70))
+            | (close < (low_min_12_1d * 1.25))
           )
           # big drop in last hour
-          long_entry_logic.append(close > (df["close_max_12"] * 0.50))
+          long_entry_logic.append(close > (close_max_12 * 0.50))
           # big drop in last hour, 1d down move
-          long_entry_logic.append((close > (df["close_max_12"] * 0.80)) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((close > (close_max_12 * 0.80)) | (rsi_3_1d > 15.0))
           # big drop in the last 12 hours, 4h still high
           long_entry_logic.append((close > (df["high_max_12_1h"] * 0.50)) | (aroonu_14_4h < 50.0))
           # big drop in the last 6 days, 1h still high
-          long_entry_logic.append((close > (df["high_max_6_1d"] * 0.25)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (high_max_6_1d * 0.25)) | (aroonu_14_1h < 50.0))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.45)) | (rsi_3_1h > 5.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.45)) | (rsi_3_1h > 5.0))
           # big drop in the last 12 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.40)) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_4h > 15.0))
           # big drop in the last 12 days, 1h still high
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.25)) | (aroonu_14_1h < 75.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h < 75.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.35)) | (rsi_3_1h > 10.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.35)) | (rsi_3_1h > 10.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.25)) | (rsi_3_1h > 15.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.25)) | (rsi_3_1h > 15.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_1h > 20.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | rsi_3_1h_gt_20)
           # big drop in the last 20 days, 1d high, 1d downtrend
-          long_entry_logic.append(
-            (close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0)
-          )
+          long_entry_logic.append((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           # big drop in the last 30 days, 4h down move, 4h still high
-          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 45.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_4h > 45.0) | (rsi_14_4h < 40.0))
 
           # Logic
           long_entry_logic.append(rsi_3 < 50.0)
@@ -18354,17 +18401,17 @@ class NostalgiaForInfinityX7(IStrategy):
         # Condition #46 - Quick mode (Long).
         if long_entry_condition_index == 46:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           # 5m & 1h down move
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
           # 15m & 4h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
           # 15m & 1h & 4h down move
@@ -18372,9 +18419,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20)
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d high
@@ -18382,29 +18429,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h downtrend
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
           # 15m down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 90.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 60.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0))
           # 15m & 1h & 1d down move, 1h still not low enough, 1d high
           long_entry_logic.append(
-            (rsi_3_15m > 20.0)
-            | (rsi_3_1h > 20.0)
-            | (rsi_3_1d > 30.0)
-            | (df["RSI_14_1h"] < 30.0)
-            | (aroonu_14_1d < 80.0)
+            (rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (rsi_14_1h < 30.0) | (aroonu_14_1d < 80.0)
           )
           # 15m & 1h down move, 4h still high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_4h < 10.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1h & 4h down move, 1d high
@@ -18426,11 +18469,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1d still high
           long_entry_logic.append((rsi_3_1h > 5.0) | (stochrsi_k_1d < 50.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still not low enough
@@ -18438,9 +18481,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | roc_9_1d_lt_50)
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 40.0))
           # 1h & 1d down move, 4h still not low enough
@@ -18454,21 +18497,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 1d stll high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 40.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 1d high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h & 4h still high
-          long_entry_logic.append(
-            (rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (df["RSI_14_1h"] < 40.0) | (rsi_14_4h < 50.0)
-          )
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h still high
@@ -18476,7 +18517,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_lt_50)
           # 1h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h down move, 1d high & overbought
@@ -18484,33 +18525,33 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
           # 1h & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1d < 80.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 65.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_4h < 65.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (df["RSI_14_15m"] < 30.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_14_15m < 30.0) | (stochrsi_k_4h < 60.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
           # 1h down move, 1h high
@@ -18520,7 +18561,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
           # 1h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -30.0))
           # 1h down move, 4h high
@@ -18530,7 +18571,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 4h high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.30))
+          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.30))
           # 1h down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1h down move, 1h high, 1d overbought
@@ -18550,15 +18591,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d still high
           long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d low
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (df["CMF_20_1d"] > -0.2))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (cmf_20_1d > -0.2))
           # 4h & 1d down move, 1d still high
           long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
           # 4h down move, 4h still not low enough, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 4h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
           # 4h down move, 4h high
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 90.0))
           # 4h down move, 4h & 1d high
@@ -18586,39 +18627,37 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 4h overbought, 1d downtrend
           long_entry_logic.append((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -20.0))
           # 1d green, 4h down move, 4h still high
-          long_entry_logic.append((df["change_pct_1d"] < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
           # 4h top wick, 1h down move, 1h still high
           long_entry_logic.append((df["top_wick_pct_4h"] < 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 50.0))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_6_1d"] - df["low_min_6_1d"]) / df["low_min_6_1d"]) < 2.0)
-            | (close > (df["high_max_12_4h"] * 0.50))
-            | (close < (df["low_min_24_4h"] * 1.05))
+            (((high_max_6_1d - df["low_min_6_1d"]) / df["low_min_6_1d"]) < 2.0)
+            | (close > (high_max_12_4h * 0.50))
+            | (close < (low_min_24_4h * 1.05))
           )
           # 1d overbought, drop but not yet near the previous lows
-          long_entry_logic.append(
-            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
-          )
+          long_entry_logic.append(roc_9_1d_lt_50 | (close > (high_max_6_1d * 0.70)) | (close < (low_min_12_1d * 1.25)))
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_12_1d"] - df["low_min_12_1d"]) / df["low_min_12_1d"]) < 2.5)
-            | (close > (df["high_max_6_1d"] * 0.60))
-            | (close < (df["low_min_12_1d"] * 1.25))
+            (((high_max_12_1d - low_min_12_1d) / low_min_12_1d) < 2.5)
+            | (close > (high_max_6_1d * 0.60))
+            | (close < (low_min_12_1d * 1.25))
           )
           # big drop in the last 2 days, 1d down move
-          long_entry_logic.append((close > (df["high_max_12_4h"] * 0.30)) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((close > (high_max_12_4h * 0.30)) | (rsi_3_1d > 30.0))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.30)) | (rsi_3_1h > 20.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.30)) | rsi_3_1h_gt_20)
           # big drop in the last 12 days, 4h still high
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.40)) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (stochrsi_k_4h < 50.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.40)) | (rsi_3_1h > 10.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_3_1h > 10.0))
           # big drop in the last 20 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 25.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h > 25.0))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.40)) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.40)) | (rsi_3_4h > 15.0))
           # big drop in the last 30 days, 4h still not low enough
-          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (stochrsi_k_4h < 30.0))
 
           # Logic
           long_entry_logic.append(rsi_3 < 40.0)
@@ -18628,64 +18667,64 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(stochrsi_k_15m < 20.0)
           long_entry_logic.append(df["WILLR_84_1h"] < -70.0)
           long_entry_logic.append(stochrsi_k_1h < 20.0)
-          long_entry_logic.append(df["BBB_20_2.0_1h"] > 12.0)
-          long_entry_logic.append(df["close_max_48"] >= (close * 1.10))
+          long_entry_logic.append(bbb_20_2_0_1h > 12.0)
+          long_entry_logic.append(close_max_48 >= (close * 1.10))
 
         # Condition #61 - Rebuy mode (Long).
         if long_entry_condition_index == 61:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
             ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m down move, 1d high & overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 20.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 3.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_4h > 3.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["RSI_14_1d"] < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (df["CMF_20_4h"] > -0.30))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (cmf_20_4h > -0.30))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 40.0) | (rsi_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (rsi_14_4h < 40.0))
             # 15m down move, 15m downtrend. 4h high
-            & ((rsi_3_15m > 3.0) | (df["CMF_20_15m"] > -0.50) | (aroonu_14_4h < 60.0))
+            & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.50) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still not low enough
-            & ((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 80.0))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 3.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1h downtrend
@@ -18693,7 +18732,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still low, 4h still high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (aroonu_14_4h < 50.0))
             # 15m down move, 15m still high
@@ -18703,7 +18742,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_4h > -50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 4h overbought
@@ -18711,7 +18750,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m still not low enough, 1d downtrend
@@ -18721,7 +18760,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high
@@ -18749,15 +18788,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high
@@ -18787,7 +18826,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
@@ -18809,7 +18848,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 10.0) | (roc_9_4h > -10.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d overbought
@@ -18817,19 +18856,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 1d high
@@ -18879,7 +18918,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 4h downtrend, 4h still high
-            & ((rsi_3_4h > 5.0) | (df["CMF_20_4h"] > -0.20) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h > 5.0) | (cmf_20_4h > -0.20) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d downtrend
@@ -18889,23 +18928,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1h > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
@@ -18921,7 +18960,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 1h high, 4h high, 1h overbought
@@ -18931,13 +18970,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (df["ROC_9"] > -40.0))
+            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d high, 1h & 4h downtrend
@@ -18955,24 +18994,24 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought
             & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
             (rsi_3 < 50.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
-            & (df["EMA_26"] > df["EMA_12"])
-            & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.030))
-            & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
+            & (aroonu_14 < 25.0)
+            & (stochrsi_k < 30.0)
+            & (ema_26 > ema_12)
+            & ((ema_26 - ema_12) > (df["open"] * 0.030))
+            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
           )
 
         # Condition #62 - Rebuy mode (Long).
         if long_entry_condition_index == 62:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d high
@@ -18984,19 +19023,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 3.0) | (aroonu_14_4h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 3.0) | (aroonu_14_4h < 20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 15m still not low enough
@@ -19030,13 +19069,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 1d overbought
@@ -19044,15 +19083,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -25.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m downtrend, 4h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.30) | (aroonu_14_4h < 50.0))
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d high
@@ -19064,13 +19103,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m stil high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 40.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1d still high
@@ -19078,7 +19117,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough
             & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 20.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -19092,7 +19131,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h & 1d down move
@@ -19108,7 +19147,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 4h still high
@@ -19120,15 +19159,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 60.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1d downtrend
@@ -19136,45 +19175,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 40.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 85.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 85.0))
             # 1h down move, 1h still not low enough, 4h stil high
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 40.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.50))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 4h still high
@@ -19188,7 +19227,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.40))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 4h overbought
@@ -19230,9 +19269,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
             # 4h down move, 1h downtrend, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["CMF_20_1h"] > -0.40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 15.0) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -19242,11 +19281,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h high
@@ -19254,9 +19293,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (df["CMF_20_4h"] > -0.40))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
@@ -19286,13 +19325,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.50) | (df["CMF_20_1d"] > -0.50) | (aroonu_14_1d < 85.0))
+            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1d high, 4h downtrend, 1d overbought
@@ -19304,33 +19343,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d green, 4h down move, 4h still high
-            & ((df["change_pct_1d"] < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+            & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
           )
 
           # Logic
           long_entry_logic.append(
             (rsi_3 < 40.0)
-            & (df["AROONU_14"] < 30.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
+            & (aroonu_14 < 30.0)
+            & (stochrsi_k < 20.0)
             & (stochrsi_k_15m < 70.0)
             & (df["WILLR_84_1h"] < -70.0)
             & (stochrsi_k_1h < 30.0)
-            & (df["BBB_20_2.0_1h"] > 12.0)
-            & (df["close_max_48"] >= (close * 1.10))
+            & (bbb_20_2_0_1h > 12.0)
+            & (close_max_48 >= (close * 1.10))
           )
 
         # Condition #63 - Rebuy mode (Long).
         if long_entry_condition_index == 63:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             (rsi_3_15m > 5.0)
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1d down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (df["CMF_20_1d"] > -0.25))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m down move, 1d high & overbought
@@ -19338,7 +19377,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 15m still high
@@ -19400,7 +19439,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 15m down move, 1h high
@@ -19420,13 +19459,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m downtrend, 4h high
-            & ((rsi_3_15m > 30.0) | (df["CMF_20_15m"] > -0.30) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 30.0) | (cmf_20_15m > -0.30) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
@@ -19460,15 +19499,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h ^ 4h down move, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 15.0) | (roc_9_1h > -40.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h > 3.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h down move, 15m still not low enough, 4h still high
             & ((rsi_3_1h > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
             # 1h down move, 1h still not low enough
@@ -19492,7 +19531,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0))
             # 1h, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 5.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19518,13 +19557,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d downtrend, 1d overbought
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.20) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.20) | (aroonu_14_1h < 30.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.20) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.20) | (stochrsi_k_1h < 30.0))
             # 1h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_1h"] > -0.30))
+            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 20.0))
             # 1h down move, 1d overbought
@@ -19532,13 +19571,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 90.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
             # 1h & 4h down mov, 1d overbought
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 1d high, 4h downtrend
@@ -19550,17 +19589,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 4h high
@@ -19608,7 +19647,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 50.0))
             # 4h down move, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
@@ -19624,7 +19663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (df["RSI_14_1d"] < 80.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h > 40.0) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h high, 1d overbought
@@ -19686,35 +19725,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 45.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 45.0))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1h & 4h still high
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
             # 4h dowqn move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d overbought
@@ -19728,13 +19767,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h downtrend, 1h high
-            & ((df["CMF_20_1h"] > -0.20) | (aroonu_14_1h < 80.0))
+            & ((cmf_20_1h > -0.20) | (aroonu_14_1h < 80.0))
             # 4h & 1d downtrend, 1d high
-            & ((df["CMF_20_4h"] > -0.30) | (df["CMF_20_1d"] > -0.30) | (stochrsi_k_1d < 60.0))
+            & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m still high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (roc_9_1h < 40.0))
             # 15m still high, 4h overbought
@@ -19742,7 +19781,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h high
             & ((aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 15m still high, 4h high & overbought
-            & ((aroonu_14_15m < 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m still high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
             # 1h still high, 4h & 1d downtrend
@@ -19762,9 +19801,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 1d high, 4h downtrend
             & ((aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
             # 4h high, 1h & 1d downtrend
-            & ((aroonu_14_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 4h high, 1h & 4h overbought
@@ -19798,38 +19837,38 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought
             & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
             # 1d green with top wick, 4h high
-            & ((df["change_pct_1d"] < 30.0) | (df["top_wick_pct_1d"] < 20.0) | (aroonu_14_4h < 80.0))
+            & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | (aroonu_14_4h < 80.0))
             # 1d top wick, 4h down move, 1d overbought
-            & ((df["top_wick_pct_1d"] < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # drop in last 20 days, 4h high
-            & ((close > (df["high_max_20_1d"] * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
             (rsi_3 > 0.0)
             & (rsi_3 < 50.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["EMA_26"] > df["EMA_12"])
-            & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.022))
-            & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
+            & (aroonu_14 < 25.0)
+            & (ema_26 > ema_12)
+            & ((ema_26 - ema_12) > (df["open"] * 0.022))
+            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
           )
 
         # Condition #101 - Rapid mode (Long).
         if long_entry_condition_index == 101:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append(df["RSI_14_1h"] < 80.0)
+          long_entry_logic.append(rsi_14_1h < 80.0)
           long_entry_logic.append(rsi_14_4h < 80.0)
-          long_entry_logic.append(df["RSI_14_1d"] < 80.0)
+          long_entry_logic.append(rsi_14_1d < 80.0)
           # big drop in the last hour
-          long_entry_logic.append(close > (df["close_max_12"] * 0.50))
+          long_entry_logic.append(close > (close_max_12 * 0.50))
           # 5m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
           # 5m & 4h down move, 15m still high
@@ -19839,29 +19878,29 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h & 4h high
           long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 30.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (rsi_14_4h < 40.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 75.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_4h < 75.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 20.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 20.0))
           # 15m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 30.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
           # 15m & 1h & 1d down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 20.0))
           # 15m down move, 1h still not low enough, 1d high
@@ -19891,7 +19930,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high & overbought
           long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 25.0))
           # 15m & 1h down move, 1h still high
@@ -19907,7 +19946,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 10.0))
           # 15m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -25.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
@@ -19925,7 +19964,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
           # 15m & 1h down move, 1h still high
@@ -19935,7 +19974,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 30.0))
           # 15m & 4h down move, 4h still high
@@ -19973,27 +20012,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h > -20.0))
           # 1h & 4h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 20.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 20.0))
           # 1h & 4h down move, 1d low
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1d"] > -0.2))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (cmf_20_1d > -0.2))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 20.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["ROC_2"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
           # 1h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_4h > -30.0))
           # 1h down move, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_1d > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
           # 1h & 4h down move, 1h still not low enough
@@ -20001,9 +20040,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h down move, 1h still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 80.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 1d high
@@ -20033,7 +20072,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m 4h still high
           long_entry_logic.append((rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 50.0))
           # 4h & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h still high
           long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
           # 4h down move, 4h still high
@@ -20043,7 +20082,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -15.0))
           # 4h down move, 4h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
           # 4h dowqn move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
           # 4h down move, 4h & 1d high
@@ -20079,63 +20118,59 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d red, 4h down move, 1h still high
-          long_entry_logic.append((df["change_pct_1d"] > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (close > (df["high_max_6_4h"] * 0.75))
-            | (close < (df["low_min_24_4h"] * 1.25))
+            (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
+            | (close > (high_max_6_4h * 0.75))
+            | (close < (low_min_24_4h * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 70.0) | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
+            aroonu_14_4h_lt_70 | (close > (high_max_6_4h * 0.80)) | (close < (low_min_24_4h * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 80.0) | (close > (df["high_max_6_4h"] * 0.85)) | (close < (df["low_min_24_4h"] * 1.25))
+            (aroonu_14_4h < 80.0) | (close > (high_max_6_4h * 0.85)) | (close < (low_min_24_4h * 1.25))
           )
           # 1h down move, drop but not yet near the previous lows
           long_entry_logic.append(
-            (rsi_3_1h > 30.0) | (close > (df["high_max_12_4h"] * 0.50)) | (close < (df["low_min_24_4h"] * 1.25))
+            (rsi_3_1h > 30.0) | (close > (high_max_12_4h * 0.50)) | (close < (low_min_24_4h * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
-          long_entry_logic.append(
-            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
-          )
+          long_entry_logic.append(roc_9_1d_lt_50 | (close > (high_max_6_1d * 0.70)) | (close < (low_min_12_1d * 1.25)))
           # big drop in last 6 hours, 1d overbought
-          long_entry_logic.append((close > (df["high_max_6_1h"] * 0.65)) | (roc_9_1d < 50.0))
+          long_entry_logic.append((close > (df["high_max_6_1h"] * 0.65)) | roc_9_1d_lt_50)
           # big drop in last 4 hours, 4h still not low enough
-          long_entry_logic.append((close > (df["high_max_24_4h"] * 0.50)) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((close > (high_max_24_4h * 0.50)) | (stochrsi_k_4h < 30.0))
           # big drop in the last 4 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_24_4h"] * 0.20)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (high_max_24_4h * 0.20)) | rsi_3_4h_gt_20)
           # big drop in the last 6 days, 1d down move
-          long_entry_logic.append((close > (df["high_max_6_1d"] * 0.30)) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((close > (high_max_6_1d * 0.30)) | (rsi_3_1d > 15.0))
           # big drop in the last 12 days, 4h high
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.50)) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.50)) | (stochrsi_k_4h < 90.0))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 30.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h > 30.0))
           # big drop in the last 20 days, 1h still high
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.05)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.05)) | (aroonu_14_1h < 50.0))
           # big drop in the last 20 days, 1d high, 1d downtrend
-          long_entry_logic.append(
-            (close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0)
-          )
+          long_entry_logic.append((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           # big drop in the last 30 days, 1h down move
-          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_1h > 15.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_1h > 15.0))
 
           # Logic
           long_entry_logic.append(rsi_3 > 3.0)
-          long_entry_logic.append(df["RSI_14"] < 36.0)
-          long_entry_logic.append(df["AROONU_14"] < 25.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
-          long_entry_logic.append(close < (df["SMA_16"] * 0.946))
+          long_entry_logic.append(rsi_14 < 36.0)
+          long_entry_logic.append(aroonu_14 < 25.0)
+          long_entry_logic.append(stochrsi_k < 20.0)
+          long_entry_logic.append(close < (sma_16 * 0.946))
           long_entry_logic.append(aroonu_14_15m < 50.0)
 
         # Condition #102 - Rapid mode (Long).
         if long_entry_condition_index == 102:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(rsi_3 < 46.0)
           long_entry_logic.append(rsi_3_15m > 5.0)
@@ -20150,7 +20185,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
           # 5m & 4h & 1d down move
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
           # 5m & 1d down move, 15m still high
           long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 40.0))
           # 5m down move, 15m high
@@ -20162,9 +20197,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h down move, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
           # 5m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 5m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3 > 5.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_14_15m < 40.0) | (aroonu_14_1h < 80.0))
           # 5m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
           # 5m down move, 15m & 4h high
@@ -20182,15 +20217,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 4h high, 1d high
           long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
           # 5m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3 > 15.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((rsi_3 > 15.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
           # 5m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3 > 15.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 15.0) | (rsi_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 30.0))
           # 15m & 1h down move, 1h still high
@@ -20198,27 +20233,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
           # 15m& 4h down move, 15m still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 40.0))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 40.0))
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
           # 15m & 1d down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 15m still not low enough, 1h high
@@ -20240,7 +20275,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h & 1d down move
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 25.0))
           # 15m & 4h down move, 4h high
@@ -20250,7 +20285,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (df["RSI_14_15m"] < 35.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_14_15m < 35.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m & 4h still high
@@ -20260,21 +20295,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (stochrsi_k_4h < 60.0))
           # 15m down move, 4h still high 1d overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | roc_9_1d_lt_50)
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 30.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
           # 15m & 1h down move, 15m high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0))
           # 15m & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
           # 15m & 1d down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 35.0) | (rsi_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 35.0) | (rsi_14_4h < 85.0))
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 15m still not low enough, 4h high
@@ -20314,7 +20349,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 60.0))
           # 15m down move, 15m high, 4h still high
@@ -20332,35 +20367,35 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h < 20.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (df["RSI_14_15m"] < 50.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_14_15m < 50.0) | (aroonu_14_1h < 80.0))
           # 15m down move, 15m high, 1h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 90.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (df["CMF_20_4h"] > -0.40))
+          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (cmf_20_4h > -0.40))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 70.0))
           # 1h down move, 1d still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d > -50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | roc_9_1d_gt_neg_50)
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
           # 1h & 4h down move, 4h high
@@ -20384,9 +20419,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 30.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 30.0))
           # 4h down move, 4h still not low enough, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h > -20.0))
           # 4h down move, 4h high, 1d downtrend
@@ -20418,9 +20453,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h high
           long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h < 70.0))
           # 15m high, 1d overbought
-          long_entry_logic.append((aroonu_14_15m < 80.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
           # 15m & 4h high
-          long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((aroonu_14_15m < 90.0) | aroonu_14_4h_lt_70)
           # 15m & 1h high
           long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_1h < 90.0))
           # 1h still high, 4h high & overbought
@@ -20434,11 +20469,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h high, 4h & 1d overbought
@@ -20446,55 +20481,53 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m red, 1h still high
           long_entry_logic.append((df["change_pct"] > -5.0) | (stochrsi_k_1h < 50.0))
           # 1d top wick, 4h down move, 4h still high
-          long_entry_logic.append((df["top_wick_pct_1d"] < 30.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((top_wick_pct_1d < 30.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 50.0))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (close > (df["high_max_6_4h"] * 0.75))
-            | (close < (df["low_min_24_4h"] * 1.25))
+            (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
+            | (close > (high_max_6_4h * 0.75))
+            | (close < (low_min_24_4h * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (stochrsi_k_4h < 90.0) | (close > (df["close_max_48"] * 0.85)) | (close < (df["low_min_24_1h"] * 1.25))
+            (stochrsi_k_4h < 90.0) | (close > (close_max_48 * 0.85)) | (close < (df["low_min_24_1h"] * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 70.0) | (close > (df["high_max_6_4h"] * 0.80)) | (close < (df["low_min_24_4h"] * 1.25))
+            aroonu_14_4h_lt_70 | (close > (high_max_6_4h * 0.80)) | (close < (low_min_24_4h * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
-          long_entry_logic.append(
-            (roc_9_1d < 50.0) | (close > (df["high_max_6_1d"] * 0.70)) | (close < (df["low_min_12_1d"] * 1.25))
-          )
+          long_entry_logic.append(roc_9_1d_lt_50 | (close > (high_max_6_1d * 0.70)) | (close < (low_min_12_1d * 1.25)))
           # big drop in the last 4 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_24_4h"] * 0.20)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (high_max_24_4h * 0.20)) | rsi_3_4h_gt_20)
           # big drop in the last 12 days, 1h high
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.30)) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.30)) | (stochrsi_k_1h < 90.0))
           # big drop in the last 20 days, 1d down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.40)) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_3_1d > 30.0))
           # big drop in the last 30 days, 4h down move, 4h still high
-          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 45.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_4h > 45.0) | (rsi_14_4h < 40.0))
           # big drop in the last 30 days, 1h high
-          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.20)) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.20)) | (stochrsi_k_1h < 80.0))
 
           # Logic
-          long_entry_logic.append(df["WILLR_14"] < -95.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 10.0)
+          long_entry_logic.append(willr_14 < -95.0)
+          long_entry_logic.append(stochrsi_k < 10.0)
           long_entry_logic.append(close < (df["BBL_20_2.0"] * 0.999))
-          long_entry_logic.append(close < (df["EMA_20"] * 0.960))
+          long_entry_logic.append(close < (ema_20 * 0.960))
 
         # Condition #103 - Rapid mode (Long).
         if long_entry_condition_index == 103:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append(df["ROC_2"] > -0.0)
+          long_entry_logic.append(roc_2 > -0.0)
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 80.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 10.0) | rsi_3_4h_gt_20)
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
           # 15m down move, 4h high & overbought
@@ -20502,11 +20535,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m & 1h high
@@ -20540,23 +20573,23 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
           # 1h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
           # 1h down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d overbought
@@ -20582,13 +20615,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 50.0))
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_15m < 30.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h high, 4h downtrend
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
           # 4h down move, 4h still high, 1d downtrend
@@ -20610,11 +20643,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h & 1d overbought
           long_entry_logic.append((rsi_3_1d > 45.0) | (roc_9_1h < 80.0) | (roc_9_1d < 80.0))
           # 15m still high, 1h & 4h high
-          long_entry_logic.append((df["RSI_14_15m"] < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_14_15m < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h still high, 4h high
-          long_entry_logic.append((df["RSI_14_15m"] < 45.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_14_15m < 45.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 70.0))
           # 15m still high, 4h high & overbought
-          long_entry_logic.append((df["RSI_14_15m"] < 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
+          long_entry_logic.append((rsi_14_15m < 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
           # 15m still high, 1h high, 4h still high
           long_entry_logic.append((aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_4h < 50.0))
           # 15m still high, 1d high
@@ -20630,11 +20663,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h high, 1h & 1d overbought
           long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 15m still high, 1h high
           long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_1h < 90.0))
           # 15m still high, 1d high
@@ -20642,93 +20675,85 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
           # 1d green, 4h down move, 4h still high
-          long_entry_logic.append((df["change_pct_1d"] < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
           # 1d top wick, 4h high
-          long_entry_logic.append((df["top_wick_pct_1d"] < 30.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((top_wick_pct_1d < 30.0) | (aroonu_14_4h < 90.0))
           # pump, 4h overbought
           long_entry_logic.append(
             (((df["high_max_6_1h"] - df["low_min_6_1h"]) / df["low_min_6_1h"]) < 0.5) | (roc_9_4h < 50.0)
           )
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (close > (df["high_max_6_4h"] * 0.85))
-            | (close < (df["low_min_24_4h"] * 1.25))
+            (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
+            | (close > (high_max_6_4h * 0.85))
+            | (close < (low_min_24_4h * 1.25))
           )
           # pump, 1h high
-          long_entry_logic.append(
-            (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 4.0) | (stochrsi_k_1h < 90.0)
-          )
+          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 4.0) | (stochrsi_k_1h < 90.0))
           # big drop in the last 2 days, 1d down move
-          long_entry_logic.append((close > (df["high_max_12_4h"] * 0.30)) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((close > (high_max_12_4h * 0.30)) | (rsi_3_1d > 30.0))
           # big drop in the last 12 days, 1h still high
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.25)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h < 50.0))
           # big drop in the last 12 days, 1h still not low enough
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.10)) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.10)) | (stochrsi_k_1h < 30.0))
           # big drop in the last 12 days, 15m still high
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.20)) | (aroonu_14_15m < 50.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.20)) | (aroonu_14_15m < 50.0))
           # big drop in the last 20 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | rsi_3_4h_gt_20)
 
           # Logic
-          long_entry_logic.append(df["RSI_4"] < 45.0)
-          long_entry_logic.append(df["RSI_14"] > 35.0)
-          long_entry_logic.append(df["RSI_20"] < df["RSI_20"].shift(1))
-          long_entry_logic.append(df["AROONU_14"] < 25.0)
-          long_entry_logic.append(close < df["SMA_16"] * 0.960)
+          long_entry_logic.append(rsi_4 < 45.0)
+          long_entry_logic.append(rsi_14 > 35.0)
+          long_entry_logic.append(rsi_20 < rsi_20.shift(1))
+          long_entry_logic.append(aroonu_14 < 25.0)
+          long_entry_logic.append(close < sma_16 * 0.960)
 
         # Condition #104 - Rapid mode (Long).
         if long_entry_condition_index == 104:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           # 5m & 4h & 1d down move
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
           # 5m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
           # 5m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
           # 15m & 1h down move
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 3.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (rsi_14_4h < 35.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_14_4h < 35.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 3.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
           # 15m & 1h & 4h down move, 15m downtrend
-          long_entry_logic.append(
-            (rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (df["CMF_20_15m"] > -0.20)
-          )
+          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (cmf_20_15m > -0.20))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
           # 15m & 1h down move, 15m & 1h downtrend
-          long_entry_logic.append(
-            (rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (df["CMF_20_1h"] > -0.40)
-          )
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 4h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (roc_9_4h < 50.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
           # 15m & 4h down move, 1h & 4h downtrend
-          long_entry_logic.append(
-            (rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.20) | (df["CMF_20_4h"] > -0.20)
-          )
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 4h still high
@@ -20736,19 +20761,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
           # 15m & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d > -25.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 20.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_70)
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1h still high
@@ -20758,11 +20783,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
           # 15m & 3h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (df["RSI_14_1h"] < 40.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (rsi_14_1h < 40.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
           # 15m down move, 15m still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 20.0) | (roc_9_1d < 80.0))
           # 1h & 4h down move
@@ -20770,7 +20795,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0))
           # 1h & 4h down move, 4h still high
@@ -20786,17 +20811,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1d still high
           long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 50.0))
           # 1h & 1d down move, 1h still moving lower
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (df["CCI_20_change_pct_1h"] > -0.0))
+          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_4h > -10.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 20.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 1h high
@@ -20808,17 +20833,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | aroonu_14_4h_lt_70)
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 20.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h still high, 1d downtrend
@@ -20830,13 +20855,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & dh down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 30.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
           # 1h down move, 1h still not low enough, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0) | (roc_9_4h > -20.0))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
           # 1h down move, 4h high & overbought
@@ -20852,21 +20877,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d still not low enough, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_1d < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h downtrend, 1h still not low enough
-          long_entry_logic.append((rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.25) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_4h > 10.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 10.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
           # 4h down move, 1h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
           # 4h down move, 1d high, 1h downtrend
-          long_entry_logic.append((rsi_3_4h > 20.0) | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
           # 4h down move, 4h high, 1h downtrend
@@ -20876,7 +20901,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1d down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 20.0))
           # 1h & 4h high, 4h overbought
@@ -20884,40 +20909,38 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
           # 4h & 1d high,1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
           # 1d red, 4h down move, 1h still high
-          long_entry_logic.append((df["change_pct_1d"] > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_24_4h"] - df["low_min_24_4h"]) / df["low_min_24_4h"]) < 2.0)
-            | (close > (df["high_max_12_4h"] * 0.60))
-            | (close < (df["low_min_24_4h"] * 1.10))
+            (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
+            | (close > (high_max_12_4h * 0.60))
+            | (close < (low_min_24_4h * 1.10))
           )
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
-            (((df["high_max_12_1d"] - df["low_min_12_1d"]) / df["low_min_12_1d"]) < 5.0)
-            | (close > (df["high_max_6_1d"] * 0.30))
-            | (close < (df["low_min_12_1d"] * 1.25))
+            (((high_max_12_1d - low_min_12_1d) / low_min_12_1d) < 5.0)
+            | (close > (high_max_6_1d * 0.30))
+            | (close < (low_min_12_1d * 1.25))
           )
           # big drop in the last hour
-          long_entry_logic.append(close > (df["close_max_12"] * 0.50))
+          long_entry_logic.append(close > (close_max_12 * 0.50))
           # big drop in the last 12 days, 15m & 4h down move
-          long_entry_logic.append((close > (df["high_max_12_1d"] * 0.40)) | (rsi_3_15m > 10.0) | (rsi_3_4h > 10.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_15m > 10.0) | (rsi_3_4h > 10.0))
           # big drop in the last 20 days, 15m & 1h down move
-          long_entry_logic.append(
-            (close > (df["high_max_20_1d"] * 0.40)) | (df["RSI_14_15m"] < 10.0) | (df["RSI_14_1h"] < 10.0)
-          )
+          long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_14_15m < 10.0) | (rsi_14_1h < 10.0))
           # big drop in the last 20 days, 1d down move
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.25)) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.25)) | (rsi_3_1d > 30.0))
           # big drop in the last 20 days, 4h still not low enough
-          long_entry_logic.append((close > (df["high_max_20_1d"] * 0.10)) | (rsi_14_4h < 30.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_14_4h < 30.0))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((close > (df["high_max_30_1d"] * 0.25)) | (rsi_3_4h > 20.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.25)) | rsi_3_4h_gt_20)
 
           # Logic
           long_entry_logic.append(rsi_3 < 40.0)
-          long_entry_logic.append(df["AROONU_14"] < 25.0)
-          long_entry_logic.append(df["STOCHRSIk_14_14_3_3"] < 20.0)
+          long_entry_logic.append(aroonu_14 < 25.0)
+          long_entry_logic.append(stochrsi_k < 20.0)
           long_entry_logic.append(aroonu_14_15m < 25.0)
           long_entry_logic.append(stochrsi_k_15m < 30.0)
           long_entry_logic.append(close < df["EMA_16"] * 0.975)
@@ -20927,15 +20950,15 @@ class NostalgiaForInfinityX7(IStrategy):
         if long_entry_condition_index == 120:
           # Protections
           long_entry_logic.append(num_open_long_grind_mode < self.grind_mode_max_slots)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(protections_long_global == True)
           long_entry_logic.append(is_pair_long_grind_mode)
           long_entry_logic.append(rsi_3 <= 50.0)
           long_entry_logic.append(rsi_3_15m >= 20.0)
           long_entry_logic.append(rsi_3_1h >= 10.0)
           long_entry_logic.append(rsi_3_4h >= 10.0)
-          long_entry_logic.append(df["RSI_14_1h"] < 80.0)
+          long_entry_logic.append(rsi_14_1h < 80.0)
           long_entry_logic.append(rsi_14_4h < 80.0)
-          long_entry_logic.append(df["RSI_14_1d"] < 80.0)
+          long_entry_logic.append(rsi_14_1d < 80.0)
           long_entry_logic.append(aroonu_14_15m < 70.0)
           long_entry_logic.append(aroonu_14_1h < 100.0)
           long_entry_logic.append(aroonu_14_4h < 100.0)
@@ -20944,18 +20967,15 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["WILLR_14"] < -80.0)
-            & (df["AROONU_14"] < 25.0)
-            & (close < (df["EMA_20"] * 0.978))
+            (stochrsi_k < 20.0) & (willr_14 < -80.0) & (aroonu_14 < 25.0) & (close < (ema_20 * 0.978))
           )
 
         # Condition #141 - Top Coins mode (Long).
         if long_entry_condition_index == 141:
           # Protections
           long_entry_logic.append(is_pair_long_top_coins_mode)
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m high
@@ -20973,7 +20993,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 1h high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 80.0))
             # 5m & 1d down move, 15m high
@@ -20989,39 +21009,39 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((rsi_3 > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 15m downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 3.0) | (df["CMF_20_15m"] > -0.30))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 3.0) | (cmf_20_15m > -0.30))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h still high
@@ -21031,11 +21051,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
             # 15m down move, 15m downtrend, 1d high
-            & ((rsi_3_15m > 5.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
@@ -21049,9 +21069,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1d overbought
@@ -21065,25 +21085,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["RSI_14_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 1h still high
@@ -21093,11 +21113,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
@@ -21113,7 +21133,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 4h still high
@@ -21123,7 +21143,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
@@ -21175,17 +21195,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still high
@@ -21211,19 +21231,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 15m still high, 1d high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 90.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h high
@@ -21231,7 +21251,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["RSI_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d high & overbought
@@ -21247,7 +21267,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high , 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 4h high
@@ -21257,7 +21277,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (df["RSI_14_1d"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (rsi_14_1d < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d still high
@@ -21291,7 +21311,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d high
@@ -21299,7 +21319,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -21309,13 +21329,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h > 15.0) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 25.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 80.0))
             # 4h down move, 1h high
@@ -21327,7 +21347,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m & 4h high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d downtrend
@@ -21369,13 +21389,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0) | roc_9_1d_lt_50)
             # 1h & 1d high, 1d overbought
             & ((aroonu_14_1h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 50.0))
+            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
             # 4h & 1d overbought
@@ -21384,18 +21404,15 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_20"] < df["RSI_20"].shift(1))
-            & (rsi_3 < 30.0)
-            & (df["AROONU_14"] < 25.0)
-            & (close < df["SMA_16"] * 0.960)
+            (rsi_20 < rsi_20.shift(1)) & (rsi_3 < 30.0) & (aroonu_14 < 25.0) & (close < sma_16 * 0.960)
           )
 
         # Condition #142 - Top Coins mode (Long).
         if long_entry_condition_index == 142:
           # Protections
           long_entry_logic.append(is_pair_long_top_coins_mode)
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 4h down move, 15m high
@@ -21407,35 +21424,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h high
             & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 75.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 3.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 90.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 20.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 60.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down move, 4h still high
@@ -21443,13 +21460,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
@@ -21461,7 +21478,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
@@ -21477,17 +21494,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (df["RSI_14_1d"] < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
             # 14m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d high
@@ -21503,7 +21520,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
@@ -21519,13 +21536,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
@@ -21535,11 +21552,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m high, 1d high
@@ -21561,7 +21578,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
             # 15m down move, 1d high, 1h overbought
             & ((rsi_3_15m > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
             # 1h & 4h down move, 1d still high
@@ -21571,7 +21588,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (rsi_3_1d > 25.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 25.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h & 1d down move
@@ -21581,9 +21598,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d < 100.0))
             # 1h & 1d downtrend, 1d high
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 1h still not low enough
@@ -21597,7 +21614,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
@@ -21609,17 +21626,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
@@ -21635,7 +21652,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h still high, 1d downtrend
@@ -21649,7 +21666,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (df["RSI_14_1d"] < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (rsi_14_1d < 40.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -21679,13 +21696,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 15m high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 15m still not low enough, 1d high
             & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -21693,17 +21710,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 80.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d overbought
-            & ((rsi_3_4h > 20.0) | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (roc_9_1d < 80.0))
             # 4h & 1d down move, 4h overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
@@ -21717,7 +21734,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d downtrend
@@ -21741,7 +21758,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high, 4h downtrend
@@ -21797,18 +21814,18 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 > 5.0)
-            & (df["RSI_4"] < 46.0)
-            # & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["RSI_20"] < df["RSI_20"].shift(1))
-            & (close < df["SMA_16"] * 0.960)
+            & (rsi_4 < 46.0)
+            # & (stochrsi_k < 20.0)
+            & (rsi_20 < rsi_20.shift(1))
+            & (close < sma_16 * 0.960)
           )
 
         # Condition #143 - Top Coins mode (Long).
         if long_entry_condition_index == 143:
           # Protections
           long_entry_logic.append(is_pair_long_top_coins_mode)
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 4h & 1d down move
@@ -21816,31 +21833,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 35.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_15m < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (df["RSI_14_1d"] < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (rsi_14_1d < 40.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1d high
@@ -21856,11 +21873,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 3.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 3.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 15m still high, 1d downtrend
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high, 1d overbought
@@ -21870,7 +21887,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h high
@@ -21878,7 +21895,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 15m & 1d down move, 1h high
@@ -21892,7 +21909,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1h still high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h high
@@ -21916,23 +21933,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h & 1d overbought
@@ -21968,11 +21985,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 60.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
@@ -21980,13 +21997,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h > 15.0) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h down move, 1h high, 1d downtrend
@@ -22010,18 +22027,18 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 40.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["EMA_26"] > df["EMA_12"])
-            & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.020))
-            & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
+            & (stochrsi_k < 20.0)
+            & (ema_26 > ema_12)
+            & ((ema_26 - ema_12) > (df["open"] * 0.020))
+            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
           )
 
         # Condition #144 - Top Coins mode (Long).
         if long_entry_condition_index == 144:
           # Protections
           long_entry_logic.append(is_pair_long_top_coins_mode)
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
@@ -22035,7 +22052,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m high
             & ((rsi_3 > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 70.0))
             # 15m & 1h down move, 1d high
@@ -22051,13 +22068,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 20.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 15m still high
@@ -22073,7 +22090,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h high
@@ -22093,17 +22110,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (df["CMF_20_1h"] > -0.20))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.20))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1h still high
@@ -22129,7 +22146,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
             # 1h & 1d down move, 1d high
@@ -22145,23 +22162,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 70.0))
             # 1h down move, 1h high, 1h still not low enough
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
@@ -22173,9 +22190,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (df["RSI_14_1d"] < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 4h high
@@ -22221,9 +22238,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h & 1d down move, 4h overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
@@ -22231,7 +22248,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 70.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -22267,25 +22284,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # 1d P&D, 4h overbought
-            & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 50.0) | (roc_9_4h < 30.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 50.0) | (roc_9_4h < 30.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["WILLR_14"] < -50.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
+            (willr_14 < -50.0)
+            & (stochrsi_k < 30.0)
             # & (df["STOCHRSIk_14_14_3_3_15m"] < 40.0)
             & (stochrsi_k_1h < 40.0)
-            & (df["BBB_20_2.0_1h"] > 12.0)
-            & (df["close_max_48"] >= (close * 1.10))
+            & (bbb_20_2_0_1h > 12.0)
+            & (close_max_48 >= (close * 1.10))
           )
 
         # Condition #145 - Top Coins mode (Long).
         if long_entry_condition_index == 145:
           # Protections
           long_entry_logic.append(is_pair_long_top_coins_mode)
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d downtrend
@@ -22293,13 +22310,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h high
             & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (rsi_3_4h > 5.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 5.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 3.0) | (roc_9_1h > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (roc_9_1h > -20.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 3.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 4h still not low enough
@@ -22313,15 +22330,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 15m still high
@@ -22331,7 +22348,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
             # 15m down move, 15m high, 4h high
@@ -22341,7 +22358,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 35.0) | (roc_9_4h < 30.0) | (roc_9_1d < 80.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h down move, 4h still high, 1d high
             & ((rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 90.0))
             # 1h & 1d down move, 1d still high
@@ -22357,15 +22374,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 20.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -50.0))
+            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (df["CMF_20_15m"] > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d still high, 1d downtrend
@@ -22387,23 +22404,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 20.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h > 20.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d overbought
@@ -22457,11 +22474,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 60.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 20.0) | (stochrsi_k_15m < 90.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 1d high
@@ -22485,7 +22502,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1d > 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
@@ -22504,7 +22521,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_14"] < 36.0)
+            (rsi_14 < 36.0)
             & (df["BBD_40_2.0"].gt(close * 0.020))
             & (df["close_delta"].gt(close * 0.02))
             & (df["BBT_40_2.0"].lt(df["BBD_40_2.0"] * 0.3))
@@ -22515,13 +22532,13 @@ class NostalgiaForInfinityX7(IStrategy):
         # Condition #161 - Scalp mode (Long).
         if long_entry_condition_index == 161:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           # 5m down move, 15m high
           long_entry_logic.append((rsi_3 > 15.0) | (aroonu_14_15m < 80.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m high
@@ -22553,7 +22570,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 50.0))
           # 15m down move, 15m still not low enough, 4h still high
@@ -22563,7 +22580,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 50.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 15m still high, 4h high
@@ -22630,15 +22647,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_14_4h < 70.0) | (df["RSI_14_1d"] < 80.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_14_4h < 70.0) | (rsi_14_1d < 80.0))
           # 15m & 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 50.0) | (rsi_3_1h > 65.0) | (rsi_3_4h > 65.0) | (aroonu_14_4h < 85.0))
           # 4h down move, 15m high
-          long_entry_logic.append((rsi_3_4h > 20.0) | (aroonu_14_15m < 80.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_15m < 80.0))
           # 4h down move, 1h high
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1h < 80.0))
           # 4h down move, 15m & 4h still high
@@ -22658,7 +22675,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (rsi_14_4h < 50.0))
           # 4h down move, 1h still high, 4h still moving down
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (df["CCI_20_change_pct_4h"] > -0.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h high, 4h still high
@@ -22672,13 +22689,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still not low enough
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
           # 4h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h < 50.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h < 50.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m & 1d high
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 80.0) | (aroonu_14_4h < 40.0))
           # 4h down move, 15m still high, 1h high
@@ -22688,7 +22705,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 60.0))
           # 4h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 70.0) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 15m still high, 1d high & overbought
@@ -22704,9 +22721,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high, 1d overbought
           long_entry_logic.append((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
           # 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_4h < 40.0))
           # 4h high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 70.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
           # 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1d high & overbought
@@ -22714,7 +22731,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high, 1h still high
           long_entry_logic.append((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 40.0))
           # 15m & 4h high
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | (aroonu_14_4h < 70.0))
+          long_entry_logic.append((stochrsi_k_15m < 70.0) | aroonu_14_4h_lt_70)
           # 15m high, 1d overbought
           long_entry_logic.append((stochrsi_k_15m < 70.0) | (roc_9_1d < 10.0))
           # 15m high, 1h still not low enough
@@ -22726,18 +22743,18 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d overbought
           long_entry_logic.append((roc_9_4h < 40.0) | (roc_9_1d < 40.0))
           # 1d green with top wick, 1d overbought
-          long_entry_logic.append((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 25.0) | (roc_9_1d < 50.0))
+          long_entry_logic.append((change_pct_1d < 25.0) | (top_wick_pct_1d < 25.0) | roc_9_1d_lt_50)
 
           # Logic
-          long_entry_logic.append(df["RSI_14"] < 50.0)
+          long_entry_logic.append(rsi_14 < 50.0)
           long_entry_logic.append(aroonu_14_15m < 90.0)
           long_entry_logic.append(stochrsi_k_15m < 90.0)
           long_entry_logic.append(
-            (df["SMA_21"].shift(1) < df["SMA_200"].shift(1).infer_objects(copy=False).fillna(value=np.nan))
-            & df["SMA_200"].shift(1).notna()
+            (df["SMA_21"].shift(1) < sma_200.shift(1).infer_objects(copy=False).fillna(value=np.nan))
+            & sma_200.shift(1).notna()
           )
           long_entry_logic.append(
-            (df["SMA_21"] > df["SMA_200"].infer_objects(copy=False).fillna(value=np.nan)) & df["SMA_200"].notna()
+            (df["SMA_21"] > sma_200.infer_objects(copy=False).fillna(value=np.nan)) & sma_200.notna()
           )
           long_entry_logic.append(
             (close > df["EMA_200_1h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_1h"].notna()
@@ -22746,21 +22763,21 @@ class NostalgiaForInfinityX7(IStrategy):
             (close > df["EMA_200_4h"].infer_objects(copy=False).fillna(value=np.nan)) & df["EMA_200_4h"].notna()
           )
           long_entry_logic.append(df["BBB_20_2.0"] > 1.5)
-          long_entry_logic.append(df["BBB_20_2.0_1h"] > 6.0)
+          long_entry_logic.append(bbb_20_2_0_1h > 6.0)
 
         # Condition #162 - Scalp mode (Long).
         if long_entry_condition_index == 162:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append((rsi_3 > 5.0) & (rsi_3_15m > 5.0) & (roc_9_15m > -10.0) & (roc_9_1d < 200.0))
 
           long_entry_logic.append(
             # 15m & 1h down move, 4h high
-            ((rsi_3_15m > 10.0) | (rsi_3_1h > 20.0) | (stochrsi_k_4h < 70.0))
+            ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (df["RSI_14_1h"] < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (rsi_14_1h < 50.0))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m still high, 1h high
@@ -22772,11 +22789,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (df["CMF_20_1d"] > -0.40))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
             # 15m & 1h down nove, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
@@ -22788,7 +22805,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
@@ -22800,7 +22817,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 4h high, 1d overbought
@@ -22810,17 +22827,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 3h down move, 1d high
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 20.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1d overbought
@@ -22836,9 +22853,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 45.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_1h > 45.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move,  4h high, 1d overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 150.0))
             # 4h down move, 1d high
@@ -22856,13 +22873,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 10.0) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1d down move, 1h high
             & ((rsi_3_1d > 3.0) | (stochrsi_k_1h < 70.0))
             # 1d down move, 15m still high
@@ -22874,9 +22891,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high
             & ((rsi_3_1d > 20.0) | (rsi_14_4h < 80.0))
             # 1d downtrend, 1d high & overbought
-            & ((df["CMF_20_1d"] > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 20.0))
             # 1h & 4h high
@@ -22898,53 +22915,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought
             & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 1h P&D, 1h down move
-            & ((df["change_pct_1h"] > -10.0) | (df["change_pct_1h"].shift(12) < 10.0) | (rsi_3_1h > 50.0))
+            & ((change_pct_1h > -10.0) | (change_pct_1h.shift(12) < 10.0) | (rsi_3_1h > 50.0))
             # 4h P&D, 4h high
-            & ((df["change_pct_4h"] > -15.0) | (df["change_pct_4h"].shift(48) < 30.0) | (aroonu_14_4h < 90.0))
+            & ((change_pct_4h > -15.0) | (change_pct_4h.shift(48) < 30.0) | (aroonu_14_4h < 90.0))
             # 4h green, 15m & 1h down move
-            & ((df["change_pct_4h"] < 10.0) | (rsi_3_15m > 10.0) | (rsi_3_1h > 35.0))
+            & ((change_pct_4h < 10.0) | (rsi_3_15m > 10.0) | (rsi_3_1h > 35.0))
             # 4h green, 1h down move
-            & ((df["change_pct_4h"] < 40.0) | (rsi_3_1h > 50.0))
+            & ((change_pct_4h < 40.0) | (rsi_3_1h > 50.0))
             # 4h green with top wick
-            & ((df["change_pct_4h"] < 50.0) | (df["change_pct_4h"] < 50.0))
+            & ((change_pct_4h < 50.0) | (change_pct_4h < 50.0))
             # 1d green with top wick, 15m still high
-            & ((df["change_pct_1d"] < 10.0) | (df["top_wick_pct_1d"] < 8.0) | (aroonu_14_15m < 50.0))
+            & ((change_pct_1d < 10.0) | (top_wick_pct_1d < 8.0) | (aroonu_14_15m < 50.0))
             # 1d green, 4h down move, 4h still high
-            & ((df["change_pct_1d"] < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 50.0))
+            & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 50.0))
             # 1d green with top wick, 4h down move
-            & ((df["change_pct_1d"] < 40.0) | (df["top_wick_pct_1d"] < 8.0) | (rsi_3_4h > 55.0))
+            & ((change_pct_1d < 40.0) | (top_wick_pct_1d < 8.0) | (rsi_3_4h > 55.0))
             # 1d top wick, 4h still high
-            & ((df["top_wick_pct_1d"] < 50.0) | (aroonu_14_4h < 50.0))
+            & ((top_wick_pct_1d < 50.0) | (aroonu_14_4h < 50.0))
             # big drop in last 4 days, 1d down move
-            & ((close > (df["high_max_24_4h"] * 0.20)) | (rsi_3_1d > 20.0))
+            & ((close > (high_max_24_4h * 0.20)) | (rsi_3_1d > 20.0))
             # big drop in the last 20 days, 4h down move
-            & ((close > (df["high_max_20_1d"] * 0.15)) | (rsi_3_4h > 20.0))
+            & ((close > (high_max_20_1d * 0.15)) | rsi_3_4h_gt_20)
             # big drop in the last 20 days, 1d down move
-            & ((close > (df["high_max_20_1d"] * 0.05)) | (rsi_3_1d > 20.0))
+            & ((close > (high_max_20_1d * 0.05)) | (rsi_3_1d > 20.0))
             # big drop in the last 20 days, 1h still high
-            & ((close > (df["high_max_20_1d"] * 0.05)) | (stochrsi_k_1h < 45.0))
+            & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 20 days, 4h high
-            & ((close > (df["high_max_20_1d"] * 0.05)) | (stochrsi_k_4h < 70.0))
+            & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_4h < 70.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["AROONU_14"] < 25.0)
-            & (df["AROOND_14"] > 75.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 30.0)
-            & (df["EMA_26"] > df["EMA_12"])
-            & ((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.030))
-            & ((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
+            (aroonu_14 < 25.0)
+            & (aroond_14 > 75.0)
+            & (stochrsi_k < 30.0)
+            & (ema_26 > ema_12)
+            & ((ema_26 - ema_12) > (df["open"] * 0.030))
+            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
             & (close < df["SMA_9"])
           )
 
         # Condition #163 - Scalp mode (Long).
         if long_entry_condition_index == 163:
           # Protections
-          long_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          long_entry_logic.append(df["protections_long_global"] == True)
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append((rsi_3 > 10.0) & (rsi_3_15m > 10.0) & (rsi_3_1h > 20.0))
+          long_entry_logic.append((rsi_3 > 10.0) & (rsi_3_15m > 10.0) & rsi_3_1h_gt_20)
 
           long_entry_logic.append(
             # 5m & 15m & 4h down mnove, 4h high
@@ -22952,7 +22969,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m & 1d down move, 1h high
             & ((rsi_3 > 15.0) | (rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 5m & 1h down move, 15m still high, 4h high
-            & ((rsi_3 > 20.0) | (rsi_3_1h > 40.0) | (df["RSI_14_15m"] < 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 > 20.0) | (rsi_3_1h > 40.0) | (rsi_14_15m < 40.0) | (aroonu_14_4h < 100.0))
             # 5m & 1h & 15m down move, 1h still not low enough
             & ((rsi_3 > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 30.0))
             # 15m & 4h down move, 4h high
@@ -22969,11 +22986,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 40.0))
             # 15m & 1h & 4h down move, 1h downtrend, 4h high
             & (
-              (rsi_3_15m > 15.0)
-              | (rsi_3_1h > 30.0)
-              | (rsi_3_4h > 55.0)
-              | (df["CMF_20_1h"] > -0.10)
-              | (aroonu_14_4h < 80.0)
+              (rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 55.0) | (cmf_20_1h > -0.10) | (aroonu_14_4h < 80.0)
             )
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 60.0))
@@ -23020,7 +23033,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h & 1d up move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (cmf_20_1d > -0.2))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h & 4h still high
@@ -23030,7 +23043,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d high
@@ -23064,11 +23077,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 15m down move, 4h high
-            & (
-              (rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h < 90.0) | (df["EMA_9"] < (df["EMA_26"] * 0.972))
-            )
+            & ((rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h < 90.0) | (ema_9 < (ema_26 * 0.972)))
             # 15m down move, 4h high and downtrend
-            & ((rsi_3_15m > 15.0) | (df["CMF_20_4h"] > -0.2) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.2) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h & 1d downtrend
@@ -23079,7 +23090,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (
               (rsi_3_15m > 20.0)
               | (rsi_3_1h > 35.0)
-              | (df["CMF_20_1h"] > -0.10)
+              | (cmf_20_1h > -0.10)
               | (aroonu_14_15m < 40.0)
               | (aroonu_14_1h < 85.0)
             )
@@ -23092,9 +23103,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (df["RSI_14_15m"] < 40.0) | (rsi_14_4h < 75.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (rsi_14_4h < 75.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h downtrend, 4h overbought
-            & ((rsi_3_15m > 20.0) | (df["CMF_20_4h"] > -0.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 20.0) | (cmf_20_4h > -0.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h & 4h high, 1f overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 85.0) | (rsi_14_4h < 70.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
@@ -23111,8 +23122,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (
               (rsi_3_15m > 30.0)
               | (rsi_3_1h > 45.0)
-              | (df["RSI_14_15m"] < 30.0)
-              | (df["RSI_14_1h"] < 50.0)
+              | (rsi_14_15m < 30.0)
+              | (rsi_14_1h < 50.0)
               | (rsi_14_4h < 70.0)
               | (aroonu_14_15m < 20.0)
               | (aroonu_14_1h < 60.0)
@@ -23125,7 +23136,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1d high
@@ -23133,15 +23144,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 15m downtrend, 4h still high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_15m"] > -0.4) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_15m > -0.4) | (aroonu_14_4h < 50.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (df["CMF_20_4h"] > -0.25) | (aroonu_14_4h < 70.0))
+            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still not low enough, 1d downtrend
@@ -23157,13 +23168,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (df["MFI_14_1h"] < 80.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h > 30.0) | (mfi_14_1h < 80.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (df["CMF_20_1d"] > -0.2))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
             # 1h down move, 1h highm 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
@@ -23171,7 +23182,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (df["RSI_14_1h"] < 50.0) | (rsi_14_4h < 70.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
             # 1h down move, 15m still not low enough, 1h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 1d high
@@ -23211,7 +23222,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h down move, 15m & 1h high, 1d downtrend
-            & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (df["CMF_20_1d"] > -0.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m high
@@ -23219,45 +23230,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m still not low enough, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (df["CMF_20_4h"] > -0.30))
+            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (cmf_20_4h > -0.30))
             # 4h down move, 15m & 1h still not low enough
             & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (df["CMF_20_4h"] > -0.3))
+            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (cmf_20_4h > -0.3))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (df["RSI_14_1d"] < 40.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 20.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 20.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 40.0) | (roc_9_1d < 20.0))
             # 4h & 1d down move, 1h & 4h low
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (df["CMF_20_1h"] > -0.3) | (df["CMF_20_4h"] > -0.4))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.4))
             # 4h down move, 4h still high 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 50.0))
+            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 20.0))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 100.0))
             # 4h & 1d down move, 4h high, 1d overbought
@@ -23269,7 +23280,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high
             & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 80.0))
             # 1d down move, 15m & 1h still high
-            & ((rsi_3_1d > 10.0) | (df["RSI_14_15m"] < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1d > 10.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h & 4h still high
@@ -23293,11 +23304,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m still high, 1h down move, 4h high
             & ((rsi_3 < 50.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high
-            & ((df["RSI_14_15m"] > 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_14_15m > 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h & 1d high
-            & ((df["RSI_14_15m"] > 30.0) | (stochrsi_k_4h < 90.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_14_15m > 30.0) | (stochrsi_k_4h < 90.0) | (stochrsi_k_1d < 70.0))
             # 1h downtrend, 4h high, 1d downtrend
-            & ((df["CMF_20_1h"] > -0.2) | (stochrsi_k_4h < 90.0) | (df["CMF_20_1d"] > -0.25))
+            & ((cmf_20_1h > -0.2) | (stochrsi_k_4h < 90.0) | (cmf_20_1d > -0.25))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
@@ -23313,42 +23324,42 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h top wick, 1h down move, 1h high
             & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
             # 1d red, 1h down move, 1h still high
-            & ((df["change_pct_1d"] > -15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
+            & ((change_pct_1d > -15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
             # 1d P&D, 1h high
-            & ((df["change_pct_1d"] > -15.0) | (df["change_pct_1d"].shift(288) < 15.0) | (stochrsi_k_1h < 80.0))
+            & ((change_pct_1d > -15.0) | (change_pct_1d.shift(288) < 15.0) | (stochrsi_k_1h < 80.0))
             # 1d P&D, 1d downtrend
-            & ((df["change_pct_1d"] > -5.0) | (df["change_pct_1d"].shift(288) < 30.0) | (df["CMF_20_1d"] > -0.1))
+            & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.1))
             # 1d P&D, 15m high
-            & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 40.0) | (aroonu_14_15m < 50.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (aroonu_14_15m < 50.0))
             # 1d P&D, 1h high
-            & ((df["change_pct_1d"] > -10.0) | (df["change_pct_1d"].shift(288) < 40.0) | (stochrsi_k_1h < 70.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (stochrsi_k_1h < 70.0))
             # 1d red with top wick, 1h high
-            & ((df["change_pct_1d"] > -10.0) | (df["top_wick_pct_1d"] < 10.0) | (aroonu_14_1h < 80.0))
+            & ((change_pct_1d > -10.0) | (top_wick_pct_1d < 10.0) | (aroonu_14_1h < 80.0))
             # 1d green, 4m down move, 4h high
-            & ((df["change_pct_1d"] < 25.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
+            & ((change_pct_1d < 25.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
             # 1d green with top wick, 1d low
-            & ((df["change_pct_1d"] < 25.0) | (df["top_wick_pct_1d"] < 10.0) | (df["CMF_20_1d"] > -0.2))
+            & ((change_pct_1d < 25.0) | (top_wick_pct_1d < 10.0) | (cmf_20_1d > -0.2))
             # 1d top wick, 1h still high
-            & ((df["top_wick_pct_1d"] < 25.0) | (aroonu_14_1h < 50.0))
+            & ((top_wick_pct_1d < 25.0) | (aroonu_14_1h < 50.0))
             # 1d top wick, 4h still high
-            & ((df["top_wick_pct_1d"] < 30.0) | (stochrsi_k_4h < 50.0))
+            & ((top_wick_pct_1d < 30.0) | (stochrsi_k_4h < 50.0))
             # 1d top wick, 1h down move
-            & ((df["top_wick_pct_1d"] < 50.0) | (rsi_3_1h > 30.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_1h > 30.0))
             # big drop in the last 12 days, 1h down move, 1h high
-            & ((close > (df["high_max_12_1d"] * 0.35)) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((close > (high_max_12_1d * 0.35)) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
             # big drop in the last 20 days, 1h down move, 1h high
-            & ((close > (df["high_max_20_1d"] * 0.30)) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 75.0))
+            & ((close > (high_max_20_1d * 0.30)) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 75.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (df["high_max_20_1d"] * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
-            (df["RSI_14"] < 30.0)
-            & (df["AROONU_14"] < 25.0)
-            & (df["AROOND_14"] > 75.0)
-            & (df["STOCHRSIk_14_14_3_3"] < 20.0)
-            & (df["EMA_9"] < (df["EMA_26"] * 0.982))
+            (rsi_14 < 30.0)
+            & (aroonu_14 < 25.0)
+            & (aroond_14 > 75.0)
+            & (stochrsi_k < 20.0)
+            & (ema_9 < (ema_26 * 0.982))
             & (close < df["SMA_9"])
           )
 
@@ -23398,17 +23409,17 @@ class NostalgiaForInfinityX7(IStrategy):
         # Condition #501 - Normal mode (Short).
         if short_entry_condition_index == 501:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          short_entry_logic.append(df["protections_short_global"] == True)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          short_entry_logic.append(protections_short_global == True)
           short_entry_logic.append(df["global_protections_short_pump"] == True)
           short_entry_logic.append(df["global_protections_short_dump"] == True)
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(df["RSI_14_1h"] > 20.0)
+          short_entry_logic.append(rsi_14_1h > 20.0)
           short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(df["RSI_14_1d"] > 10.0)
+          short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m up move, 4h still not high enough
           short_entry_logic.append((rsi_3 < 97.0) | (aroonu_14_4h > 60.0))
           # 5m up move, 4h still low
@@ -23418,7 +23429,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h up move, 1d uptrend
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 90.0) | (roc_9_1d < 100.0))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((rsi_3 < 95.0) | (df["AROOND_14_15m"] < 25.0) | (df["AROOND_14_1h"] < 25.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
           # 4m up move, 1h & 4h still low
           short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0))
           # 4m & 1h up move, 1h still low
@@ -23426,7 +23437,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 80.0) | (aroonu_14_4h > 20.0))
           # 5m up move, 15m & 1h uptrend
-          short_entry_logic.append((rsi_3 < 90.0) | (df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30))
+          short_entry_logic.append((rsi_3 < 90.0) | (cmf_20_15m < 0.30) | (cmf_20_1h < 0.30))
           # 5m up move, 15m stil low
           short_entry_logic.append((rsi_3 < 90.0) | (aroonu_14_15m > 50.0))
           # 5m up move, 15m & 1h still not high enough
@@ -23434,7 +23445,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
           # 15m & 1h up move, 4h still going up
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 4h still not high enough
@@ -23444,7 +23455,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 75.0))
           # 15m up move, 1d lost, 1h low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_14_1d"] > 40.0) | (aroonu_14_1h > 40.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
           # 15m up move, 15m & 4h uptrend
           short_entry_logic.append((rsi_3_15m < 95.0) | (aroonu_14_15m < 90.0) | (aroonu_14_4h < 90.0))
           # 15m up move, 15m stil not high enough, 1h low
@@ -23456,15 +23467,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (aroonu_14_4h > 70.0))
           # 15m up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
           # 15m up move, 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 80.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 70.0))
           # 15m & 1h up move, 1h not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (df["AROOND_14_1h"] < 50.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (aroond_14_1h < 50.0))
           # 15m & 1h up move, 1d stil not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (df["RSI_14_1h"] > 80.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_14_1h > 80.0))
           # 15m & 1h up move, 1d uptrend
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (roc_9_1d < 40.0))
           # 15m & 1h up move, 15m still not high enough
@@ -23474,7 +23485,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 90.0))
           # 15m & 4h up move, 4h not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (aroond_14_4h < 50.0))
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 30.0))
           # 15m & 4h up move, 1h low
@@ -23502,7 +23513,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 15m low
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (stochrsi_k_15m > 50.0))
           # 15m down move, 15m still not high enough, 4h low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["RSI_14_15m"] > 70.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_14_15m > 70.0) | (stochrsi_k_4h > 40.0))
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_4h < 50.0))
           # 15m & 1h up move, 1h still not high enough
@@ -23530,9 +23541,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h still low
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 50.0) | (roc_9_1h < 30.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_1d > 50.0) | (roc_9_1h < 30.0))
           # 1h & 4h strong up move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 95.0) | (rsi_3_4h < 95.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (mfi_14_1h < 95.0) | (rsi_3_4h < 95.0))
           # 1h up move, 1d still low, 1h uptrend
           short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1d > 50.0) | (roc_9_1h < 20.0))
           # 1h strong up move, 15m still move higher
@@ -23542,9 +23553,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d still not high enough
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1d > 70.0))
           # 1h up move, 4h low, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_4h > 20.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_4h > 20.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still low, 1d uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 60.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 60.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still not high enough, 1d low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_1d > 30.0))
           # 1h up move, 4h low, 1h uptrend
@@ -23556,7 +23567,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 15m & 4h still low
           short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (aroond_14_15m < 50.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (stochrsi_k_15m > 90.0))
           # 1h up move, 15m still not high enough, 1h still low
@@ -23566,7 +23577,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d strong up move
           short_entry_logic.append((rsi_3_4h < 95.0) | (rsi_3_1d < 95.0))
           # 4h up move, 15m still low, 1h not high enough
-          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 50.0) | (df["AROOND_14_1h"] < 25.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 50.0) | (aroond_14_1h < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
           short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 70.0) | (roc_9_4h < 60.0))
           # 4h up move, 15m uptrend
@@ -23578,7 +23589,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1h still low
           short_entry_logic.append((rsi_3_4h < 90.0) | (aroonu_14_1h > 40.0))
           # 4h up move, 1d still low, 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 85.0) | (df["RSI_14_1d"] > 40.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h < 85.0) | (rsi_14_1d > 40.0) | (roc_9_4h < 20.0))
           # 4h up move, 4h still low
           short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_4h > 50.0))
           # 4h up move, 1h low
@@ -23592,9 +23603,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 1h & 4h still not low enough
           short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 50.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
-          short_entry_logic.append((df["CMF_20_15m"] < 0.30) | (df["CMF_20_1h"] < 0.30) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
           short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1h > 20.0))
           # 1h & 4h uptrend
@@ -23614,13 +23625,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still not high enough, 1h & 4h overbought
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 1h & 4h & 1d uptrend
           short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
           # 5m green, 15m still not high enough
-          short_entry_logic.append((df["change_pct"] < 5.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((df["change_pct"] < 5.0) | (aroond_14_15m < 50.0))
           # 5m green, 15m still not high enough
           short_entry_logic.append((df["change_pct"] < 5.0) | (stochrsi_k_15m > 90.0))
           # pump in the last half hour, 1h low
@@ -23633,16 +23644,16 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((close < (df["close_min_48"] * 1.50)) | (aroonu_14_15m > 50.0))
 
           # Logic
-          short_entry_logic.append(df["EMA_12"] > df["EMA_26"])
-          short_entry_logic.append((df["EMA_12"] - df["EMA_26"]) > (df["open"] * 0.030))
-          short_entry_logic.append((df["EMA_12"].shift() - df["EMA_26"].shift()) > (df["open"] / 100.0))
+          short_entry_logic.append(ema_12 > ema_26)
+          short_entry_logic.append((ema_12 - ema_26) > (df["open"] * 0.030))
+          short_entry_logic.append((ema_12.shift() - ema_26.shift()) > (df["open"] / 100.0))
           short_entry_logic.append(close > (df["BBU_20_2.0"] * 1.004))
 
         # Condition #502 - Normal mode (Short).
         if short_entry_condition_index == 502:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          short_entry_logic.append(df["protections_short_global"] == True)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          short_entry_logic.append(protections_short_global == True)
 
           # 5m & 15m & 1h & 4h up move
           short_entry_logic.append((rsi_3 < 97.0) | (rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 80.0))
@@ -23685,7 +23696,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h stil low
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (aroonu_14_4h > 50.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (df["RSI_14_1d"] > 40.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (rsi_14_1d > 40.0))
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 30.0))
           # 15m up move, 1h still low, 1d low
@@ -23715,9 +23726,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1h > 70.0))
           # 1h up move, 4h still low, 1h moving higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_1d"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_1d > 40.0))
           # 1h strong up move, 15m still move higher
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h up move, relative stable before the hour
@@ -23737,7 +23748,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 70.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_14_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 20.0))
           # 1h up move, 4h low
@@ -23753,13 +23764,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h low
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 20.0))
           # 4h up move, 1d still low
-          short_entry_logic.append((rsi_3_4h < 97.0) | (df["RSI_14_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_4h < 97.0) | (rsi_14_1d > 50.0))
           # 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_1h > 70.0))
           # 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_4h > 80.0))
           # 4h up move, 15m still not high enough, 4h moving higher
-          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 80.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 80.0) | (cci_20_change_pct_4h < 0.0))
           # 4h up move, 15m still low
           short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 50.0))
           # 4h up move, 1h still low
@@ -23769,7 +23780,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_4h > 70.0))
           # 4h up move, 1d still low, 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 85.0) | (df["RSI_14_1d"] > 50.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h < 85.0) | (rsi_14_1d > 50.0) | (roc_9_4h < 20.0))
           # 4h up move, 4h uptrend
           short_entry_logic.append((rsi_3_4h < 80.0) | (roc_9_4h < 20.0))
           # 4h up move, 1h low
@@ -23801,7 +23812,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h low
           short_entry_logic.append((stochrsi_k_1h > 20.0) | (aroonu_14_4h > 20.0))
           # 1d big green, 1d still not high enough
-          short_entry_logic.append((df["change_pct_1d"] < 30.0) | (df["RSI_14_1d"] > 65.0))
+          short_entry_logic.append((change_pct_1d < 30.0) | (rsi_14_1d > 65.0))
           # rise in the last hour, relatively stable before the hour
           short_entry_logic.append(
             (close < (df["close_min_12"] * 1.10)) | (df["close_min_12"] > (df["close_min_48"] * 1.10))
@@ -23812,25 +23823,25 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((close < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h < 90.0))
 
           # Logic
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
-          short_entry_logic.append(close > (df["EMA_20"] * 1.060))
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(stochrsi_k > 80.0)
+          short_entry_logic.append(close > (ema_20 * 1.060))
           short_entry_logic.append(close > (df["BBU_20_2.0"] * 0.995))
-          short_entry_logic.append(df["AROOND_14_15m"] < 25.0)
+          short_entry_logic.append(aroond_14_15m < 25.0)
 
         # Condition #503 - Normal mode (Short).
         if short_entry_condition_index == 503:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(df["RSI_14_1h"] > 20.0)
+          short_entry_logic.append(rsi_14_1h > 20.0)
           short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(df["RSI_14_1d"] > 10.0)
+          short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 5m down move, 4h still high
           short_entry_logic.append((rsi_3 < 90.0) | (df["MFI_14"] > 10.0) | (stochrsi_k_4h > 30.0))
           # 5m & 1h down move, 1h still high
@@ -23846,7 +23857,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h high, 4h downtrend
           short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h < 10.0))
           # 5m & 1h down move, 4h down
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 85.0) | (df["CMF_20_4h"] > -0.2))
+          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 85.0) | (cmf_20_4h > -0.2))
           # 5m down move, 1h high
           short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (stochrsi_k_1h > 30.0))
           # 5m down move, 1h high
@@ -23855,7 +23866,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 15m still not low enough, 1h & 4h still not low enough
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 75.0) | (df["MFI_14_4h"] > 50.0)
+            (rsi_3_15m < 95.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 75.0) | (df["MFI_14_4h"] > 50.0)
           )
           # 5m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0))
@@ -23866,9 +23877,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 50.0) | (rsi_14_4h > 50.0))
           # 15m & 1h & 4h down move
-          short_entry_logic.append(
-            (rsi_3_15m < 90.0) | (df["RSI_3_change_pct_1h"] > -60.0) | (df["RSI_3_change_pct_4h"] > -40.0)
-          )
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_change_pct_1h > -60.0) | (rsi_3_change_pct_4h > -40.0))
           # 15m down move, 1d downtrend, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (roc_9_1d > -25.0) | (stochrsi_k_1h > 30.0))
           # 15m & 1d down move, 1h still high
@@ -23876,122 +23885,116 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 15m still not low enough, 4h down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["AROOND_14_15m"] < 50.0) | (rsi_3_4h < 85.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (aroond_14_15m < 50.0) | (rsi_3_4h < 85.0))
           # 15m down move, 1h still high, 1d strong downtrend
-          short_entry_logic.append((rsi_3_15m < 80.0) | (df["AROOND_14_1h"] < 25.0) | (df["MFI_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_1h < 25.0) | (df["MFI_14_1d"] < 90.0))
           # 15m down move, 1h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0) | roc_9_1d_lt_50)
           # 15m down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 15m & 4h down move, 1d downtrend
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (roc_9_1d > -70.0))
           # 15m down move, 15m not low enough, 1h overbought
           short_entry_logic.append(
-            (df["RSI_14_change_pct_15m"] > -40.0) | (stochrsi_k_15m > 90.0) | (df["RSI_14_1h"] > 30.0)
+            (df["RSI_14_change_pct_15m"] > -40.0) | (stochrsi_k_15m > 90.0) | (rsi_14_1h > 30.0)
           )
           # 15m strong down move, 1h still high
           short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 50.0))
           # 15m downtrend, 1h & 4h still high
           short_entry_logic.append((roc_9_15m < 10.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 50.0))
           # 15m & 1h & 4h down move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_4h < 0.0))
           # 15m strong down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["MFI_14_15m"] < 85.0) | (df["AROOND_14_15m"] < 25.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (mfi_14_15m < 85.0) | (aroond_14_15m < 25.0))
           # 14m down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 80.0) | (df["AROOND_14_15m"] < 50.0) | (df["UO_7_14_28_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m < 50.0) | (df["UO_7_14_28_4h"] > 50.0))
           # 15m down move, 1h stil high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["AROOND_14_1h"] < 25.0) | (roc_9_1d > -80.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (aroond_14_1h < 25.0) | (roc_9_1d > -80.0))
           # 15m down move, 1h high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | roc_9_1d_gt_neg_50)
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h < 10.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1d > -120.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
           # 1h down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((df["RSI_3_change_pct_1h"] > -65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_change_pct_1h > -65.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1h still high
           short_entry_logic.append((rsi_3_4h < 90.0) | (df["ROC_2_1d"] < 20.0) | (stochrsi_k_1h > 50.0))
           # 15m still high, 1h down move, 4h high
-          short_entry_logic.append(
-            (df["AROOND_14_15m"] < 50.0) | (df["RSI_3_change_pct_1h"] < 50.0) | (stochrsi_k_4h > 30.0)
-          )
+          short_entry_logic.append((aroond_14_15m < 50.0) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h > 30.0))
           # 15m still high, 1h & 4h down move, 4h still high
           short_entry_logic.append(
-            (df["AROOND_14_15m"] < 50.0) | (rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (stochrsi_k_4h > 80.0)
+            (aroond_14_15m < 50.0) | (rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (stochrsi_k_4h > 80.0)
           )
           # 15m & 1h still high, 4h overbought
-          short_entry_logic.append((df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_1h"] < 50.0) | (roc_9_4h > -40.0))
+          short_entry_logic.append((aroond_14_15m < 50.0) | (aroond_14_1h < 50.0) | (roc_9_4h > -40.0))
           # 15m still high, 1h down move, 1d downtrend
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h < 90.0) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
           short_entry_logic.append((stochrsi_k_1h > 50.0) | (df["UO_7_14_28_4h"] > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
-          short_entry_logic.append((df["AROOND_14_1h"] < 25.0) | (roc_9_4h < 20.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h < 20.0) | roc_9_1d_lt_50)
           # 4h moving down, 1d P&D
-          short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | roc_9_1d_gt_neg_50)
           # 1d strong downtrend, 4h still high
-          short_entry_logic.append((df["ROC_2_1d"] < 20.0) | (roc_9_1d < 50.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((df["ROC_2_1d"] < 20.0) | roc_9_1d_lt_50 | (stochrsi_k_4h > 70.0))
           # 1d P&D, 1d overbought
-          short_entry_logic.append((df["ROC_2_1d"] < 10.0) | (roc_9_1d > -50.0) | (stochrsi_k_1h > 5.0))
+          short_entry_logic.append((df["ROC_2_1d"] < 10.0) | roc_9_1d_gt_neg_50 | (stochrsi_k_1h > 5.0))
           # 1h red, previous 1h green, 1h overbought
           short_entry_logic.append(
-            (df["change_pct_1h"] < 1.0) | (df["change_pct_1h"].shift(12) > -5.0) | (df["RSI_14_1h"].shift(12) < 80.0)
+            (change_pct_1h < 1.0) | (change_pct_1h.shift(12) > -5.0) | (rsi_14_1h.shift(12) < 80.0)
           )
           # 1h red, 1h stil high, 4h downtrend
-          short_entry_logic.append((df["change_pct_1h"] < 5.0) | (stochrsi_k_1h > 50.0) | (roc_9_4h > -25.0))
+          short_entry_logic.append((change_pct_1h < 5.0) | (stochrsi_k_1h > 50.0) | (roc_9_4h > -25.0))
           # 4h red, 15m down move, 4h still high
-          short_entry_logic.append((df["change_pct_4h"] < 5.0) | (rsi_3_15m < 90.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((change_pct_4h < 5.0) | (rsi_3_15m < 90.0) | (stochrsi_k_4h > 30.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (roc_9_4h.shift(48) > -25.0)
+            (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (roc_9_4h.shift(48) > -25.0)
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 10.0) | (df["AROOND_14_4h"] < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
+            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
           )
           # 4h red, 4h still high, 1d downtrend
-          short_entry_logic.append((df["change_pct_4h"] < 10.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 40.0))
+          short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 40.0))
           # 1d P&D, 1d overbought
-          short_entry_logic.append(
-            (df["change_pct_1d"] < 10.0) | (df["change_pct_1d"].shift(288) > -10.0) | (roc_9_1d > -100.0)
-          )
+          short_entry_logic.append((change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (roc_9_1d > -100.0))
           # 1d P&D, 4h still high
-          short_entry_logic.append(
-            (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (df["AROOND_14_4h"] < 50.0)
-          )
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((change_pct_1d < 15.0) | (change_pct_1d.shift(288) > -15.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < 0.0))
 
           # Logic
-          short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
-          short_entry_logic.append(df["RSI_4"] > 54.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(close > df["SMA_16"] * 1.058)
+          short_entry_logic.append(rsi_20 > rsi_20.shift(1))
+          short_entry_logic.append(rsi_4 > 54.0)
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(close > sma_16 * 1.058)
 
         # Condition #504 - Normal mode (Short).
         if short_entry_condition_index == 504:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(df["RSI_14_1h"] > 20.0)
+          short_entry_logic.append(rsi_14_1h > 20.0)
           short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(df["RSI_14_1d"] > 10.0)
+          short_entry_logic.append(rsi_14_1d > 10.0)
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (df["MFI_14_15m"] < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 50.0)
+            (rsi_3_15m < 95.0) | (mfi_14_15m < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 50.0)
           )
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["MFI_14_15m"] < 85.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (mfi_14_15m < 85.0) | (stochrsi_k_4h > 30.0))
           # 14m & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h & 4h still high
@@ -23999,51 +24002,51 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h strong down move, 4h still high
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_1h"] < 40.0) | (stochrsi_k_4h > 30.0))
           # 1h strong down move, 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 75.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 75.0) | (aroond_14_4h < 50.0))
           # 15m down move, 1h strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
           short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
 
           # Logic
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["AROOND_14_15m"] < 25.0)
-          short_entry_logic.append(close > (df["EMA_9"] * 1.058))
-          short_entry_logic.append(close > (df["EMA_20"] * 1.040))
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(aroond_14_15m < 25.0)
+          short_entry_logic.append(close > (ema_9 * 1.058))
+          short_entry_logic.append(close > (ema_20 * 1.040))
 
         # Condition #541 - Quick mode (Short).
         if short_entry_condition_index == 541:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 5m & 15m down move, 4h still high
           short_entry_logic.append((rsi_3 < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (rsi_14_4h > 50.0))
           # 5m & 15m & 1h down move
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0) | (rsi_3_1h < 95.0))
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 15m & 1h strong down move & downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] > 5.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h > 5.0))
           # 15m strong down move, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_4h > 10.0))
           # 15m & 1h down move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["CCI_20_change_pct_1h"] > 0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_1h > 0.0))
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 30.0))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 50.0) | (df["MFI_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 50.0) | (df["MFI_14_4h"] > 50.0))
           # 15m strong down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["MFI_14_15m"] < 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (mfi_14_15m < 90.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 1h not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 80.0))
           # 15m down move, 1h strong down move
           short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_14_change_pct_1h"] < 70.0))
           # 15m down move, 4h & 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
           # 15m down move, 1h strong down move, 4h stil high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h & 4h still high
@@ -24053,44 +24056,39 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 30.0))
           # 15m down move, 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["RSI_3_change_pct_1h"] < 30.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_change_pct_1h < 30.0) | (stochrsi_k_4h > 10.0))
           # 1m down move, 1h still dropping, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["CCI_20_change_pct_1h"] < 0.0) | (rsi_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h > 20.0))
           # 15m down move, 1h high
           short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h > 10.0))
           # 1h strong down move, 4h high
           short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h downtrend, 4h not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["CMF_20_4h"] > -0.25) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (cmf_20_4h > -0.25) | (stochrsi_k_4h > 70.0))
           # 1h down move, 4h high, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_14_4h > 40.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_14_4h > 40.0) | roc_9_1d_gt_neg_50)
           # 1h down move, 4h strong down move
           short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_4h"] < 40.0))
           # 1h & 4h down move, 4h still going down
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < 0.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 70.0))
           # 1h down move, 4h down move, 4h P&D
-          short_entry_logic.append(
-            (rsi_3_1h < 90.0) | (df["RSI_3_change_pct_4h"] < 70.0) | (rsi_14_4h.shift(48) > 30.0)
-          )
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 70.0) | (rsi_14_4h.shift(48) > 30.0))
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
-            (rsi_3_1h < 90.0)
-            | (df["RSI_3_change_pct_4h"] < 50.0)
-            | (df["AROOND_14_4h"] < 25.0)
-            | (stochrsi_k_1d > 60.0)
+            (rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d > 60.0)
           )
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0) | (df["ROC_2_1d"] > -50.0))
           # 4h downtrend, 4h still high, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_4h > 70.0) | (roc_9_1d < 60.0))
           # 15m down move, 1h strong down move, 1d overbought
-          short_entry_logic.append((df["MFI_14_15m"] < 80.0) | (df["RSI_3_change_pct_1h"] < 80.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((mfi_14_15m < 80.0) | (rsi_3_change_pct_1h < 80.0) | roc_9_1d_gt_neg_50)
           # 1h not low enough, 4h high, 1d strong downtrend
           short_entry_logic.append((stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((df["RSI_3_change_pct_1h"] < 65.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_change_pct_1h < 65.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
           # 15m strong down move, 1h still high
           short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 30.0))
           # 15m downtrend, 4h down move, 4h stil high
@@ -24100,48 +24098,38 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h P&D, 4h still high
           short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h > 30.0))
           # 1h downtrend, 4h down move, 1d downtrend
-          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h < 90.0) | roc_9_1d_lt_50)
           short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
           # 4h down move, 1d P&D
-          short_entry_logic.append((roc_9_4h < 20.0) | (df["ROC_2_1d"] < 20.0) | (roc_9_1d > -50.0))
+          short_entry_logic.append((roc_9_4h < 20.0) | (df["ROC_2_1d"] < 20.0) | roc_9_1d_gt_neg_50)
           # 1h P&D, 4h overbought
-          short_entry_logic.append(
-            (df["change_pct_1h"] < 2.0) | (df["change_pct_1h"].shift(12) > 2.0) | (rsi_14_4h > 20.0)
-          )
+          short_entry_logic.append((change_pct_1h < 2.0) | (change_pct_1h.shift(12) > 2.0) | (rsi_14_4h > 20.0))
           # 1h P&D, 1d overbought
-          short_entry_logic.append(
-            (df["change_pct_1h"] < 5.0) | (df["change_pct_1h"].shift(12) > -5.0) | (roc_9_1d > -100.0)
-          )
+          short_entry_logic.append((change_pct_1h < 5.0) | (change_pct_1h.shift(12) > -5.0) | (roc_9_1d > -100.0))
           # 1h & 4h red, 1h not low enough
-          short_entry_logic.append(
-            (df["change_pct_1h"] < 10.0) | (df["change_pct_4h"] < 10.0) | (df["MFI_14_1h"] > 50.0)
-          )
+          short_entry_logic.append((change_pct_1h < 10.0) | (change_pct_4h < 10.0) | (mfi_14_1h > 50.0))
           # 1h red, 1h still not low enough, 1d down move
-          short_entry_logic.append((df["change_pct_1h"] < 15.0) | (df["MFI_14_1h"] > 50.0) | (rsi_3_1d < 90.0))
+          short_entry_logic.append((change_pct_1h < 15.0) | (mfi_14_1h > 50.0) | (rsi_3_1d < 90.0))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
+            (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
           )
           # 1d P&D, 1d overbought
-          short_entry_logic.append(
-            (df["change_pct_1d"] < 10.0) | (df["change_pct_1d"].shift(288) > -10.0) | (roc_9_1d > -100.0)
-          )
+          short_entry_logic.append((change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (roc_9_1d > -100.0))
           # 1d P&D, 4h still high
-          short_entry_logic.append(
-            (df["change_pct_1d"] < 15.0) | (df["change_pct_1d"].shift(288) > -15.0) | (df["AROOND_14_4h"] < 50.0)
-          )
+          short_entry_logic.append((change_pct_1d < 15.0) | (change_pct_1d.shift(288) > -15.0) | (aroond_14_4h < 50.0))
 
           # Logic
-          short_entry_logic.append(df["RSI_14"] > 64.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["AROONU_14"] > 75.0)
-          short_entry_logic.append(df["EMA_9"] > (df["EMA_26"] * 1.040))
+          short_entry_logic.append(rsi_14 > 64.0)
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(aroonu_14 > 75.0)
+          short_entry_logic.append(ema_9 > (ema_26 * 1.040))
 
         # Condition #542 - Quick mode (Short).
         if short_entry_condition_index == 542:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
-          short_entry_logic.append(df["protections_short_global"] == True)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          short_entry_logic.append(protections_short_global == True)
 
           # 5m & 15m up move, 15m stil low
           short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_15m < 80.0) | (aroonu_14_15m > 60.0))
@@ -24150,9 +24138,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (cci_20_change_pct_1h < -0.0))
           # 15m & 4h up move, 4h still moving higher
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (df["CCI_20_change_pct_4h"] < -0.0))
+          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1d up move, 4h uptrend
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1d < 80.0) | (roc_9_4h < 20.0))
           # 15m up move, 15m & 4h high
@@ -24162,7 +24150,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 90.0) | (stochrsi_k_15m > 70.0))
           # 15m & 4h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | roc_9_1d_lt_50)
           # 15m & 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 80.0) | (rsi_14_4h > 60.0))
           # 15m up move, 15m still not high enough, 4h still low
@@ -24176,19 +24164,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 60.0) | (aroonu_14_4h > 40.0))
           # 1h & 1d up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_15m > 80.0))
           # 1h & 4h up move, 1d uptrend
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (roc_9_1d < 100.0))
           # 1h & 4h up move, 1d still low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (df["RSI_14_1d"] > 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (rsi_14_1d > 50.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 95.0) | (aroonu_14_4h > 10.0))
           # 1h & 4h up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_4h > 80.0))
           # 1h & 1d up move, 15m still low
@@ -24198,17 +24186,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 30.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 60.0) | (df["CCI_20_change_pct_1h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 15m uptrend
           short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 30.0))
           # 1h up move, 15m & 4h uptrend
           short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 20.0) | (roc_9_4h < 20.0))
           # 1h & 4h up move, 4h still moving higher
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (df["CCI_20_change_pct_4h"] < -0.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (cci_20_change_pct_4h < -0.0))
           # 1h up move, 15m low
           short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_15m > 40.0))
           # 1h up move, 4h still not high enough, 1d low
-          short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_4h > 80.0) | (df["RSI_14_1d"] > 40.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_4h > 80.0) | (rsi_14_1d > 40.0))
           # 1h & 4h up move, 4h still low
           short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (aroonu_14_4h > 50.0))
           # 1h & 4h up move, 1d still low
@@ -24222,7 +24210,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h & 1d uptrend
           short_entry_logic.append((rsi_3_1h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h < 95.0) | (df["RSI_14_1d"] > 40.0))
+          short_entry_logic.append((rsi_3_4h < 95.0) | (rsi_14_1d > 40.0))
           # 4h down move, 15m still not high enough, 1d low
           short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
           # 4h up move, 1h & 4h uptrend
@@ -24244,7 +24232,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 4h low
           short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h > 40.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h high, 4h uptrend
           short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
           # 15m & 4h high, 1h uptrend
@@ -24260,9 +24248,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h still not high enough
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 70.0))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_1h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 1d bot wick, 4h still not high enough
           short_entry_logic.append((df["bot_wick_pct_1d"] < 30.0) | (stochrsi_k_4h > 80.0))
           # rise in the last 12 hours, relatively stable before the 12 hours
@@ -24273,49 +24261,49 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((close < (df["low_min_30_1d"] * 4.0)) | (rsi_3_4h < 85.0))
 
           # Logic
-          short_entry_logic.append(df["WILLR_14"] > -50.0)
-          short_entry_logic.append(df["AROONU_14"] > 75.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
+          short_entry_logic.append(willr_14 > -50.0)
+          short_entry_logic.append(aroonu_14 > 75.0)
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(stochrsi_k > 80.0)
           short_entry_logic.append(df["WILLR_84_1h"] > -30.0)
           short_entry_logic.append(stochrsi_k_1h > 80.0)
-          short_entry_logic.append(df["BBB_20_2.0_1h"] > 20.0)
+          short_entry_logic.append(bbb_20_2_0_1h > 20.0)
           short_entry_logic.append(df["close_min_48"] <= (close * 0.90))
 
         # Condition #543 - Rapid mode (Short).
         if short_entry_condition_index == 543:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
-          short_entry_logic.append(df["RSI_14_1h"] > 20.0)
+          short_entry_logic.append(rsi_14_1h > 20.0)
           short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(df["RSI_14_1d"] > 10.0)
+          short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (df["ROC_9"] < 50.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 15m down move, 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 60.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 60.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_3_change_pct_1h"] < 40.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 40.0) | (stochrsi_k_4h > 30.0))
           # 5m down move, 1h down, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["CMF_20_1h"] < 0.2) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (cmf_20_1h < 0.2) | (stochrsi_k_4h > 50.0))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["AROOND_14_1h"] < 25.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (aroond_14_1h < 25.0) | (stochrsi_k_4h > 10.0))
           # 15m down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 90.0) | (df["OBV_change_pct_15m"] < 50.0) | (stochrsi_k_1h > 30.0))
           # 5m & 1h strong down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 70.0))
           # 5m & 1h strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (df["MFI_14_1h"] < 90.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h < 90.0))
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0) | (df["AROOND_14_4h"] < 50.0)
+            (rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0) | (aroond_14_4h < 50.0)
           )
           # 15m & 1h down move, 4h still high, 4h downtrend
           short_entry_logic.append(
             (rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (df["UO_7_14_28_4h"] > 60.0) | (roc_9_4h < 20.0)
           )
           # 15m & 1h down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | roc_9_1d_lt_50)
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 55.0))
           # 15m down move, 15m still not low enough, 1h still high
@@ -24323,47 +24311,44 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 75.0) | (stochrsi_k_1h > 30.0))
           # 15m down move, 15m still not low enoug, 1h high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 85.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 10.0))
           # 15m down move, 1h downtrend, 4h overbought
           short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h > 50.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_3_change_pct_4h"] < 65.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 70.0))
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
           # 1h down move, 1h not low enough, 1h still high
-          short_entry_logic.append((rsi_3_1h < 85.0) | (df["AROOND_14_1h"] < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 85.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 50.0))
           # 4h down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h > 50.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h > 50.0) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h < 90.0) | (rsi_3_1d < 90.0) | (roc_9_1d < 60.0))
           # 4h overbought, 1h still high, 1d downtrend
-          short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h > 70.0) | (roc_9_1d < 50.0))
+          short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h > 70.0) | roc_9_1d_lt_50)
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
-            (df["change_pct_4h"] < 5.0) | (df["change_pct_4h"].shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
+            (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
           )
           # 4h red, 4h moving down, 4h still high, 1d downtrend
           short_entry_logic.append(
-            (df["change_pct_4h"] < 10.0)
-            | (df["CCI_20_change_pct_4h"] < 0.0)
-            | (stochrsi_k_4h > 50.0)
-            | (roc_9_1d < 40.0)
+            (change_pct_4h < 10.0) | (cci_20_change_pct_4h < 0.0) | (stochrsi_k_4h > 50.0) | (roc_9_1d < 40.0)
           )
 
           # Logic
-          short_entry_logic.append(df["RSI_14"] > 60.0)
+          short_entry_logic.append(rsi_14 > 60.0)
           short_entry_logic.append(df["MFI_14"] > 60.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(df["EMA_26"] < df["EMA_12"])
-          short_entry_logic.append((df["EMA_26"] - df["EMA_12"]) > (df["open"] * 0.024))
-          short_entry_logic.append((df["EMA_26"].shift() - df["EMA_12"].shift()) > (df["open"] / 100.0))
-          short_entry_logic.append(close < (df["EMA_20"] * 0.958))
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(ema_26 < ema_12)
+          short_entry_logic.append((ema_26 - ema_12) > (df["open"] * 0.024))
+          short_entry_logic.append((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+          short_entry_logic.append(close < (ema_20 * 0.958))
           short_entry_logic.append(close < (df["BBL_20_2.0"] * 0.992))
 
         # # Condition #620 - Grind mode (Short).
@@ -24375,35 +24360,35 @@ class NostalgiaForInfinityX7(IStrategy):
         #   short_entry_logic.append(rsi_3_15m >= 10.0)
         #   short_entry_logic.append(rsi_3_1h >= 5.0)
         #   short_entry_logic.append(rsi_3_4h >= 5.0)
-        #   short_entry_logic.append(df["RSI_14_1h"] < 85.0)
+        #   short_entry_logic.append(rsi_14_1h < 85.0)
         #   short_entry_logic.append(df["RSI_14_4h"] < 85.0)
-        #   short_entry_logic.append(df["RSI_14_1d"] < 85.0)
-        #   short_entry_logic.append(df["close_max_48"] >= (df["close"] * 1.10))
+        #   short_entry_logic.append(rsi_14_1d < 85.0)
+        #   short_entry_logic.append(close_max_48 >= (df["close"] * 1.10))
 
         #   # Logic
-        #   short_entry_logic.append(df["STOCHRSIk_14_14_3_3"] > 80.0)
-        #   short_entry_logic.append(df["WILLR_14"] > -20.0)
-        #   short_entry_logic.append(df["AROOND_14"] < 25.0)
+        #   short_entry_logic.append(stochrsi_k > 80.0)
+        #   short_entry_logic.append(willr_14 > -20.0)
+        #   short_entry_logic.append(aroond_14 < 25.0)
 
         # Condition #641 - Top Coins mode (Short).
         if short_entry_condition_index == 641:
           # Protections
           short_entry_logic.append(is_pair_short_top_coins_mode)
 
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(df["RSI_14_1h"] > 20.0)
+          short_entry_logic.append(rsi_14_1h > 20.0)
           short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(df["RSI_14_1d"] > 10.0)
+          short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m down move, 1h still not low enough, 4h high
           short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 30.0))
           # 5m down move, 1h high, 4h still not low enough
           short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
           # 15m down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["AROOND_14_15m"] < 25.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 95.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 1d still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1d > 70.0))
           # 15m & 1h down move, 1h still not low enough
@@ -24436,24 +24421,24 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_4h < 15.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 80.0))
 
           # Logic
-          short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
+          short_entry_logic.append(rsi_20 > rsi_20.shift(1))
           short_entry_logic.append(rsi_3 > 70.0)
-          short_entry_logic.append(df["AROOND_14"] < 25.0)
-          short_entry_logic.append(close > df["SMA_16"] * 1.044)
+          short_entry_logic.append(aroond_14 < 25.0)
+          short_entry_logic.append(close > sma_16 * 1.044)
 
         # Condition #642 - Top Coins mode (Short).
         if short_entry_condition_index == 642:
           # Protections
           short_entry_logic.append(is_pair_short_top_coins_mode)
 
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 5m & 1h & 4h down move
           short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 95.0) | (rsi_3_4h < 90.0))
           # 5m down move, 15m & 4h still high
           short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
           # 5m down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3 < 85.0) | (df["AROOND_14_15m"] < 50.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h > 20.0))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 90.0))
           # 15m & 1h down move, 1d still not low enough
@@ -24547,52 +24532,52 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high
           short_entry_logic.append((stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 20.0))
           # 1d red, 1d high
-          short_entry_logic.append((df["change_pct_1d"] < 5.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((change_pct_1d < 5.0) | (stochrsi_k_1d > 20.0))
           # 1d P&D, 1d high
           short_entry_logic.append(
-            (df["change_pct_1d"] < 10.0) | (df["change_pct_1d"].shift(288) > -10.0) | (stochrsi_k_1d > 50.0)
+            (change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (stochrsi_k_1d > 50.0)
           )
 
           # Logic
-          short_entry_logic.append(df["RSI_4"] > 54.0)
-          short_entry_logic.append(df["RSI_20"] > df["RSI_20"].shift(1))
-          short_entry_logic.append(close > df["SMA_16"] * 1.042)
+          short_entry_logic.append(rsi_4 > 54.0)
+          short_entry_logic.append(rsi_20 > rsi_20.shift(1))
+          short_entry_logic.append(close > sma_16 * 1.042)
 
         # Condition #661 - Scalp mode (Short).
         if short_entry_condition_index == 661:
           # Protections
-          short_entry_logic.append(df["num_empty_288"] <= allowed_empty_candles_288)
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 15m down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (df["AROOND_14_15m"] < 80.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (aroond_14_15m < 80.0))
           # 15m & 1h down move, 15m still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 50.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (aroond_14_15m < 50.0))
           # 15m down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 15m & 1h down move, 1h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (df["AROOND_14_1h"] < 70.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (aroond_14_1h < 70.0))
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (stochrsi_k_1h > 50.0))
           # 15m & 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (df["AROOND_14_4h"] < 80.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (aroond_14_4h < 80.0))
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m > 50.0))
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (df["AROOND_14_15m"] < 50.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 50.0))
           # 15m down move, 4h still high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 60.0) | (df["AROOND_14_4h"] < 50.0) | (roc_9_1d > -100.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_4h < 50.0) | (roc_9_1d > -100.0))
           # 15m down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 55.0) | (df["AROOND_14_15m"] > 30.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 55.0) | (aroond_14_15m > 30.0) | (stochrsi_k_4h > 50.0))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h > 60.0))
           # 15m down move, 15m still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 75.0) | (df["AROOND_14_4h"] < 50.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (aroond_14_4h < 50.0) | (stochrsi_k_1d > 10.0))
           short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 60.0) | (stochrsi_k_1d > 10.0))
           # 1h & 4h down move, 4h high
           short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
@@ -24603,99 +24588,99 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 40.0))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (df["AROOND_14_4h"] < 85.0) | (df["AROOND_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (aroond_14_4h < 85.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 55.0) | (df["AROOND_14_1h"] < 50.0) | (df["AROOND_14_4h"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 55.0) | (aroond_14_1h < 50.0) | (aroond_14_4h < 90.0))
           # 1h down move, 1h high
           short_entry_logic.append((rsi_3_1h < 55.0) | (stochrsi_k_1h > 40.0))
           # 1h & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (df["AROOND_14_15m"] < 70.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (aroond_14_15m < 70.0))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_15m"] < 50.0) | (df["AROOND_14_4h"] < 80.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 50.0) | (aroond_14_4h < 80.0))
           # 1h down move, 15m high, 1h still high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_15m"] < 70.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h > 60.0))
           # 1h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (df["AROOND_14_1h"] < 60.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (df["AROOND_14_1h"] < 70.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d > 20.0))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 10.0))
           # 1h down move, 5m up move, 1h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h > 50.0))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (df["AROOND_14_1h"] < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 40.0))
           # 1h down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_1h"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_1h"] < 50.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (df["AROOND_14_1h"] < 80.0) | (df["AROOND_14_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 80.0) | (aroond_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 60.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 60.0) | (aroond_14_4h < 70.0))
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 30.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (df["RSI_14_1d"] > 20.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (rsi_14_1d > 20.0))
           # 4h down move, 15m high
-          short_entry_logic.append((rsi_3_4h < 80.0) | (df["AROOND_14_15m"] < 80.0))
+          short_entry_logic.append((rsi_3_4h < 80.0) | (aroond_14_15m < 80.0))
           # 4h down move, 1h high
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h > 50.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h > 50.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (df["AROOND_14_15m"] < 80.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h still high, 4h still moving down
-          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h > 50.0) | (df["CCI_20_change_pct_4h"] < 0.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h > 50.0) | (cci_20_change_pct_4h < 0.0))
           # 4h down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 55.0) | (df["AROOND_14_1h"] < 70.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_4h < 55.0) | (aroond_14_1h < 70.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (df["AROOND_14_15m"] < 70.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_4h > 60.0))
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 30.0))
           # 4h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 50.0) | (df["AROOND_14_4h"] < 50.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 50.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still not low enough
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 70.0))
           # 4h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h > 50.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h > 50.0) | (aroond_14_4h < 70.0))
           # 4h down move, 15m & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_4h < 70.0))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (df["AROOND_14_15m"] < 80.0) | (df["AROOND_14_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 80.0) | (aroond_14_4h < 40.0))
           # 4h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 30.0))
           # 4h down move, 15m & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
           # 4h down move, 1h & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h > 30.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h > 30.0) | (aroond_14_4h < 70.0))
           # 4h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 20.0))
           # 15m high, 4h high
-          short_entry_logic.append((df["AROOND_14_15m"] < 70.0) | (df["AROOND_14_4h"] < 85.0))
+          short_entry_logic.append((aroond_14_15m < 70.0) | (aroond_14_4h < 85.0))
           # 15m high, 4h still high
-          short_entry_logic.append((df["AROOND_14_15m"] < 80.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((aroond_14_15m < 80.0) | (stochrsi_k_4h > 50.0))
           # 15m high, 1h still high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 60.0))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (df["AROOND_14_4h"] < 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (aroond_14_4h < 70.0))
           # 15m high, 1h still not low enough
           short_entry_logic.append((stochrsi_k_15m > 20.0) | (stochrsi_k_1h > 70.0))
 
           # Logic
-          short_entry_logic.append(df["RSI_14"] > 50.0)
-          short_entry_logic.append(df["AROOND_14_15m"] < 90.0)
+          short_entry_logic.append(rsi_14 > 50.0)
+          short_entry_logic.append(aroond_14_15m < 90.0)
           short_entry_logic.append(stochrsi_k_15m > 10.0)
-          if isinstance(df["SMA_200"].iloc[-1], np.float64):
-            short_entry_logic.append(df["SMA_21"].shift(1) > df["SMA_200"].shift(1))
-            short_entry_logic.append(df["SMA_21"] < df["SMA_200"])
+          if isinstance(sma_200.iloc[-1], np.float64):
+            short_entry_logic.append(df["SMA_21"].shift(1) > sma_200.shift(1))
+            short_entry_logic.append(df["SMA_21"] < sma_200)
           else:
             short_entry_logic.append(pd.Series([False]))
           if isinstance(df["EMA_200_1h"].iloc[-1], np.float64):
@@ -24706,7 +24691,7 @@ class NostalgiaForInfinityX7(IStrategy):
             short_entry_logic.append(close < df["EMA_200_4h"])
           else:
             short_entry_logic.append(pd.Series([False]))
-          short_entry_logic.append(df["BBB_20_2.0_1h"] > 4.0)
+          short_entry_logic.append(bbb_20_2_0_1h > 4.0)
 
         ###############################################################################################
 


### PR DESCRIPTION
## Summary
- Consolidates the smaller entry Series/mask read PRs into one upstream-ready patch.
- Reuses already-read `populate_entry_trend` Series and comparison masks instead of rebuilding the same dataframe expressions repeatedly.
- Replaces the overlapping smaller PRs #912, #913, #914, #915, #916, #917, #918, #919, #920, #952, #953, #954, #955, and #956.

## Safety
- Behavior is intended to stay identical: indicators, thresholds, candle selection, entry condition order, and returned dataframe columns are unchanged.
- The new locals are bound inside the same `populate_entry_trend` call and replace the exact same dataframe expressions.
- No CMF formula/math changes.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this consolidation because it only reuses already-computed Series/comparison masks inside the same dataframe call.
- Validation focused on static checks, undefined-local scanning, merge conflict simulation, and targeted diff review for unchanged expressions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- ready-stack merge simulation with the remaining open independent PRs plus the new consolidated branches
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`