### PR TITLE
Reuse X7 short entry threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -23377,6 +23377,28 @@ class NostalgiaForInfinityX7(IStrategy):
     #   \$$$$$$ \$$   \$$ \$$$$$$ \$$   \$$  \$$          \$$$$$$$$\$$   \$$   \$$   \$$$$$$$$\$$   \$$
     #
 
+    # Reused short entry threshold masks
+    rsi_3_15m_lt_95 = rsi_3_15m < 95.0
+    rsi_3_1h_lt_95 = rsi_3_1h < 95.0
+    rsi_3_15m_lt_90 = rsi_3_15m < 90.0
+    rsi_3_1h_lt_90 = rsi_3_1h < 90.0
+    rsi_3_4h_lt_85 = rsi_3_4h < 85.0
+    stochrsi_k_1h_gt_50 = stochrsi_k_1h > 50.0
+    stochrsi_k_4h_gt_50 = stochrsi_k_4h > 50.0
+    rsi_3_15m_lt_85 = rsi_3_15m < 85.0
+    rsi_3_4h_lt_90 = rsi_3_4h < 90.0
+    rsi_3_1h_lt_80 = rsi_3_1h < 80.0
+    stochrsi_k_4h_gt_30 = stochrsi_k_4h > 30.0
+    rsi_3_1h_lt_85 = rsi_3_1h < 85.0
+    rsi_3_4h_lt_95 = rsi_3_4h < 95.0
+    stochrsi_k_1h_gt_70 = stochrsi_k_1h > 70.0
+    stochrsi_k_1h_gt_30 = stochrsi_k_1h > 30.0
+    stochrsi_k_15m_gt_50 = stochrsi_k_15m > 50.0
+    rsi_3_4h_lt_80 = rsi_3_4h < 80.0
+    roc_9_4h_lt_20 = roc_9_4h < 20.0
+    stochrsi_k_4h_gt_70 = stochrsi_k_4h > 70.0
+    rsi_3_lt_90 = rsi_3 < 90.0
+
     for enabled_short_entry_signal in short_entry_signal_params:
       short_entry_condition_index = int(enabled_short_entry_signal.rsplit("_", 2)[1])
       if short_entry_signal_params[enabled_short_entry_signal]:
@@ -23405,175 +23427,175 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m up move, 4h still not high enough
           short_entry_logic.append((rsi_3 < 97.0) | (aroonu_14_4h > 60.0))
           # 5m up move, 4h still low
-          short_entry_logic.append((rsi_3 < 97.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (stochrsi_k_4h_gt_50))
           # 5m & 15m strong up move
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
           # 5m & 1h up move, 1d uptrend
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 90.0) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (roc_9_1d < 100.0))
           # 5m up move, 15m & 1h still not high enough
           short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
           # 4m up move, 1h & 4h still low
-          short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70))
           # 4m & 1h up move, 1h still low
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_50))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 80.0) | (aroonu_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h > 20.0))
           # 5m up move, 15m & 1h uptrend
-          short_entry_logic.append((rsi_3 < 90.0) | (cmf_20_15m < 0.30) | (cmf_20_1h < 0.30))
+          short_entry_logic.append((rsi_3_lt_90) | (cmf_20_15m < 0.30) | (cmf_20_1h < 0.30))
           # 5m up move, 15m stil low
-          short_entry_logic.append((rsi_3 < 90.0) | (aroonu_14_15m > 50.0))
+          short_entry_logic.append((rsi_3_lt_90) | (aroonu_14_15m > 50.0))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 75.0))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
           # 15m & 1h up move, 4h still going up
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_4h < -0.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_50))
           # 15m & 1h up move, 1h still low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 70.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_50))
           # 15m & 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h > 75.0))
           # 15m up move, 1d lost, 1h low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
           # 15m up move, 15m & 4h uptrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (aroonu_14_15m < 90.0) | (aroonu_14_4h < 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m < 90.0) | (aroonu_14_4h < 90.0))
           # 15m up move, 15m stil not high enough, 1h low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 10.0))
           # 15m up move, 1h still not high enough, 4h low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 70.0) | (aroonu_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (aroonu_14_4h > 20.0))
           # 15m up move, 1h & 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 80.0))
           # 15m up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (aroonu_14_4h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_4h > 70.0))
           # 15m up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_95) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
           # 15m up move, 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_change_pct_1h < 80.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m & 1h up move, 1h not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (aroond_14_1h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (aroond_14_1h < 50.0))
           # 15m & 1h up move, 1d stil not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_14_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_14_1h > 80.0))
           # 15m & 1h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (roc_9_1d < 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (roc_9_1d < 40.0))
           # 15m & 1h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_15m > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_15m > 60.0))
           # 15m & 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 80.0))
           # 15m & 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 90.0))
           # 15m & 4h up move, 4h not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 90.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (aroond_14_4h < 50.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d > 30.0))
           # 15m & 4h up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1h > 20.0))
           # 15m & 4h up move, 4h low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 60.0) | (aroonu_14_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 60.0) | (aroonu_14_4h > 30.0))
           # 15m up move, 1h & 4h low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_1h > 40.0) | (aroonu_14_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h > 40.0) | (aroonu_14_4h > 10.0))
           # 15m up move, 1h still low, 4h low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_1h > 60.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h > 60.0) | (stochrsi_k_4h_gt_30))
           # 15m up move, 1h low, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h_gt_70))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 20.0))
           # 15m & 1h up move, 1d still low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1d > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1d > 60.0))
           # 15m & 1h up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 70.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_30))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_30))
           # 15m & 4h down move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 15m & 4h up move, 15m low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (stochrsi_k_15m > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_50))
           # 15m down move, 15m still not high enough, 4h low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_14_15m > 70.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_14_15m > 70.0) | (stochrsi_k_4h > 40.0))
           # 15m up move, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h < 50.0))
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 60.0))
           # 15m & 4h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h < 80.0) | (aroonu_14_15m > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h_lt_80) | (aroonu_14_15m > 50.0))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_1h > 20.0))
           # 15m & 1h up move, 1h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 30.0))
           # 15m up move, 15m still not high enough, 1h still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 90.0) | (stochrsi_k_1h_gt_50))
           # 1h & 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_70))
           # 1h up move, 4h low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_30))
           # 1h & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (df["UO_7_14_28_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (df["UO_7_14_28_4h"] > 60.0))
           # 1h & 4h up move, 4h still low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_50))
           # 1h & 4h up move, 4h uptrend
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (roc_9_4h < 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (roc_9_4h < 40.0))
           # 1h & 1d strong up move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_1d < 95.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
           # 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_1d > 50.0) | (roc_9_1h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d > 50.0) | (roc_9_1h < 30.0))
           # 1h & 4h strong up move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (mfi_14_1h < 95.0) | (rsi_3_4h < 95.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (mfi_14_1h < 95.0) | (rsi_3_4h_lt_95))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1d > 50.0) | (roc_9_1h < 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_1d > 50.0) | (roc_9_1h < 20.0))
           # 1h strong up move, 15m still move higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h & 4h up move, 1h still low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_50))
           # 1h & 4h up move, 1d still not high enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1d > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1d > 70.0))
           # 1h up move, 4h low, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_4h > 20.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_4h > 20.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still low, 1d uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 60.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h > 60.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still not high enough, 1d low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d > 30.0))
           # 1h up move, 4h low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 20.0) | (roc_9_1h < 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 20.0) | (roc_9_1h < 10.0))
           # 1h up move, 4h low, 1h overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 40.0) | (roc_9_1h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 40.0) | (roc_9_1h < 30.0))
           # 1h up move, 15m & 1h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 15.0) | (roc_9_1h < 15.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 15.0) | (roc_9_1h < 15.0))
           # 1h up move, 15m & 4h still low
