### PR TITLE
Reuse X7 entry RSI-3 threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12683,6 +12683,10 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_15m_gt_3 = rsi_3_15m > 3.0
     rsi_3_1h_gt_20 = rsi_3_1h > 20.0
     rsi_3_4h_gt_20 = rsi_3_4h > 20.0
+    rsi_3_1h_gt_10 = rsi_3_1h > 10.0
+    rsi_3_1h_gt_15 = rsi_3_1h > 15.0
+    rsi_3_4h_gt_10 = rsi_3_4h > 10.0
+    rsi_3_4h_gt_15 = rsi_3_4h > 15.0
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
@@ -12749,13 +12753,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move
             & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((rsi_3 > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_15m < 30.0))
             # 5m & 1h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 30.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m down move, 15m high
@@ -12767,15 +12771,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h downtrend, 1h high
             & ((rsi_3_15m > 1.0) | (cmf_20_1h > -0.1) | (aroonu_14_1h < 70.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h & 1d down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
             # 15m & 1h down move, 15m still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
@@ -12789,7 +12793,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 1d downtrend
@@ -12825,9 +12829,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 60.0))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 4h still high
@@ -12839,13 +12843,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (rsi_14_4h < 80.0))
             # 15m & 1h down move, 15m still high
@@ -12853,13 +12857,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 1h high
@@ -12909,11 +12913,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 4h still high
@@ -12921,13 +12925,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.3))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.3))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d overbought
@@ -12939,37 +12943,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_14_4h < 75.0))
+            & ((rsi_3_1h_gt_10) | (rsi_14_4h < 75.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h > 10.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
             # 1h down mve, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (roc_9_4h < 80.0))
             # 1h down move, 1h still high, 4h downtrend
@@ -13017,21 +13021,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -13138,7 +13142,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
@@ -13148,7 +13152,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 5m & 4h down move, 15m still high
@@ -13176,15 +13180,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 1h high
             & ((rsi_3 > 5.0) | (rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still not low enough
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3 > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 1.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 15m downtrend
@@ -13196,15 +13200,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d > -40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 15m downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (cmf_20_15m > -0.40))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h still high
@@ -13232,9 +13236,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (cmf_20_4h > -0.35))
             # 15m & 4h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 4h still high
@@ -13252,15 +13256,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1d still high, 4h still high
             & ((rsi_3_1d > 50.0) | (rsi_14_1d < 50.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
@@ -13270,15 +13274,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (roc_9_1d < 10.0))
             # 15m & 4h down move, 4h still high
@@ -13302,15 +13306,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 4h high
@@ -13338,11 +13342,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
@@ -13374,7 +13378,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1d overbought
@@ -13388,9 +13392,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 1d down move, 1h still high
@@ -13480,7 +13484,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 40.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 1.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1h > 1.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -10.0))
             # 1h down move, 15m downtrend, 1h still high
             & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 15m downtrend
@@ -13488,9 +13492,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d high
@@ -13508,73 +13512,73 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h % 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (cmf_20_4h > -0.30))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (cmf_20_4h > -0.30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h still high
@@ -13672,33 +13676,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (roc_9_1d > -25.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1d overbought
@@ -13847,7 +13851,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1h still high
-            ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0))
+            ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
             # 5m down move, 15m high, 1d overbought
             & ((rsi_3 > 5.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
             # 5m down move, 15m still high, 1d downtrend
@@ -13869,7 +13873,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m down move, 15m still high, 1h high
@@ -13891,11 +13895,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 15m & 1d down move, 15m high
@@ -14065,25 +14069,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
             # 1h down move, 4h still high, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 10.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 60.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 60.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
@@ -14211,35 +14215,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 35.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 35.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -40.0))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 60.0))
             # 4h down move, 15m & 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1h still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 15m high
@@ -14447,7 +14451,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h high, 1d high & overbought
@@ -14485,7 +14489,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 4h & 1d downtrend
             & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 1d P&D, 4h downtrend
-            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
+            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # 1d P&D, 15m high
             & ((change_pct_1d > -20.0) | (change_pct_1d.shift(288) < 20.0) | (aroonu_14_15m < 70.0))
             # 1d red with top wick, 4h high