-          short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (aroond_14_15m < 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (aroond_14_15m < 50.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 85.0) | (stochrsi_k_15m > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (stochrsi_k_15m > 90.0))
           # 1h up move, 15m still not high enough, 1h still low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_15m > 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_15m > 80.0) | (stochrsi_k_1h_gt_50))
           # 1h up move, 1h still low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h > 60.0))
           # 4h & 1d strong up move
-          short_entry_logic.append((rsi_3_4h < 95.0) | (rsi_3_1d < 95.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_3_1d < 95.0))
           # 4h up move, 15m still low, 1h not high enough
-          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 50.0) | (aroond_14_1h < 25.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_50) | (aroond_14_1h < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
-          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 70.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 70.0) | (roc_9_4h < 60.0))
           # 4h up move, 15m uptrend
-          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_15m < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_15m < 20.0))
           # 4h up move, 1h uptrend
-          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_1h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 20.0))
           # 4h up move, 1h & 4h overbought
-          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
           # 4h up move, 1h still low
-          short_entry_logic.append((rsi_3_4h < 90.0) | (aroonu_14_1h > 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
           # 4h up move, 1d still low, 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 85.0) | (rsi_14_1d > 40.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (rsi_14_1d > 40.0) | (roc_9_4h_lt_20))
           # 4h up move, 4h still low
-          short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_4h_gt_50))
           # 4h up move, 1h low
           short_entry_logic.append((rsi_3_4h < 70.0) | (aroonu_14_1h > 25.0))
           # 4h up move, 1d low
@@ -23583,7 +23605,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1d low
           short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
           # 1d up move, 1h & 4h still not low enough
-          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h_gt_50))
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
@@ -23593,7 +23615,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h uptrend
           short_entry_logic.append((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
           # 1h uptrend, 4h uptrend
-          short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
           # 4h uptrend, 1d uptrend
           short_entry_logic.append((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
           # 4h uptrend, 15m uptrend
@@ -23638,61 +23660,61 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(protections_short_global == True)
 
           # 5m & 15m & 1h & 4h up move
-          short_entry_logic.append((rsi_3 < 97.0) | (rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 80.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_80))
           # 5m & 4h up move
-          short_entry_logic.append((rsi_3 < 97.0) | (rsi_3_4h < 95.0))
+          short_entry_logic.append((rsi_3 < 97.0) | (rsi_3_4h_lt_95))
           # 5m up move, 4h still not high enough
           short_entry_logic.append((rsi_3 < 97.0) | (stochrsi_k_4h > 80.0))
           # 5m & 15m strong up move
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
           # 5m & 15m up move, 4h low
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 90.0) | (aroonu_14_4h > 30.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_90) | (aroonu_14_4h > 30.0))
           # 5m & 1h & 4h up move
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 90.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
           # 5m & 1h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_15m > 70.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_85) | (stochrsi_k_15m > 70.0))
           # 5m up move, 15m still low
-          short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_15m > 50.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_15m_gt_50))
           # 5m up move, 4h low
-          short_entry_logic.append((rsi_3 < 90.0) | (aroonu_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_lt_90) | (aroonu_14_4h > 20.0))
           # 15m & 1h down move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 97.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m < 97.0) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 80.0))
           # 15m up move, 1h still low
           short_entry_logic.append((rsi_3_15m < 97.0) | (stochrsi_k_1h > 60.0))
           # 15m & 1h & 4h up move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 85.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_85))
           # 15m & 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 60.0))
           # 15m up move, 1h still low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h > 40.0))
           # 15m up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (aroonu_14_4h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_4h > 70.0))
           # 15m & 1h & 4h up move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (rsi_3_4h < 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
           # 15m & 1h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (stochrsi_k_15m > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_15m > 80.0))
           # 15m & 1h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 90.0) | (stochrsi_k_1d > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_1d > 40.0))
           # 15m & 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_1h > 80.0))
           # 15m & 1h up move, 4h stil low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 80.0) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h > 50.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (rsi_14_1d > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (rsi_14_1d > 40.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d > 30.0))
           # 15m up move, 1h still low, 1d low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_1h > 50.0) | (aroonu_14_1d > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h > 50.0) | (aroonu_14_1d > 30.0))
           # 15m up move, 1h high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_1h < 100.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h < 100.0))
           # 15m up move, 1h still low
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_50))
           # 15m up move, 4h uptrend
-          short_entry_logic.append((rsi_3_15m < 90.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_4h_lt_20))
           # 15m & 1h up move, 1h still low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 65.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 65.0) | (stochrsi_k_1h > 60.0))
           # 15m up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30))
           # 15m & 4h up move, 15m still low
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h < 75.0) | (aroonu_14_15m > 50.0))
           # 15m up move, 1h low
@@ -23704,39 +23726,39 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h uptrend
           short_entry_logic.append((rsi_3_15m < 75.0) | (roc_9_1h < 40.0))
           # 1h & 1d strong up move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_1d < 95.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
           # 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_70))
           # 1h up move, 4h still low, 1h moving higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_1d > 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d > 40.0))
           # 1h strong up move, 15m still move higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["CCI_20_change_pct_15m"] < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h up move, relative stable before the hour
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["close_min_12"] > (df["close_min_48"] * 1.10)))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (df["close_min_12"] > (df["close_min_48"] * 1.10)))
           # 1h up move, 15m uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_15m < 100.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_15m < 100.0))
           # 1h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1d > 10.0))
           # 1h up move, 1h & 4h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_1h < 30.0) | (roc_9_4h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_1h < 30.0) | (roc_9_4h < 30.0))
           # 1h up move, 4h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_4h_lt_20))
           # 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_4h > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (stochrsi_k_1d > 30.0))
           # 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_70))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h > 20.0))
           # 1h up move, 4h low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (aroonu_14_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (aroonu_14_4h > 10.0))
           # 1h up move, 1h still low
-          short_entry_logic.append((rsi_3_1h < 75.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_50))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h < 70.0) | (rsi_14_4h > 40.0))
           # 1h up move, 4h low
@@ -23748,23 +23770,23 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1d still low
           short_entry_logic.append((rsi_3_4h < 97.0) | (rsi_14_1d > 50.0))
           # 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_70))
           # 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_4h > 80.0))
           # 4h up move, 15m still not high enough, 4h moving higher
-          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 80.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (stochrsi_k_15m > 80.0) | (cci_20_change_pct_4h < 0.0))
           # 4h up move, 15m still low
-          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 50.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (stochrsi_k_15m_gt_50))
           # 4h up move, 1h still low
-          short_entry_logic.append((rsi_3_4h < 90.0) | (aroonu_14_1h > 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
           # 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70))
           # 4h up move, 1d still low, 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 85.0) | (rsi_14_1d > 50.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (rsi_14_1d > 50.0) | (roc_9_4h_lt_20))
           # 4h up move, 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 80.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (roc_9_4h_lt_20))
           # 4h up move, 1h low
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h > 20.0))
           # 4h up move, 4h low
@@ -23772,15 +23794,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1d < 95.0) | (stochrsi_k_1h > 90.0))
           # 1d up move, 1h still low
-          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_50))
           # 1d up move, 4h still low
           short_entry_logic.append((rsi_3_1d < 80.0) | (stochrsi_k_4h > 40.0))
           # 15m low, 1h still low
-          short_entry_logic.append((aroonu_14_15m > 20.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((aroonu_14_15m > 20.0) | (stochrsi_k_1h_gt_50))
           # 15m low, 4h low
           short_entry_logic.append((aroonu_14_15m > 20.0) | (stochrsi_k_4h > 20.0))
           # 15m still low, 1h low
-          short_entry_logic.append((aroonu_14_15m > 50.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((aroonu_14_15m > 50.0) | (stochrsi_k_1h_gt_30))
           # 15m still not high enough, 4h low
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (aroonu_14_4h > 10.0))
           # 1h & 4h low
@@ -23802,7 +23824,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big pump in the last 6 days, 4h still not high enough
           short_entry_logic.append((close < (df["low_min_6_1d"] * 4.0)) | (stochrsi_k_4h > 80.0))
           # big pump in the last 20 days, 1h up move
-          short_entry_logic.append((close < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h < 90.0))
+          short_entry_logic.append((close < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h_lt_90))
 
           # Logic
           short_entry_logic.append(aroond_14 < 25.0)
@@ -23825,109 +23847,109 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m strong down move
           short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 5m down move, 4h still high
-          short_entry_logic.append((rsi_3 < 90.0) | (df["MFI_14"] > 10.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_lt_90) | (df["MFI_14"] > 10.0) | (stochrsi_k_4h_gt_30))
           # 5m & 1h down move, 1h still high
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70))
           # 5m down move, 4h downtrend, 1h still high
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_30))
           # 5m & 4h strong down move, 4h still not low enough
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0))
           # 5m down move, 1h high, 1d overbought