@@ -14526,11 +14530,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1d < 40.0))
             # 5m & 1h & 4h down move
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0))
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h high
@@ -14538,7 +14542,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m & 1d down move, 15m still high
@@ -14552,7 +14556,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
@@ -14560,7 +14564,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high & overbought
@@ -14568,13 +14572,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 15m stil high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_4h > -40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
@@ -14590,7 +14594,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
@@ -14616,7 +14620,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (cmf_20_15m > -0.40))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (cmf_20_15m > -0.40))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 1h down move, 1h high, 4h high
@@ -14630,7 +14634,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h high, 1h downtrend
@@ -14640,41 +14644,41 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (roc_9_1d < 100.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h & 3h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
             # 1h down move, 1d high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_15m > -50.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_15m > -50.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 10.0) | (roc_9_4h > -15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h still high, 4h downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
             # 1h down move, 1h high
@@ -14732,19 +14736,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -10.0))
             # 4h down move, 1d high & overbought
@@ -14813,7 +14817,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m > 20.0)
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
@@ -14873,11 +14877,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 15.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 15.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -40.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 1d high
@@ -14885,59 +14889,59 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 40.0))
             # 1h down move, 4h downtrend. 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (roc_9_4h > -20.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (aroonu_14_4h < 30.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 15m high, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (cmf_20_15m > -0.30))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h < 10.0) | (roc_9_1d < 60.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
@@ -15027,31 +15031,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 15m downtrend, 1d high
-            & ((rsi_3_4h > 10.0) | (cmf_20_15m > -0.30) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_10) | (cmf_20_15m > -0.30) | (aroonu_14_1d < 80.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (roc_9_4h > -40.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1ddown move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1d high, 1d downtrend
@@ -15131,7 +15135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
-            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
+            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -15170,7 +15174,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 4h still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0))
             # 5m & 4h & 1d down move
             & ((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 35.0))
             # 5m & 4h down move, 4h high
@@ -15188,7 +15192,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3 > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 1d overbought
@@ -15218,9 +15222,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
             # 15m & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (roc_9_1d > -10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (roc_9_1d > -10.0))
             # 15m & 4h down move, 4h still not low enough
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 20.0))
             # 15m & 4h down move, 15m still not low enough
@@ -15290,13 +15294,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 1d high
@@ -15346,9 +15350,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (rsi_3_1h > 15.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (rsi_3_1h_gt_15))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1h still high
@@ -15554,39 +15558,39 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d high
@@ -15600,7 +15604,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
@@ -15706,33 +15710,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h still high
@@ -15816,7 +15820,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
@@ -15886,7 +15890,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d hihg, 1h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
-            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
+            & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -15981,7 +15985,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 40.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h overbought, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1h still high
@@ -16147,15 +16151,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 15m downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (cmf_20_15m > -0.40))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 1h high
@@ -16197,9 +16201,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
@@ -16207,7 +16211,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1d downtrend
@@ -16223,17 +16227,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 5.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d overbought
@@ -16279,7 +16283,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 1h high
@@ -16371,11 +16375,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 3.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d < 20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
@@ -16397,95 +16401,95 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -25.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -35.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -35.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_15m > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_15m > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 20.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (cmf_20_1h > -0.40))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (cmf_20_1h > -0.40))
             # 1h down move, 1d downtrend, 4h high
-            & ((rsi_3_1h > 10.0) | (cmf_20_1d > -0.30) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d < 90.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_10) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -25.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -25.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h downtrend, 1h still high
-            & ((rsi_3_1h > 15.0) | (cmf_20_1h > -0.30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (stochrsi_k_1h < 40.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (cmf_20_1h > -0.25))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0) | (cmf_20_1h > -0.25))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h high, 15m downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -15.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0) | (roc_9_15m > -15.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0) | (roc_9_1h > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
@@ -16619,19 +16623,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 35.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 70.0))
             # 4h down move, 1d high & overbought