-          short_entry_logic.append((rsi_3 < 90.0) | (roc_9_1h < 15.0) | (roc_9_1d > -40.0))
+          short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h < 15.0) | (roc_9_1d > -40.0))
           # 5m down move, 1h & 4h high
-          short_entry_logic.append((rsi_3 < 90.0) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_lt_90) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h downtrend
           short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h < 10.0))
           # 5m & 1h down move, 4h down
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 85.0) | (cmf_20_4h > -0.2))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_85) | (cmf_20_4h > -0.2))
           # 5m down move, 1h high
-          short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (stochrsi_k_1h_gt_30))
           # 5m down move, 1h high
-          short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((df["RSI_14_change_pct"] < 40.0) | (stochrsi_k_4h_gt_30))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m still not low enough, 1h & 4h still not low enough
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 75.0) | (df["MFI_14_4h"] > 50.0)
+            (rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 75.0) | (df["MFI_14_4h"] > 50.0)
           )
           # 5m & 1h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50))
           # 15m & 4h down move, 1h still not low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_70))
           # 15m & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_4h < 80.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_1h > 50.0) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_50) | (rsi_14_4h > 50.0))
           # 15m & 1h & 4h down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_change_pct_1h > -60.0) | (rsi_3_change_pct_4h > -40.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_change_pct_1h > -60.0) | (rsi_3_change_pct_4h > -40.0))
           # 15m down move, 1d downtrend, 1h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (roc_9_1d > -25.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_1d > -25.0) | (stochrsi_k_1h_gt_30))
           # 15m & 1d down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1d < 90.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_30))
           # 15m & 4h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m still not low enough, 4h down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (aroond_14_15m < 50.0) | (rsi_3_4h < 85.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroond_14_15m < 50.0) | (rsi_3_4h_lt_85))
           # 15m down move, 1h still high, 1d strong downtrend
           short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_1h < 25.0) | (df["MFI_14_1d"] < 90.0))
           # 15m down move, 1h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30) | roc_9_1d_lt_50)
           # 15m down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 15m & 4h down move, 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | (roc_9_1d > -70.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_85) | (roc_9_1d > -70.0))
           # 15m down move, 15m not low enough, 1h overbought
           short_entry_logic.append(
             (df["RSI_14_change_pct_15m"] > -40.0) | (stochrsi_k_15m > 90.0) | (rsi_14_1h > 30.0)
           )
           # 15m strong down move, 1h still high
-          short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h_gt_50))
           # 15m downtrend, 1h & 4h still high
-          short_entry_logic.append((roc_9_15m < 10.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((roc_9_15m < 10.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_50))
           # 15m & 1h & 4h down move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_4h < 0.0))
           # 15m strong down move
-          short_entry_logic.append((rsi_3_15m < 90.0) | (mfi_14_15m < 85.0) | (aroond_14_15m < 25.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (mfi_14_15m < 85.0) | (aroond_14_15m < 25.0))
           # 14m down move, 4h still high
           short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m < 50.0) | (df["UO_7_14_28_4h"] > 50.0))
           # 15m down move, 1h stil high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 85.0) | (aroond_14_1h < 25.0) | (roc_9_1d > -80.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_1h < 25.0) | (roc_9_1d > -80.0))
           # 15m down move, 1h high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 30.0) | roc_9_1d_gt_neg_50)
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_30) | roc_9_1d_gt_neg_50)
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h < 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h < 10.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h > 50.0))
           # 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_change_pct_1h > -65.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_change_pct_1h > -65.0) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1h still high
-          short_entry_logic.append((rsi_3_4h < 90.0) | (df["ROC_2_1d"] < 20.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (df["ROC_2_1d"] < 20.0) | (stochrsi_k_1h_gt_50))
           # 15m still high, 1h down move, 4h high
-          short_entry_logic.append((aroond_14_15m < 50.0) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((aroond_14_15m < 50.0) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h_gt_30))
           # 15m still high, 1h & 4h down move, 4h still high
           short_entry_logic.append(
-            (aroond_14_15m < 50.0) | (rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (stochrsi_k_4h > 80.0)
+            (aroond_14_15m < 50.0) | (rsi_3_1h_lt_85) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 80.0)
           )
           # 15m & 1h still high, 4h overbought
           short_entry_logic.append((aroond_14_15m < 50.0) | (aroond_14_1h < 50.0) | (roc_9_4h > -40.0))
           # 15m still high, 1h down move, 1d downtrend
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h < 90.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
-          short_entry_logic.append((stochrsi_k_1h > 50.0) | (df["UO_7_14_28_4h"] > 55.0) | (rsi_3_1d < 90.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_50) | (df["UO_7_14_28_4h"] > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
-          short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h < 20.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
           # 4h moving down, 1d P&D
           short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | roc_9_1d_gt_neg_50)
           # 1d strong downtrend, 4h still high
-          short_entry_logic.append((df["ROC_2_1d"] < 20.0) | roc_9_1d_lt_50 | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((df["ROC_2_1d"] < 20.0) | roc_9_1d_lt_50 | (stochrsi_k_4h_gt_70))
           # 1d P&D, 1d overbought
           short_entry_logic.append((df["ROC_2_1d"] < 10.0) | roc_9_1d_gt_neg_50 | (stochrsi_k_1h > 5.0))
           # 1h red, previous 1h green, 1h overbought
@@ -23935,9 +23957,9 @@ class NostalgiaForInfinityX7(IStrategy):
             (change_pct_1h < 1.0) | (change_pct_1h.shift(12) > -5.0) | (rsi_14_1h.shift(12) < 80.0)
           )
           # 1h red, 1h stil high, 4h downtrend
-          short_entry_logic.append((change_pct_1h < 5.0) | (stochrsi_k_1h > 50.0) | (roc_9_4h > -25.0))
+          short_entry_logic.append((change_pct_1h < 5.0) | (stochrsi_k_1h_gt_50) | (roc_9_4h > -25.0))
           # 4h red, 15m down move, 4h still high
-          short_entry_logic.append((change_pct_4h < 5.0) | (rsi_3_15m < 90.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((change_pct_4h < 5.0) | (rsi_3_15m_lt_90) | (stochrsi_k_4h_gt_30))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
             (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (roc_9_4h.shift(48) > -25.0)
@@ -23947,12 +23969,12 @@ class NostalgiaForInfinityX7(IStrategy):
             (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
           )
           # 4h red, 4h still high, 1d downtrend
-          short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h > 30.0) | (roc_9_1d < 40.0))
+          short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h_gt_30) | (roc_9_1d < 40.0))
           # 1d P&D, 1d overbought
           short_entry_logic.append((change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (roc_9_1d > -100.0))
           # 1d P&D, 4h still high
           short_entry_logic.append((change_pct_1d < 15.0) | (change_pct_1d.shift(288) > -15.0) | (aroond_14_4h < 50.0))
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_95) | (cci_20_change_pct_4h < 0.0))
 
           # Logic
           short_entry_logic.append(rsi_20 > rsi_20.shift(1))