@@ -16769,17 +16773,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1d < 30.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 60.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m down move, 4h still high, 1d downtrend
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 15m & 1h & 4h down move
@@ -16789,25 +16793,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 70.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 1d overbought
@@ -16817,7 +16821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h still not low enough
@@ -16825,11 +16829,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
             # 15m & 1d down move, 1d high
@@ -16853,9 +16857,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h still not low enough
@@ -16873,7 +16877,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
@@ -16885,99 +16889,99 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 75.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1d < 50.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (rsi_14_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (rsi_14_1d < 50.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_15m < 80.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 60.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 15.0) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d still high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 50.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d overbought
@@ -17105,47 +17109,47 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 20.0))
             # 4h down move, 15m high, 1h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_1h > -10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
             # 4h down move, 4h still not low e nough, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
             # 15m & 1d down move, 15m high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (rsi_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (rsi_14_1d < 50.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 15.0) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
             # 4h & 1d down move, 15m high
@@ -17304,9 +17308,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m still high
             ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
             # 5m & 1h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0))
             # 5m & 1d down move, 1d still not low enough
@@ -17324,29 +17328,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1h high
             & ((rsi_3 > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 90.0))
             # 5m & 1h down move, 1h high
-            & ((rsi_3 > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3 > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
             # 15m & 1h & 1d down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_1d > 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_1d > 25.0))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 15m still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_15m < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
@@ -17360,7 +17364,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0))
             # 15m & 4h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 15m & 4h down move, 15m high
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d overbought
@@ -17388,7 +17392,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
@@ -17398,11 +17402,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d high
@@ -17426,15 +17430,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1h high
@@ -17458,13 +17462,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 4h high
@@ -17492,9 +17496,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 90.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 4h high
@@ -17546,11 +17550,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 1d high
@@ -17560,9 +17564,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h still high
@@ -17574,49 +17578,49 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 70.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 4h high
@@ -17704,23 +17708,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d  downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
@@ -17817,27 +17821,27 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h & 4h down move
-            ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 15m downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_15m > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_15m > -30.0))
             # 15m & 4h down move, 1h downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
             # 15m & 4h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 40.0))
             # 15m down move, 1h still high, 1d overbought
@@ -17849,11 +17853,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 15m downtrend
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_15m > -30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
             # 15m down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 30.0))
             # 15m & 4h down move, 4h high
@@ -17871,9 +17875,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 4h high
@@ -17889,9 +17893,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h > 3.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
             # 1h & 1d down move, 1d downtrend
@@ -17907,79 +17911,79 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1h > -25.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1h > -25.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 50.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (roc_9_1h > -10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 80.0))
             # 1h down move, 4h still high, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (cmf_20_15m > -0.40))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0) | (cmf_20_15m > -0.40))
             # 1h down move, 4h still high, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h > 10.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 10.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h still high, 4h downtrend
@@ -18019,21 +18023,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
             # 15m down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d high
@@ -18134,13 +18138,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
           # 15m & 4h down move
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (rsi_14_4h < 35.0))
           # 15m down move, 4h still high, 15m downtrend
           long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
           # 15m & 1h down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
           # 15m down move, 1h still not low enough
@@ -18148,7 +18152,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (rsi_3_1d > 10.0))
           # 15m & 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
           # 15m & 1h down move, 1h high
@@ -18156,9 +18160,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
           # 15m down move, 1h & 4h high
@@ -18172,7 +18176,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
@@ -18192,49 +18196,49 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h > 5.0) | (stochrsi_k_1h < 25.0))
           # 1h & 4h down move
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
           # 15m & 1d down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 70.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d < 85.0))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (stochrsi_k_1h < 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 25.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
           # 1h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
           # 1h down move, 4h high
@@ -18270,17 +18274,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high
           long_entry_logic.append((rsi_3_4h > 5.0) | (aroonu_14_1d < 100.0))
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
           # 4h downmove, 4h still high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
           # 4h down move, 1h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 10.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (rsi_14_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (rsi_14_1d < 50.0))
           # 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_1h < 30.0))
           # 4h & 1d down move, 1d high
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
           # 4h down move, 4h still high, 1d high