@@ -23972,27 +23994,25 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(rsi_14_1d > 10.0)
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (mfi_14_15m < 90.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 50.0)
-          )
+          short_entry_logic.append((rsi_3_15m_lt_95) | (mfi_14_15m < 90.0) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (mfi_14_15m < 85.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (mfi_14_15m < 85.0) | (stochrsi_k_4h_gt_30))
           # 14m & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["UO_7_14_28_1h"] < 45.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (df["UO_7_14_28_1h"] < 45.0) | (stochrsi_k_4h_gt_30))
           # 1h strong down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_1h"] < 40.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (df["RSI_14_change_pct_1h"] < 40.0) | (stochrsi_k_4h_gt_30))
           # 1h strong down move, 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 75.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h < 75.0) | (aroond_14_4h < 50.0))
           # 15m down move, 1h strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h > 5.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
-          short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_30))
 
           # Logic
           short_entry_logic.append(aroond_14 < 25.0)
@@ -24008,82 +24028,82 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m down move, 4h still high
           short_entry_logic.append((rsi_3 < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (rsi_14_4h > 50.0))
           # 5m & 15m & 1h down move
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m < 95.0) | (rsi_3_1h < 95.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95) | (rsi_3_1h_lt_95))
           # 5m strong down move
           short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 15m & 1h strong down move & downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h > 5.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h > 5.0))
           # 15m strong down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h > 10.0))
           # 15m & 1h down move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (cci_20_change_pct_1h > 0.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_1h > 0.0))
           # 15m & 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_30))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 50.0) | (df["MFI_14_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_change_pct_1h < 50.0) | (df["MFI_14_4h"] > 50.0))
           # 15m strong down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (mfi_14_15m < 90.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (mfi_14_15m < 90.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 1h not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h > 80.0))
           # 15m down move, 1h strong down move
-          short_entry_logic.append((rsi_3_15m < 95.0) | (df["RSI_14_change_pct_1h"] < 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (df["RSI_14_change_pct_1h"] < 70.0))
           # 15m down move, 4h & 1d downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_95) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
           # 15m down move, 1h strong down move, 4h stil high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h downtrend, 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (roc_9_1h < 20.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_1h < 20.0) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1h < 85.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_change_pct_1h < 30.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_change_pct_1h < 30.0) | (stochrsi_k_4h > 10.0))
           # 1m down move, 1h still dropping, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 90.0) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h > 20.0))
           # 15m down move, 1h high
           short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h > 10.0))
           # 1h strong down move, 4h high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h downtrend, 4h not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (cmf_20_4h > -0.25) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (cmf_20_4h > -0.25) | (stochrsi_k_4h_gt_70))
           # 1h down move, 4h high, 1d overbought
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_14_4h > 40.0) | roc_9_1d_gt_neg_50)
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_14_4h > 40.0) | roc_9_1d_gt_neg_50)
           # 1h down move, 4h strong down move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (df["RSI_14_change_pct_4h"] < 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (df["RSI_14_change_pct_4h"] < 40.0))
           # 1h & 4h down move, 4h still going down
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (cci_20_change_pct_4h < 0.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h_gt_70))
           # 1h down move, 4h down move, 4h P&D
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 70.0) | (rsi_14_4h.shift(48) > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 70.0) | (rsi_14_4h.shift(48) > 30.0))
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
-            (rsi_3_1h < 90.0) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d > 60.0)
+            (rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d > 60.0)
           )
           # 1h down move, 1h still high, 1d going down
-          short_entry_logic.append((rsi_3_1h < 85.0) | (stochrsi_k_1h > 50.0) | (df["ROC_2_1d"] > -50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50) | (df["ROC_2_1d"] > -50.0))
           # 4h downtrend, 4h still high, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_4h > 70.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70) | (roc_9_1d < 60.0))
           # 15m down move, 1h strong down move, 1d overbought
           short_entry_logic.append((mfi_14_15m < 80.0) | (rsi_3_change_pct_1h < 80.0) | roc_9_1d_gt_neg_50)
           # 1h not low enough, 4h high, 1d strong downtrend