@@ -18356,13 +18360,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 12 days, 1h down move
           long_entry_logic.append((close > (high_max_12_1d * 0.45)) | (rsi_3_1h > 5.0))
           # big drop in the last 12 days, 4h down move
-          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_4h_gt_15))
           # big drop in the last 12 days, 1h still high
           long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h < 75.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (high_max_20_1d * 0.35)) | (rsi_3_1h > 10.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.35)) | (rsi_3_1h_gt_10))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (high_max_20_1d * 0.25)) | (rsi_3_1h > 15.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.25)) | (rsi_3_1h_gt_15))
           # big drop in the last 20 days, 1h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.10)) | rsi_3_1h_gt_20)
           # big drop in the last 20 days, 1d high, 1d downtrend
@@ -18387,15 +18391,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append(rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
           # 15m & 4h down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_3_4h > 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (rsi_3_4h > 30.0))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (rsi_14_4h < 30.0))
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20)
           # 15m & 1h down move, 1h still high
@@ -18403,9 +18407,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
           # 15m & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
           # 15m & 4h down move, 4h still not low enough
@@ -18417,7 +18421,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 60.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0))
           # 15m & 1h & 1d down move, 1h still not low enough, 1d high
           long_entry_logic.append(
             (rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (rsi_14_1h < 30.0) | (aroonu_14_1d < 80.0)
@@ -18439,9 +18443,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 1d high
           long_entry_logic.append((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0) | (aroonu_14_1d < 90.0))
           # 1h & 4h down move
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 1d high
@@ -18451,57 +18455,57 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1d still high
           long_entry_logic.append((rsi_3_1h > 5.0) | (stochrsi_k_1d < 50.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | roc_9_1d_lt_50)
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 40.0))
           # 1h & 1d down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 1d stll high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 40.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_lt_50)
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_4h < 70.0))
           # 1h & 4h down move, 1h still not low enough
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
           # 1h & 4h down move, 4h still high
@@ -18563,15 +18567,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h > -20.0))
           # 4h & 1d down move
-          long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 4h & 1d still high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d low
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (cmf_20_1d > -0.2))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (cmf_20_1d > -0.2))
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d overbought
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
           # 4h down move, 4h still not low enough, 1d downtrend
@@ -18629,11 +18633,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 12 days, 4h still high
           long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (stochrsi_k_4h < 50.0))
           # big drop in the last 20 days, 1h down move
-          long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_3_1h > 10.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_3_1h_gt_10))
           # big drop in the last 20 days, 4h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h > 25.0))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((close > (high_max_30_1d * 0.40)) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.40)) | (rsi_3_4h_gt_15))
           # big drop in the last 30 days, 4h still not low enough
           long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (stochrsi_k_4h < 30.0))
 
@@ -18656,7 +18660,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 4h down move, 4h high
@@ -18664,7 +18668,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1d high & overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
@@ -18672,15 +18676,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 20.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_4h > 3.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h > 3.0))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 4h downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (cmf_20_4h > -0.30))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (cmf_20_4h > -0.30))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
@@ -18706,9 +18710,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still low, 4h still high
@@ -18720,9 +18724,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_4h > -50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 15m still high
@@ -18730,7 +18734,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 50.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h overbought
@@ -18750,9 +18754,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
@@ -18796,17 +18800,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h down move, 4h high, 1d overbought
@@ -18816,35 +18820,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_15m > -15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_15m > -15.0))
             # 1h & 3h down move, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (roc_9_1d < 80.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
-            & ((rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 10.0) | (roc_9_4h > -10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
@@ -18902,19 +18906,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h downtrend, 4h still high
             & ((rsi_3_4h > 5.0) | (cmf_20_4h > -0.20) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0) | (roc_9_1h > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18997,19 +19001,19 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d high
-            ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 90.0))
+            ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 90.0))
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 4h still not low enough
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_14_4h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_14_4h < 30.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (rsi_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h still high
@@ -19019,37 +19023,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 20.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 20.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h still not low enough
@@ -19067,7 +19071,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -25.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
             # 15m & 4h down move, 4h still high
@@ -19095,7 +19099,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 4h high
@@ -19109,57 +19113,57 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 30.0))
             # 1h& 1d down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_14_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
@@ -19247,21 +19251,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h > 5.0) | (aroonu_14_4h < 60.0))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
             # 4h down move, 1h downtrend, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m high, 4h downtrend
@@ -19349,7 +19353,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m > 5.0)
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
@@ -19357,7 +19361,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1d high & overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move 1h still high
@@ -19371,13 +19375,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 4h down move, 4h high
@@ -19397,7 +19401,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 15m still high
@@ -19471,15 +19475,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high
             & ((rsi_3_15m < 40.0) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 2.0) | (rsi_3_4h > 15.0) | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h > 2.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h stil high
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h ^ 4h down move, 1d downtrend
@@ -19501,11 +19505,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 1d high, 4h downtrend
@@ -19515,61 +19519,61 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h, 1d downtrend
             & ((rsi_3_1h > 5.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (roc_9_1d < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d downtrend, 1d overbought
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.20) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (aroonu_14_1h < 30.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.20) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (stochrsi_k_1h < 30.0))
             # 1h down move, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (cmf_20_1h > -0.30))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
             # 1h & 4h down mov, 1d overbought
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h > 15.0) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1h high
@@ -19681,31 +19685,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_4h > -20.0))
             # 4h down move, 15m high, 15m downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 60.0) | (roc_9_15m > -10.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_15m > -10.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -30.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -30.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high
             & (rsi_3_4h_gt_20 | (aroonu_14_15m < 45.0))
             # 4h down move, 1h still not low enough, 1d downtrend
@@ -19852,7 +19856,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last hour
           long_entry_logic.append(close > (close_max_12 * 0.50))
           # 5m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
           # 5m & 4h down move, 15m still high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
           # 5 & 15m down move, 1h high
@@ -19864,15 +19868,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1d still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_14_4h < 40.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_4h < 75.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 20.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
           # 15m & 4h down move, 1d downtrend
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 30.0))
           # 15m & 4h down move, 4h still not low enough
@@ -19884,7 +19888,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append(rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_3_1d > 20.0))
           # 15m down move, 1h still not low enough, 1d high
           long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 30.0) | (aroonu_14_1d < 90.0))
           # 15m & 1h down move, 1h still not low enough
@@ -19926,7 +19930,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 10.0))
           # 15m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 1d high
@@ -19944,7 +19948,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (stochrsi_k_4h < 75.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 30.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 30.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
           # 15m & 1h down move, 1h still high
@@ -19952,9 +19956,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
           # 15m & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 15m still not low enough
@@ -19962,7 +19966,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 50.0))
           # 1h & 1d down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 4h high & overbought
@@ -19992,35 +19996,35 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 15m downtrend
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 25.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h > -20.0))
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 20.0))
           # 1h & 4h down move, 1d low
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (cmf_20_1d > -0.2))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1d > -0.2))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
           # 1h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (roc_9_4h > -30.0))
           # 1h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 10.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
           # 1h down move, 1d high & overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h down move, 1h still not low enough, 4h high
@@ -20050,19 +20054,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high
           long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_15m < 40.0))
           # 4h down move, 1d still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
           # 4h down move, 15m 4h still high
-          long_entry_logic.append((rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 50.0))
           # 4h & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
           # 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
           # 4h down move, 4h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -15.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d > -15.0))
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
           # 4h dowqn move, 4h still high, 1d downtrend
@@ -20138,7 +20142,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 20 days, 1d high, 1d downtrend
           long_entry_logic.append((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           # big drop in the last 30 days, 1h down move
-          long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_1h > 15.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_1h_gt_15))
 
           # Logic
           long_entry_logic.append(rsi_3 > 3.0)
@@ -20156,8 +20160,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(rsi_3 < 46.0)
           long_entry_logic.append(rsi_3_15m > 5.0)
-          long_entry_logic.append(rsi_3_1h > 10.0)
-          long_entry_logic.append(rsi_3_4h > 10.0)
+          long_entry_logic.append(rsi_3_1h_gt_10)
+          long_entry_logic.append(rsi_3_4h_gt_10)
           # 5m & 15m down move, 4h still high
           long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
           # 5m & 15m down move, 15m still high