-          short_entry_logic.append((stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
           # 1h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_change_pct_1h < 65.0) | (stochrsi_k_4h > 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_change_pct_1h < 65.0) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 15m strong down move, 1h still high
-          short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h_gt_30))
           # 15m downtrend, 4h down move, 4h stil high
-          short_entry_logic.append((roc_9_15m < 15.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((roc_9_15m < 15.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h overbought
           short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (rsi_14_4h > 20.0) | (roc_9_4h > -25.0))
           # 1h P&D, 4h still high
-          short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h down move, 1d downtrend
-          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h < 90.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
           # 4h down move, 1d P&D
-          short_entry_logic.append((roc_9_4h < 20.0) | (df["ROC_2_1d"] < 20.0) | roc_9_1d_gt_neg_50)
+          short_entry_logic.append((roc_9_4h_lt_20) | (df["ROC_2_1d"] < 20.0) | roc_9_1d_gt_neg_50)
           # 1h P&D, 4h overbought
           short_entry_logic.append((change_pct_1h < 2.0) | (change_pct_1h.shift(12) > 2.0) | (rsi_14_4h > 20.0))
           # 1h P&D, 1d overbought
@@ -24114,31 +24134,31 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(protections_short_global == True)
 
           # 5m & 15m up move, 15m stil low
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_15m < 80.0) | (aroonu_14_15m > 60.0))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_15m < 80.0) | (aroonu_14_15m > 60.0))
           # 15m & 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 15m & 1h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (cci_20_change_pct_1h < -0.0))
           # 15m & 4h up move, 4h still moving higher
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 95.0) | (cci_20_change_pct_4h < -0.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_95) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1d up move, 4h uptrend
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_1d < 80.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1d < 80.0) | (roc_9_4h_lt_20))
           # 15m up move, 15m & 4h high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0))
           # 15m up move, 15m still not high enough, 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_15m > 80.0) | (roc_9_1d < 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m > 80.0) | (roc_9_1d < 80.0))
           # 15m & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 90.0) | (stochrsi_k_15m > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_15m > 70.0))
           # 15m & 4h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 85.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_85) | roc_9_1d_lt_50)
           # 15m & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 80.0) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_80) | (rsi_14_4h > 60.0))
           # 15m up move, 15m still not high enough, 4h still low
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
           # 15m up move, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h < 50.0))
           # 15m & 1h up move, 15m still low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_15m > 40.0))
           # 15m & 1h up move, 15m still low
@@ -24148,67 +24168,67 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d up move, 1h still moving higher
           short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_15m > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0))
           # 1h & 4h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (roc_9_1d < 100.0))
           # 1h & 4h up move, 1d still low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (rsi_14_1d > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (rsi_14_1d > 50.0))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
-          short_entry_logic.append((rsi_3_1h < 95.0) | (aroonu_14_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (aroonu_14_4h > 10.0))
           # 1h & 4h up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 70.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_4h > 80.0))
           # 1h & 1d up move, 15m still low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_1d < 90.0) | (stochrsi_k_15m > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_1d < 90.0) | (stochrsi_k_15m > 60.0))
           # 1h up move, 15m high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (aroonu_14_15m < 100.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_15m < 100.0))
           # 1h up move, 4h low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h_gt_30))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 15m uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 30.0))
           # 1h up move, 15m & 4h uptrend
-          short_entry_logic.append((rsi_3_1h < 90.0) | (roc_9_15m < 20.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 20.0) | (roc_9_4h_lt_20))
           # 1h & 4h up move, 4h still moving higher
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 80.0) | (cci_20_change_pct_4h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_80) | (cci_20_change_pct_4h < -0.0))
           # 1h up move, 15m low
-          short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_15m > 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_15m > 40.0))
           # 1h up move, 4h still not high enough, 1d low
-          short_entry_logic.append((rsi_3_1h < 85.0) | (aroonu_14_4h > 80.0) | (rsi_14_1d > 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_4h > 80.0) | (rsi_14_1d > 40.0))
           # 1h & 4h up move, 4h still low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_4h > 50.0))
           # 1h & 4h up move, 1d still low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (aroonu_14_1d > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_1d > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 30.0))
           # 1h up move, 1d still low, 1d uptrend
-          short_entry_logic.append((rsi_3_1h < 80.0) | (aroonu_14_1d > 50.0) | (roc_9_1d < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (aroonu_14_1d > 50.0) | (roc_9_1d < 30.0))
           # 1h up move, 1d low
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1d > 20.0))
           # 1h up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_1h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h < 95.0) | (rsi_14_1d > 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_14_1d > 40.0))
           # 4h down move, 15m still not high enough, 1d low
-          short_entry_logic.append((rsi_3_4h < 95.0) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
           # 4h up move, 1h & 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 95.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
           # 4h up move, 15m low
-          short_entry_logic.append((rsi_3_4h < 90.0) | (stochrsi_k_15m > 45.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (stochrsi_k_15m > 45.0))
           # 4h up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
           # 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_4h < 85.0) | (aroonu_14_15m > 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (aroonu_14_15m > 60.0))
           # 4h up move, 15m low
-          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_15m > 30.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 30.0))
           # 4h up move, 4h uptrend
-          short_entry_logic.append((rsi_3_4h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (aroonu_14_4h < 100.0) | (roc_9_4h_lt_20))
           # 4h up move, 15m still low, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h > 80.0))
           # 4h up move, 15m still low, 4h still not high enough
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 80.0))
           # 1d up move, 4h low
@@ -24216,7 +24236,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h high, 4h uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
           # 15m & 4h high, 1h uptrend
           short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
           # 15m high, 1d low
@@ -24224,11 +24244,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high & uptrend
           short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_15m < 30.0))
           # 15m high, 1h & 4h uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
           # 1h high, 15m uptrend
           short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_15m < 20.0))
           # 15m & 4h still not high enough
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_4h_gt_70))
           # 1h & 4h overbought, 1h uptrend
           short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
@@ -24240,7 +24260,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (close < (df["low_min_12_1h"] * 1.30)) | (df["low_min_12_1h"] > (df["low_min_24_1h"] * 1.10))
           )
           # big pump in the last 30 days, 4h up move
-          short_entry_logic.append((close < (df["low_min_30_1d"] * 4.0)) | (rsi_3_4h < 85.0))
+          short_entry_logic.append((close < (df["low_min_30_1d"] * 4.0)) | (rsi_3_4h_lt_85))
 
           # Logic
           short_entry_logic.append(willr_14 > -50.0)
@@ -24263,64 +24283,64 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m strong down move
           short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 15m down move, 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 60.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_change_pct_1h < 60.0) | (stochrsi_k_1h_gt_50))
           # 15m down move, 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_change_pct_1h < 40.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_change_pct_1h < 40.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h down, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (cmf_20_1h < 0.2) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (cmf_20_1h < 0.2) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (aroond_14_1h < 25.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_1h < 25.0) | (stochrsi_k_4h > 10.0))
           # 15m down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (df["OBV_change_pct_15m"] < 50.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (df["OBV_change_pct_15m"] < 50.0) | (stochrsi_k_1h_gt_30))
           # 5m & 1h strong down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_70))
           # 5m & 1h strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (mfi_14_1h < 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h < 90.0))
           # 15m & 1h down move, 4h still high
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0) | (aroond_14_4h < 50.0)
+            (rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70) | (aroond_14_4h < 50.0)
           )
           # 15m & 1h down move, 4h still high, 4h downtrend
           short_entry_logic.append(
-            (rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | (df["UO_7_14_28_4h"] > 60.0) | (roc_9_4h < 20.0)
+            (rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (df["UO_7_14_28_4h"] > 60.0) | (roc_9_4h_lt_20)
           )
           # 15m & 1h down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 90.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | roc_9_1d_lt_50)
           # 15m & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 55.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 55.0))
           # 15m down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_30))
           # 15m & 1h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 75.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_30))
           # 15m down move, 15m still not low enoug, 1h high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 10.0))
           # 15m down move, 1h downtrend, 4h overbought
-          short_entry_logic.append((rsi_3_15m < 85.0) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h_gt_70))
           # 1h down move, 1h still not low enough, 4h still not low
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 70.0) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h > 50.0))
           # 1h down move, 1h not low enough, 1h still high
-          short_entry_logic.append((rsi_3_1h < 85.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (aroond_14_1h < 50.0) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_4h < 80.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h > 50.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h < 90.0) | (rsi_3_1d < 90.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d < 90.0) | (roc_9_1d < 60.0))
           # 4h overbought, 1h still high, 1d downtrend
-          short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h > 70.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h_gt_70) | roc_9_1d_lt_50)
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
             (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
           )
           # 4h red, 4h moving down, 4h still high, 1d downtrend
           short_entry_logic.append(
-            (change_pct_4h < 10.0) | (cci_20_change_pct_4h < 0.0) | (stochrsi_k_4h > 50.0) | (roc_9_1d < 40.0)
+            (change_pct_4h < 10.0) | (cci_20_change_pct_4h < 0.0) | (stochrsi_k_4h_gt_50) | (roc_9_1d < 40.0)
           )
 
           # Logic
@@ -24366,39 +24386,39 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h still not low enough
-          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
           # 15m down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 1d still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1d > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d > 70.0))
           # 15m & 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_1h < 85.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_1h > 30.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h > 75.0))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still not low enough, 4h still high
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 60.0))
           # 1h & 4h & 1d down move
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (rsi_3_1d < 80.0))
           # 1h & 4h down move, 15m not low enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_15m > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_15m > 75.0))
           # 1h down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 75.0) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1h > 90.0))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 75.0))
           # 1h down move, 1h & 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_70))
           # 4h down move, 15m still high, 1h still not low enough
-          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h > 75.0))
           # 4h down move, 15m & 4h still not low enough
           short_entry_logic.append((rsi_3_4h < 15.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 80.0))
 
@@ -24416,99 +24436,99 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 5m & 1h & 4h down move
-          short_entry_logic.append((rsi_3 < 90.0) | (rsi_3_1h < 95.0) | (rsi_3_4h < 90.0))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_95) | (rsi_3_4h_lt_90))
           # 5m down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3 < 90.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
           # 5m down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h > 20.0))
           # 15m & 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h > 90.0))
           # 15m & 1h down move, 1d still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 95.0) | (stochrsi_k_1d > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d > 70.0))
           # 15m strong down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 95.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h > 20.0))
           # 15m & 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 80.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_1h > 80.0))
           # 15m down move, 15m stil high, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h > 80.0))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m < 90.0) | (stochrsi_k_1h > 60.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h > 60.0) | (stochrsi_k_4h > 60.0))
           # 15m & 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 95.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_15m > 80.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (stochrsi_k_4h > 20.0))
           # 15m down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
           # 15m & 4h down move, 1d still high
-          short_entry_logic.append((rsi_3_15m < 85.0) | (rsi_3_4h < 75.0) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1d > 50.0))
           # 15m & 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 80.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70))
           # 15m & 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_1h < 75.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_1h < 75.0) | (stochrsi_k_4h_gt_70))
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 80.0))
           # 15m down move, 1h still high, 4h still high
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h high, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
           # 15m down move, 4h high, 1d stil high
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 50.0))
           # 15m & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m & 4h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h < 80.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h_lt_80) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m still high 4h still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h > 10.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 95.0) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h > 90.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 95.0) | (rsi_3_4h < 85.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 80.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 90.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 90.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 80.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 85.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 85.0))
           # 1h & 4h down move, 1d still high