@@ -20217,9 +20221,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
           # 15m& 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 40.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
           # 15m & 4h down move, 15m still high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
           # 15m & 4h down move, 4h still not low enough
@@ -20255,7 +20259,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
           # 15m & 4h down move, 15m still not low enough
@@ -20355,13 +20359,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 90.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
           # 1h & 1d down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (cmf_20_4h > -0.40))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (cmf_20_4h > -0.40))
           # 1h down move, 1d high & overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h & 4h down move, 4h still high
@@ -20397,9 +20401,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1d high, 1h overbought
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
           # 4h down move, 4h still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (roc_9_1d < 100.0))
           # 4h down move, 15m still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 15m still not low enough
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 30.0))
           # 4h down move, 4h still not low enough, 1d downtrend
@@ -20507,7 +20511,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 80.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 10.0) | rsi_3_4h_gt_20)
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h_gt_10) | rsi_3_4h_gt_20)
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 1h high
@@ -20555,15 +20559,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
           # 1h down move, 4h still high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 4h & 1d high
@@ -20699,23 +20703,23 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h & 1d down move
           long_entry_logic.append((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
           # 5m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
           # 5m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
           # 15m & 1h down move
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 3.0))
           # 15m & 1h down move, 4h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_14_4h < 35.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
           # 15m & 1h & 4h down move, 15m downtrend
           long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (cmf_20_15m > -0.20))
           # 15m & 1h down move, 4h still not low enough
@@ -20723,11 +20727,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
           # 15m & 1h down move, 15m & 1h downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 4h overbought
@@ -20735,13 +20739,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
           # 15m & 4h down move, 1h & 4h downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
           # 15m & 4h down move, 4h still high
@@ -20773,7 +20777,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 20.0) | (roc_9_1d < 80.0))
           # 1h & 4h down move
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0))
+          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 4h high
@@ -20787,33 +20791,33 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 5.0) | (aroonu_14_4h < 85.0))
           # 1h & 4h down move
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 1d still high
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
           # 1h & 1d down move, 1h still moving lower
-          long_entry_logic.append((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (cci_20_change_pct_1h > -0.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_4h > -10.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_4h > -10.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 20.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 70.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h down move, 1h still high
@@ -20859,11 +20863,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d still not low enough, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_1d < 30.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h downtrend, 1h still not low enough
-          long_entry_logic.append((rsi_3_4h > 10.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
           # 4h down move, 1h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 10.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_4h > 15.0) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
           # 4h & 1d down move, 1d high
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
           # 4h down move, 1d high & overbought
@@ -20909,7 +20913,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last hour
           long_entry_logic.append(close > (close_max_12 * 0.50))
           # big drop in the last 12 days, 15m & 4h down move
-          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_15m > 10.0) | (rsi_3_4h > 10.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_15m > 10.0) | (rsi_3_4h_gt_10))
           # big drop in the last 20 days, 15m & 1h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_14_15m < 10.0) | (rsi_14_1h < 10.0))
           # big drop in the last 20 days, 1d down move
@@ -20967,7 +20971,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m high
             & ((rsi_3 > 3.0) | (rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0))
             # 5m & 1h down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 40.0))
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 5m & 4h down move, 15m still high
@@ -20991,15 +20995,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((rsi_3 > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h & 4h down move, 1d downtrend
@@ -21025,13 +21029,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 70.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 1d down move, 1d still high
@@ -21041,15 +21045,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
@@ -21059,13 +21063,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
             # 15m & 4h down move, 15m high
@@ -21105,15 +21109,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
@@ -21157,9 +21161,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 10.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d still high
@@ -21167,51 +21171,51 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 20.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 15.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (roc_9_4h > -30.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
@@ -21269,47 +21273,47 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 60.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h > 15.0) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 4h downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
@@ -21398,7 +21402,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 15m high
-            ((rsi_3 > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0))
+            ((rsi_3 > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
             # 5m & 1d down move, 15m high
             & ((rsi_3 > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h & 1d high
@@ -21406,25 +21410,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h high
             & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
@@ -21438,27 +21442,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 70.0))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m still high
@@ -21468,13 +21472,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 20.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
             # 15m & 4h down move, 4h still high
@@ -21508,15 +21512,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1h high
@@ -21564,51 +21568,51 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1h overbought
             & ((rsi_3_15m > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 25.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 60.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d < 100.0))
             # 1h & 1d downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move. 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 15m & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h still high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
@@ -21656,41 +21660,41 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 90.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 40.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 15m still not low enough, 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 4h high
@@ -21811,21 +21815,21 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h & 1d down move
-            ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 10.0))
+            ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 10.0))
             # 5m & 4h down move, 4h still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 15m still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_15m < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1d downtrend
@@ -21833,7 +21837,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 15m still high
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1d down move, 4h still high
@@ -21841,17 +21845,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (rsi_14_1d < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 80.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0))
             # 15m & 1d down move, 1h still high
@@ -21865,9 +21869,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
@@ -21875,7 +21879,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 4h overbought
@@ -21901,25 +21905,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
@@ -21953,31 +21957,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 60.0))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h > 15.0) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h & 1d down move, 1d still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
             # 4h down move, 4h & 1d high