-          short_entry_logic.append((rsi_3_1h < 90.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d > 50.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 85.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 85.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 85.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 80.0) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 75.0))
           # 1h & 4h down move, 15m still high
-          short_entry_logic.append((rsi_3_1h < 80.0) | (rsi_3_4h < 80.0) | (stochrsi_k_15m > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (stochrsi_k_15m_gt_50))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 75.0) | (rsi_3_4h < 90.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 75.0))
           # 1h & 4h down move, 1h still high
-          short_entry_logic.append((rsi_3_1h < 70.0) | (rsi_3_4h < 85.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 60.0))
           # 1h down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still high, 1h still not low enough
-          short_entry_logic.append((rsi_3_4h < 85.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 80.0))
           # 4h down move, 15m still high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 75.0))
           # 4h down move, 1h still not low enough, 1d still high
-          short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d > 50.0))
           # 15m & 1h still high, 4h high
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0))
           # 15m still high, 1h & 1d high
-          short_entry_logic.append((stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 30.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30) | (stochrsi_k_1d > 30.0))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
           # 15m high, 1h & 4h still not low enough
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 75.0) | (stochrsi_k_4h > 75.0))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_30))
           # 1h & 4h still high, 1d high
-          short_entry_logic.append((stochrsi_k_1h > 70.0) | (stochrsi_k_4h > 70.0) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70) | (stochrsi_k_1d > 50.0))
           # 1h & 4h high
-          short_entry_logic.append((stochrsi_k_1h > 30.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_30) | (stochrsi_k_4h > 10.0))
           # 1h & 4h high
           short_entry_logic.append((stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 20.0))
           # 4h & 1d high
@@ -24535,25 +24555,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m still high
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (aroond_14_15m < 50.0))
           # 15m down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 1h high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (aroond_14_1h < 70.0))
           # 15m & 1h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (aroond_14_4h < 80.0))
           # 15m & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m > 50.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m_gt_50))
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
           # 15m down move, 4h still high, 1d overbought
           short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_4h < 50.0) | (roc_9_1d > -100.0))
           # 15m down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 55.0) | (aroond_14_15m > 30.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 55.0) | (aroond_14_15m > 30.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h > 60.0))
           # 15m down move, 15m still not low enough, 4h high
@@ -24564,9 +24584,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h high
           short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 50.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_70))
           # 1h down move, 1h high
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 40.0))
           # 1h down move, 4h & 1d high
@@ -24582,21 +24602,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m high, 1h still high
           short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h > 60.0))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d > 20.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d > 10.0))
           # 1h down move, 5m up move, 1h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h_gt_50))
           # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 40.0))
           # 1h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
@@ -24606,55 +24626,55 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 60.0) | (aroond_14_4h < 70.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 30.0) | (df["AROOND_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_30) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (rsi_14_1d > 20.0))
           # 4h down move, 15m high
-          short_entry_logic.append((rsi_3_4h < 80.0) | (aroond_14_15m < 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (aroond_14_15m < 80.0))
           # 4h down move, 1h high
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h > 50.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 50.0))
           # 4h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 20.0))
           # 4h down move, 1h still high, 4h still moving down
-          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h > 50.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h_gt_50) | (cci_20_change_pct_4h < 0.0))
           # 4h down move, 1h high, 4h still high
           short_entry_logic.append((rsi_3_4h < 55.0) | (aroond_14_1h < 70.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still high
           short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_4h > 60.0))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 50.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m_gt_50) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 70.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_70))
           # 4h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h > 50.0) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 70.0))
           # 4h down move, 15m & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_4h < 70.0))
           # 4h down move, 15m high, 4h still high
           short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 80.0) | (aroond_14_4h < 40.0))
           # 4h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 50.0) | (stochrsi_k_4h > 30.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_30))
           # 4h down move, 15m & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
           # 4h down move, 1h & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h > 30.0) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h_gt_30) | (aroond_14_4h < 70.0))
           # 4h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h > 50.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d > 20.0))
           # 15m high, 4h high
           short_entry_logic.append((aroond_14_15m < 70.0) | (aroond_14_4h < 85.0))
           # 15m high, 4h still high
-          short_entry_logic.append((aroond_14_15m < 80.0) | (stochrsi_k_4h > 50.0))
+          short_entry_logic.append((aroond_14_15m < 80.0) | (stochrsi_k_4h_gt_50))
           # 15m high, 1h still high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 60.0))
           # 15m & 4h high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (aroond_14_4h < 70.0))
           # 15m high, 1h still not low enough
-          short_entry_logic.append((stochrsi_k_15m > 20.0) | (stochrsi_k_1h > 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 20.0) | (stochrsi_k_1h_gt_70))
 
           # Logic
           short_entry_logic.append(rsi_14 > 50.0)


### PR DESCRIPTION
## Summary
- Adds reused short-entry threshold masks for repeated RSI/STOCHRSI/ROC comparisons.
- Keeps the branch independent on latest upstream main.

## Safety
- Only repeated boolean Series comparisons are named and reused inside populate_entry_trend.
- Indicators, candle selection, thresholds, condition order, order classification, profit arithmetic, and return values are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required for this patch because it only reuses already-equivalent threshold comparison results in the same populate_entry_trend call; trading conditions and output formulas are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