@@ -22024,21 +22028,21 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
+            ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_15m < 40.0))
             # 5m & 4h & 1d down move
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 10.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 10.0))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -10.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -10.0))
             # 5m & 4h down move, 15m high
-            & ((rsi_3 > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3 > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 4h downtrend
@@ -22048,19 +22052,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (rsi_14_4h < 20.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 4h high
@@ -22074,7 +22078,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 4h high & overbought
@@ -22092,9 +22096,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.20))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 15m still high
@@ -22110,39 +22114,39 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_1h > -10.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
@@ -22194,31 +22198,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 4h still not low enough
             & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 30.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 20.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 15m high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0) | (stochrsi_k_15m < 60.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 4h still not low enough, 1d high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d downtrend
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
@@ -22296,19 +22300,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (roc_9_1h > -20.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m downtrend, 1h high
@@ -22348,45 +22352,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h > 10.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (rsi_3_1d > 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d > 20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (roc_9_1d > -40.0))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 40.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
@@ -22438,23 +22442,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 4h down move, 15m stil high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h > 15.0) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 60.0))
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 15m high
@@ -22795,7 +22799,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (rsi_14_4h < 80.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
@@ -22805,23 +22809,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
             # 1h & 3h down move, 1d high
-            & ((rsi_3_1h > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 15.0) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h > 15.0) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 15.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 15.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high
@@ -22851,9 +22855,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0))
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1h > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_1h > -30.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 10.0) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -23210,21 +23214,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h > 3.0) | (aroonu_14_15m < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 10.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m still not low enough, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (cmf_20_4h > -0.30))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (cmf_20_4h > -0.30))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0) | (cmf_20_4h > -0.3))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (cmf_20_4h > -0.3))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 15.0) | (rsi_14_1d < 40.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 15.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high, 1d overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_15m < 40.0) | (roc_9_1d < 20.0))
             # 4h & 1d down move, 1h & 4h low


### PR DESCRIPTION
## Summary
- add reusable `populate_entry_trend` masks for the heavily repeated RSI-3 1h/4h threshold checks
- replace repeated `rsi_3_1h` / `rsi_3_4h` Series comparisons with those local masks
- keep the existing entry conditions, thresholds, ordering, and return behavior unchanged

## Safety
- This is a mechanical repeated-read cleanup in `populate_entry_trend`.
- The new locals evaluate the same pandas Series comparisons once, then reuse the resulting masks.
- No indicator formulas, CMF logic, candle selection, stake sizing, profit arithmetic, slot counts, thresholds, or condition order were changed.
- The branch is based on current `origin/main` and `git merge-tree` reports `NO_CONFLICT`.

## Backtest Scope
- No dedicated backtest was run for this PR.
- I treated this as not requiring a full backtest because it only aliases existing boolean Series comparisons and does not change the trading conditions themselves.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` -> `NO_CONFLICT`
