### PR TITLE
Reuse X7 long exit decision thresholds

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -28529,6 +28529,13 @@ class NostalgiaForInfinityX7(IStrategy):
     last_change_pct_1h = last_candle["change_pct_1h"]
     last_close = last_candle["close"]
     last_high_max_30_1d = last_candle["high_max_30_1d"]
+    # Reused long exit decision thresholds
+    last_stochrsi_k_4h_gt_50 = last_stochrsi_k_4h > 50.0
+    last_rsi_14_lt_50 = last_rsi_14 < 50.0
+    last_stochrsi_k_1h_gt_50 = last_stochrsi_k_1h > 50.0
+    last_rsi_3_1h_lt_30 = last_rsi_3_1h < 30.0
+    last_rsi_3_4h_lt_30 = last_rsi_3_4h < 30.0
+
     if 0.01 > current_profit >= 0.001:
       if (
         (last_willr_14 > -1.0)
@@ -28575,9 +28582,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_7"
@@ -28599,7 +28606,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
         (last_willr_14 > -1.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -28615,7 +28622,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -28660,7 +28667,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
@@ -28670,7 +28677,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_rsi_14 > 78.0)
         and (last_willr_14 > -5.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_24"
@@ -28686,17 +28693,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_27"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -28706,7 +28713,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -28719,7 +28726,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -28731,15 +28738,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_37"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -28749,7 +28756,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -28757,7 +28764,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -5.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -28772,7 +28779,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -28781,7 +28788,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -28801,9 +28808,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
@@ -28816,7 +28823,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_0_50"
-      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
         (last_rsi_3 > 95.0)
@@ -28828,17 +28835,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -5.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 44.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -28848,13 +28855,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -12.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -28869,10 +28876,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
@@ -28887,7 +28894,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 38.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_60"
@@ -28896,7 +28903,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -1.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -28908,14 +28915,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
       elif (last_rsi_3 > 90.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_0_65"
-      elif (last_rsi_3 > 84.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 84.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -28933,7 +28940,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
-        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -28955,12 +28962,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -28970,24 +28977,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -29003,7 +29010,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -29012,18 +29019,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_83"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -6.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
@@ -29031,7 +29038,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
@@ -29039,14 +29046,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -2.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_0_88"
@@ -29061,7 +29068,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -29080,7 +29087,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_92"
@@ -29118,7 +29125,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
@@ -29135,12 +29142,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
@@ -29196,7 +29203,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -29219,7 +29226,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
-      elif (last_rsi_3 > 95.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
         (last_rsi_3 > 95.0)
@@ -29234,7 +29241,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
         and (last_rsi_3_1d < 60.0)
@@ -29245,7 +29252,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -29254,7 +29261,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_114"
@@ -29262,8 +29269,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_115"
       elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -29286,7 +29293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_120"
       elif (last_rsi_3 > 95.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_121"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_122"
       elif (last_rsi_3 > 95.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_0_123"
@@ -29305,11 +29312,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_0_125"
-      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
         (last_rsi_3 > 95.0)
@@ -29324,7 +29331,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_0_130"
-      elif (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
         (last_rsi_3 > 95.0)
@@ -29387,9 +29394,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
@@ -29411,7 +29418,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_9"
       elif (
         (last_willr_14 > -20.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -29427,7 +29434,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_11"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -29466,13 +29473,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_19"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_1_20"
-      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_1_21"
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
@@ -29482,7 +29489,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 95.0)
         and (last_rsi_14 > 75.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_24"
@@ -29498,17 +29505,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_27"
-      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -29518,7 +29525,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_30"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -29531,7 +29538,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -2.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -29543,15 +29550,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -15.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_36"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_37"
       elif (last_rsi_3 > 85.0) and (last_willr_14 > -15.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -29561,7 +29568,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -15.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -29569,7 +29576,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -29584,7 +29591,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -29593,7 +29600,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_willr_14 > -5.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -29613,9 +29620,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_48"
       elif (
@@ -29628,7 +29635,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_1_50"
-      elif (last_rsi_3 > 66.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 66.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
         (last_rsi_3 > 80.0)
@@ -29640,17 +29647,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_53"
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 46.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -29660,13 +29667,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -14.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -29681,10 +29688,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_58"
       elif (
@@ -29699,7 +29706,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 40.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_60"
@@ -29708,7 +29715,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -29720,14 +29727,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_64"
       elif (last_rsi_3 > 68.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_1_65"
-      elif (last_rsi_3 > 82.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 82.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_1_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -29745,7 +29752,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
-        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_1_69"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -29767,39 +29774,39 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_75"
-      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 50.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14_lt_50) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -16.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_78"
-      elif (last_rsi_3 > 92.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -29815,7 +29822,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -29824,18 +29831,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_1_83"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_1_84"
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_85"
       elif (
@@ -29843,7 +29850,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_86"
       elif (
@@ -29851,14 +29858,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_87"
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -20.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_1_88"
@@ -29873,7 +29880,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -29892,13 +29899,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_92"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 50.0)
         and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
@@ -29909,7 +29916,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_93"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
         and (last_aroonu_14_1h > 75.0)
@@ -29930,7 +29937,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_96"
       elif (
@@ -29947,7 +29954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_98"
       elif (
@@ -30008,7 +30015,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -30031,7 +30038,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_109"
-      elif (last_rsi_3 > 72.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 72.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
         (last_rsi_3 > 50.0)
@@ -30057,16 +30064,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_1_113"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_1_114"
@@ -30074,8 +30081,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_115"
       elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -30098,7 +30105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_120"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_121"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_1_122"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_1_123"
@@ -30117,11 +30124,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_1_125"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_1_126"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_1_127"
-      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
       elif (
         (last_rsi_3 > 86.0)
@@ -30136,7 +30143,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_1_130"
-      elif (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_1_131"
       elif (
         (last_rsi_3 > 80.0)
@@ -30199,9 +30206,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
@@ -30223,7 +30230,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_9"
       elif (
         (last_willr_14 > -20.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -30239,7 +30246,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_11"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -30278,13 +30285,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_19"
       elif (last_rsi_3 > 48.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_2_20"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_2_21"
       elif (
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -4.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
@@ -30294,7 +30301,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 > 70.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_24"
@@ -30310,17 +30317,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_27"
-      elif (last_rsi_3 > 75.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -30330,7 +30337,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_30"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -30343,7 +30350,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -4.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -30355,15 +30362,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_36"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_37"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -20.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -30373,7 +30380,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -30381,7 +30388,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -15.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -30396,7 +30403,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -30405,7 +30412,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 60.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -30425,9 +30432,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 60.0)
         and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_48"
       elif (
@@ -30440,7 +30447,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_2_50"
-      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
         (last_rsi_3 > 78.0)
@@ -30452,17 +30459,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_53"
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 48.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -30472,13 +30479,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -16.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -30493,10 +30500,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_58"
       elif (
@@ -30511,7 +30518,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_60"
@@ -30520,7 +30527,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -4.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -30532,14 +30539,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_64"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_2_65"
-      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_2_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -30550,14 +30557,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_67"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 25.0)
         and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
-        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_2_69"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -30579,12 +30586,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -30594,24 +30601,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -18.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_78"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -30627,7 +30634,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -30636,18 +30643,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_83"
-      elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_2_84"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_85"
       elif (
@@ -30655,7 +30662,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_86"
       elif (
@@ -30663,14 +30670,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_87"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -22.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_2_88"
@@ -30685,7 +30692,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -30701,10 +30708,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_91"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_92"
@@ -30742,7 +30749,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_96"
       elif (
@@ -30759,7 +30766,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
@@ -30784,7 +30791,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_101"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 30.0)
@@ -30801,7 +30808,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_103"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 60.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 90.0)
@@ -30810,7 +30817,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
@@ -30818,22 +30825,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
         and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_107"
-      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
         (last_rsi_3 > 74.0)
@@ -30843,7 +30850,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_109"
-      elif (last_rsi_3 > 70.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
         (last_rsi_3 > 48.0)
@@ -30869,7 +30876,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -4.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -30878,16 +30885,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_115"
       elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -30906,11 +30913,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_2_119"
-      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_2_120"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_121"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_2_122"
       elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_2_123"
@@ -30929,11 +30936,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_2_125"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_2_126"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_2_127"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
       elif (
         (last_rsi_3 > 84.0)
@@ -30948,7 +30955,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_2_130"
-      elif (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_2_131"
       elif (
         (last_rsi_3 > 78.0)
@@ -31011,9 +31018,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
@@ -31035,7 +31042,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
         (last_willr_14 > -20.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -31051,7 +31058,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_11"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -31090,13 +31097,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_19"
       elif (last_rsi_3 > 46.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_3_20"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -6.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
@@ -31106,7 +31113,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_rsi_14 > 68.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_24"
@@ -31122,17 +31129,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_27"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -31142,7 +31149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -31155,7 +31162,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -6.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -31167,15 +31174,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_37"
       elif (last_rsi_3 > 75.0) and (last_willr_14 > -25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -31185,7 +31192,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -31193,7 +31200,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -31208,7 +31215,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -31217,7 +31224,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 55.0)
         and (last_willr_14 > -15.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -31237,9 +31244,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 55.0)
         and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
@@ -31252,7 +31259,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_3_50"
-      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
         (last_rsi_3 > 76.0)
@@ -31264,17 +31271,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_rsi_14_lt_50)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -31284,13 +31291,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -18.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -31305,10 +31312,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
@@ -31323,7 +31330,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_60"
@@ -31332,7 +31339,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -6.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -31344,14 +31351,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_3_65"
-      elif (last_rsi_3 > 78.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 78.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -31369,7 +31376,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
-        (last_rsi_3 > 94.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 94.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_3_69"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -31391,12 +31398,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -31405,25 +31412,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
-      elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -31439,27 +31446,27 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_3_83"
-      elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
@@ -31467,7 +31474,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
@@ -31475,14 +31482,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_87"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -24.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_3_88"
@@ -31497,14 +31504,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_90"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
         and (last_aroonu_14_4h > 50.0)
@@ -31516,7 +31523,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_92"
@@ -31551,15 +31558,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 35.0)
         and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
@@ -31571,7 +31578,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
@@ -31632,7 +31639,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 68.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -31655,7 +31662,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
-      elif (last_rsi_3 > 68.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 68.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 > 46.0)
@@ -31681,7 +31688,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -6.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -31690,7 +31697,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_114"
@@ -31698,8 +31705,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_115"
       elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -31720,9 +31727,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_119"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_3_120"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_121"
-      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_3_122"
       elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_3_123"
@@ -31741,11 +31748,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_3_125"
-      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_3_126"
-      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
         (last_rsi_3 > 82.0)
@@ -31760,7 +31767,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_3_130"
-      elif (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
         (last_rsi_3 > 76.0)
@@ -31823,9 +31830,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
@@ -31847,7 +31854,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_9"
       elif (
         (last_willr_14 > -20.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -31863,7 +31870,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_11"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -31902,13 +31909,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_19"
       elif (last_rsi_3 > 44.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_4_20"
-      elif (last_rsi_3 > 55.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 55.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_4_21"
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -8.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
@@ -31918,7 +31925,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 > 66.0)
         and (last_willr_14 > -30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_24"
@@ -31934,17 +31941,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_27"
-      elif (last_rsi_3 > 65.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -31954,7 +31961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_30"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -31967,7 +31974,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -8.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -31979,15 +31986,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -30.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_36"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_37"
       elif (last_rsi_3 > 70.0) and (last_willr_14 > -30.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -31997,7 +32004,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -30.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -32005,7 +32012,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -32020,7 +32027,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -32029,7 +32036,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -32048,10 +32055,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_47"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_48"
       elif (
@@ -32064,7 +32071,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_4_50"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
         (last_rsi_3 > 74.0)
@@ -32076,17 +32083,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_53"
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 52.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -32096,13 +32103,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -32117,10 +32124,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_58"
       elif (
@@ -32135,7 +32142,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_60"
@@ -32144,7 +32151,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -32156,14 +32163,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_64"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_4_65"
-      elif (last_rsi_3 > 76.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 76.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_4_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -32181,12 +32188,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
-        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_4_69"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_4_70"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_4_71"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_72"
@@ -32203,12 +32210,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -32218,24 +32225,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_77"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -22.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_78"
-      elif (last_rsi_3 > 86.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -32251,7 +32258,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_willr_14 > -16.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -32260,18 +32267,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_4_83"
-      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_4_84"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_85"
       elif (
@@ -32279,22 +32286,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_86"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_87"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -26.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_4_88"
@@ -32309,7 +32316,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -32328,7 +32335,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_92"
@@ -32366,7 +32373,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_96"
       elif (
@@ -32383,7 +32390,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_98"
       elif (
@@ -32444,7 +32451,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -32467,11 +32474,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_109"
-      elif (last_rsi_3 > 66.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 66.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
         (last_rsi_3 > 44.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_14_4h > 70.0)
         and (last_aroonu_14_1h > 75.0)
@@ -32493,7 +32500,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -32502,7 +32509,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_4_114"
@@ -32510,8 +32517,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_115"
       elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -32534,7 +32541,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_120"
       elif (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_121"
-      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_4_122"
       elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_4_123"
@@ -32553,11 +32560,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_4_125"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_4_126"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_4_127"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
       elif (
         (last_rsi_3 > 80.0)
@@ -32572,7 +32579,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_4_130"
-      elif (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_4_131"
       elif (
         (last_rsi_3 > 74.0)
@@ -32635,9 +32642,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
@@ -32659,7 +32666,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_9"
       elif (
         (last_willr_14 > -20.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -32675,7 +32682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_11"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -32714,13 +32721,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_19"
       elif (last_rsi_3 > 42.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_5_20"
-      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 50.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -10.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
@@ -32730,7 +32737,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 > 64.0)
         and (last_willr_14 > -35.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_24"
@@ -32746,17 +32753,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_27"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -32766,7 +32773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -32779,7 +32786,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -32791,15 +32798,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -35.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_37"
       elif (last_rsi_3 > 65.0) and (last_willr_14 > -35.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -32809,7 +32816,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_willr_14 > -35.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -32817,7 +32824,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -30.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -32832,7 +32839,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -32841,7 +32848,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -32861,9 +32868,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 45.0)
         and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
@@ -32876,7 +32883,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -12.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_5_50"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 54.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 54.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
         (last_rsi_3 > 72.0)
@@ -32888,17 +32895,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 54.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -32908,13 +32915,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -22.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -32929,10 +32936,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_58"
       elif (
@@ -32947,7 +32954,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_60"
@@ -32956,7 +32963,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -32968,18 +32975,18 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_5_65"
-      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 56.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 56.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_stochrsi_k_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -32993,14 +33000,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
-        (last_rsi_3 > 92.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 92.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_5_70"
       elif (last_rsi_3 > 56.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_5_71"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
         (last_rsi_3 > 70.0)
@@ -33015,12 +33022,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -33030,24 +33037,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 68.0)
         and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -24.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
-      elif (last_rsi_3 > 84.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 84.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
         (last_rsi_3 > 64.0)
         and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -33063,7 +33070,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_willr_14 > -18.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -33072,18 +33079,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 64.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_83"
-      elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -16.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
@@ -33091,7 +33098,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
@@ -33099,14 +33106,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_87"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -28.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_5_88"
@@ -33121,7 +33128,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -33140,7 +33147,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_92"
@@ -33178,7 +33185,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
@@ -33195,7 +33202,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_98"
       elif (
@@ -33256,7 +33263,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 64.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -33279,7 +33286,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
-      elif (last_rsi_3 > 64.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 64.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 > 42.0)
@@ -33305,7 +33312,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -33314,7 +33321,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_114"
@@ -33322,8 +33329,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_115"
       elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -33346,7 +33353,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_120"
       elif (last_rsi_3 > 52.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_121"
-      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_122"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -12.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_5_123"
@@ -33365,11 +33372,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_5_125"
-      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_5_126"
-      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_rsi_3 > 86.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
         (last_rsi_3 > 78.0)
@@ -33384,7 +33391,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_5_130"
-      elif (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
         (last_rsi_3 > 72.0)
@@ -33447,9 +33454,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
@@ -33471,7 +33478,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_9"
       elif (
         (last_willr_14 > -15.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -33487,7 +33494,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_11"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -33526,13 +33533,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_19"
       elif (last_rsi_3 > 44.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_6_20"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -8.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
@@ -33542,7 +33549,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 > 66.0)
         and (last_willr_14 > -30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_24"
@@ -33558,17 +33565,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_27"
-      elif (last_rsi_3 > 65.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -33578,7 +33585,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -33591,7 +33598,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -8.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -33603,15 +33610,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -30.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_37"
       elif (last_rsi_3 > 70.0) and (last_willr_14 > -30.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -33621,7 +33628,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -30.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -33629,7 +33636,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -33644,7 +33651,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -33653,7 +33660,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 55.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -33672,10 +33679,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_47"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
@@ -33688,7 +33695,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_6_50"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
         (last_rsi_3 > 74.0)
@@ -33700,17 +33707,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 52.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -33720,13 +33727,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -33741,10 +33748,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
@@ -33759,7 +33766,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_60"
@@ -33768,7 +33775,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -33780,14 +33787,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_6_65"
-      elif (last_rsi_3 > 76.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 76.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -33805,12 +33812,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
-        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_6_70"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_6_71"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_72"
@@ -33827,12 +33834,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -33842,24 +33849,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -22.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
-      elif (last_rsi_3 > 86.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -33875,7 +33882,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 76.0)
         and (last_willr_14 > -16.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -33884,18 +33891,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_83"
-      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
@@ -33903,22 +33910,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
         (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_87"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -26.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_6_88"
@@ -33933,7 +33940,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -33952,7 +33959,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_92"
@@ -33990,7 +33997,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
@@ -34007,7 +34014,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_98"
       elif (
@@ -34068,7 +34075,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 66.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -34091,11 +34098,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
-      elif (last_rsi_3 > 66.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 66.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 > 44.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_14_4h > 70.0)
         and (last_aroonu_14_1h > 75.0)
@@ -34117,7 +34124,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -34126,7 +34133,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_114"
@@ -34134,8 +34141,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_115"
       elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -34158,7 +34165,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_120"
       elif (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_121"
-      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_122"
       elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_6_123"
@@ -34177,11 +34184,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_6_125"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_6_126"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
         (last_rsi_3 > 80.0)
@@ -34196,7 +34203,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_6_130"
-      elif (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
         (last_rsi_3 > 74.0)
@@ -34259,9 +34266,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
@@ -34283,7 +34290,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_9"
       elif (
         (last_willr_14 > -10.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -34299,7 +34306,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_11"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -34338,13 +34345,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_19"
       elif (last_rsi_3 > 46.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_7_20"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_7_21"
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -6.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
@@ -34354,7 +34361,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_rsi_14 > 68.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_24"
@@ -34370,17 +34377,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_27"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -34390,7 +34397,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_30"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -34403,7 +34410,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -6.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -34415,15 +34422,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -25.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_36"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_37"
       elif (last_rsi_3 > 75.0) and (last_willr_14 > -25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -34433,7 +34440,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -34441,7 +34448,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -34456,7 +34463,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -34465,7 +34472,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 60.0)
         and (last_willr_14 > -15.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -34485,9 +34492,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 55.0)
         and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_48"
       elif (
@@ -34500,7 +34507,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_7_50"
-      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 50.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
         (last_rsi_3 > 76.0)
@@ -34512,17 +34519,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_53"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_rsi_14_lt_50)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -34532,13 +34539,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -18.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_55"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -34553,10 +34560,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_58"
       elif (
@@ -34571,7 +34578,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_60"
@@ -34580,7 +34587,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -6.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -34592,14 +34599,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_64"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_7_65"
-      elif (last_rsi_3 > 78.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 78.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_7_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -34617,7 +34624,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
-        (last_rsi_3 > 94.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 94.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_7_69"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -34639,12 +34646,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -34653,25 +34660,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_78"
-      elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -34687,27 +34694,27 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_82"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_7_83"
-      elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_7_84"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_85"
       elif (
@@ -34715,7 +34722,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_86"
       elif (
@@ -34723,14 +34730,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_87"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -24.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_7_88"
@@ -34745,14 +34752,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_90"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
         and (last_aroonu_14_4h > 50.0)
@@ -34764,7 +34771,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_92"
@@ -34799,15 +34806,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_96"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 35.0)
         and (last_aroonu_14_4h > 50.0)
         and (last_stochrsi_k_4h > 30.0)
@@ -34819,7 +34826,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
@@ -34880,7 +34887,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 68.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -34903,7 +34910,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_109"
-      elif (last_rsi_3 > 68.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 68.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
         (last_rsi_3 > 46.0)
@@ -34929,7 +34936,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -4.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -34938,7 +34945,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_7_114"
@@ -34946,8 +34953,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_115"
       elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -34968,9 +34975,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_119"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_7_120"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_121"
-      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_7_122"
       elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_7_123"
@@ -34989,11 +34996,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_7_125"
-      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_7_126"
-      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_7_127"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
       elif (
         (last_rsi_3 > 82.0)
@@ -35008,7 +35015,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_7_130"
-      elif (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_7_131"
       elif (
         (last_rsi_3 > 76.0)
@@ -35071,9 +35078,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
@@ -35095,7 +35102,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_9"
       elif (
         (last_willr_14 > -8.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -35111,7 +35118,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_11"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -35150,13 +35157,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_19"
       elif (last_rsi_3 > 48.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_8_20"
-      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_8_21"
       elif (
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -4.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
@@ -35166,7 +35173,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 > 70.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_24"
@@ -35182,17 +35189,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_27"
-      elif (last_rsi_3 > 75.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 75.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -35202,7 +35209,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_30"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -35215,7 +35222,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -4.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -35227,15 +35234,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -20.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_36"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_37"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -20.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -35245,7 +35252,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -35253,7 +35260,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -15.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -35268,7 +35275,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -35277,7 +35284,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -35297,9 +35304,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 60.0)
         and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_48"
       elif (
@@ -35312,7 +35319,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_8_50"
-      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 48.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
         (last_rsi_3 > 78.0)
@@ -35324,17 +35331,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_53"
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 48.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -35344,13 +35351,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -16.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_55"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -35365,10 +35372,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_58"
       elif (
@@ -35383,7 +35390,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_60"
@@ -35392,7 +35399,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -4.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -35404,14 +35411,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_64"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_8_65"
-      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_8_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -35422,14 +35429,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_67"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 25.0)
         and (last_roc_2_4h < -30.0)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
-        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_8_69"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -35451,12 +35458,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -35466,24 +35473,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -18.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_78"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -35499,7 +35506,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -35508,18 +35515,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_83"
-      elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_8_84"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_85"
       elif (
@@ -35527,7 +35534,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_86"
       elif (
@@ -35535,14 +35542,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_87"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -22.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_8_88"
@@ -35557,7 +35564,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -35573,10 +35580,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_91"
       elif (
         (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_92"
@@ -35614,7 +35621,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_96"
       elif (
@@ -35631,7 +35638,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
@@ -35656,7 +35663,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_101"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h > 30.0)
@@ -35673,7 +35680,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_103"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 60.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 90.0)
@@ -35682,7 +35689,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 25.0)
@@ -35690,22 +35697,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h > 70.0)
         and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_107"
-      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
         (last_rsi_3 > 74.0)
@@ -35715,7 +35722,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_109"
-      elif (last_rsi_3 > 70.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
         (last_rsi_3 > 48.0)
@@ -35741,7 +35748,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -35750,16 +35757,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
         (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_115"
       elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -35778,11 +35785,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_8_119"
-      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_8_120"
       elif (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_121"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_8_122"
       elif (last_rsi_3 > 86.0) and (last_willr_14 > -6.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_8_123"
@@ -35801,11 +35808,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_8_125"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_8_126"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_8_127"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
       elif (
         (last_rsi_3 > 84.0)
@@ -35820,7 +35827,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_8_130"
-      elif (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_8_131"
       elif (
         (last_rsi_3 > 78.0)
@@ -35883,9 +35890,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
@@ -35907,7 +35914,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_9"
       elif (
         (last_willr_14 > -6.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -35923,7 +35930,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_11"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -35962,13 +35969,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_19"
       elif (last_rsi_3 > 50.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_9_20"
-      elif (last_rsi_3 > 90.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_9_21"
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
@@ -35978,7 +35985,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 92.0)
         and (last_rsi_14 > 72.0)
         and (last_willr_14 > -15.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_24"
@@ -35994,17 +36001,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_27"
-      elif (last_rsi_3 > 80.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 80.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -36014,7 +36021,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_30"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -36027,7 +36034,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -2.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -36039,15 +36046,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -15.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_36"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_37"
       elif (last_rsi_3 > 85.0) and (last_willr_14 > -15.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -36057,7 +36064,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -15.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -36065,7 +36072,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -36080,7 +36087,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_42"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -36089,7 +36096,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_willr_14 > -5.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -36109,9 +36116,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 65.0)
         and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_48"
       elif (
@@ -36124,7 +36131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_9_50"
-      elif (last_rsi_3 > 66.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 66.0) and (last_rsi_14 < 46.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
         (last_rsi_3 > 80.0)
@@ -36136,17 +36143,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_53"
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 46.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -36156,13 +36163,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -14.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_55"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -36177,10 +36184,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_58"
       elif (
@@ -36195,7 +36202,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 40.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_60"
@@ -36204,7 +36211,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -36216,14 +36223,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_64"
       elif (last_rsi_3 > 68.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_9_65"
-      elif (last_rsi_3 > 82.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 82.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_9_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -36241,7 +36248,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
-        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_9_69"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -36263,39 +36270,39 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_75"
-      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 50.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14_lt_50) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -16.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_78"
-      elif (last_rsi_3 > 92.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -36311,7 +36318,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -36320,18 +36327,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_9_83"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_9_84"
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_85"
       elif (
@@ -36339,7 +36346,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_86"
       elif (
@@ -36347,14 +36354,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_87"
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -20.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_9_88"
@@ -36369,7 +36376,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -36388,13 +36395,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_92"
       elif (
         (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 50.0)
         and (last_aroonu_14_1h > 75.0)
         and (last_stochrsi_k_1h > 70.0)
@@ -36405,7 +36412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_93"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 45.0)
         and (last_aroonu_14_1h > 75.0)
@@ -36426,7 +36433,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_96"
       elif (
@@ -36443,7 +36450,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_98"
       elif (
@@ -36504,7 +36511,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 72.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -36527,7 +36534,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_109"
-      elif (last_rsi_3 > 72.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 72.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
         (last_rsi_3 > 50.0)
@@ -36553,16 +36560,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_9_113"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_9_114"
@@ -36570,8 +36577,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_115"
       elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -36594,7 +36601,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_120"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_121"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_9_122"
       elif (last_rsi_3 > 88.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_9_123"
@@ -36613,11 +36620,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_9_125"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_9_126"
-      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_9_127"
-      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
       elif (
         (last_rsi_3 > 86.0)
@@ -36632,7 +36639,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_9_130"
-      elif (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_9_131"
       elif (
         (last_rsi_3 > 80.0)
@@ -36695,9 +36702,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
@@ -36719,7 +36726,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_9"
       elif (
         (last_willr_14 > -4.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -36735,7 +36742,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_11"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -36774,13 +36781,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_19"
       elif (last_rsi_3 > 60.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_10_20"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_10_21"
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
@@ -36790,7 +36797,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 94.0)
         and (last_rsi_14 > 74.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_24"
@@ -36806,17 +36813,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_27"
-      elif (last_rsi_3 > 85.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 85.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -36826,7 +36833,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_30"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -36839,7 +36846,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -36851,15 +36858,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_36"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_37"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -36869,7 +36876,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -36877,7 +36884,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -36892,7 +36899,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_42"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -36901,7 +36908,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -36921,9 +36928,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_48"
       elif (
@@ -36936,7 +36943,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_10_50"
-      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
         (last_rsi_3 > 82.0)
@@ -36948,17 +36955,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_53"
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 44.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -36968,13 +36975,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -12.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_55"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -36989,10 +36996,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_58"
       elif (
@@ -37007,7 +37014,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 38.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_60"
@@ -37016,7 +37023,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -37028,14 +37035,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_64"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_10_65"
-      elif (last_rsi_3 > 84.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 84.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_10_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -37053,7 +37060,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
-        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_10_69"
       elif (last_rsi_3 > 68.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -37075,12 +37082,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -37090,24 +37097,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_78"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -37123,7 +37130,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -37132,18 +37139,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_10_83"
-      elif (last_rsi_3 > 92.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 92.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_10_84"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -6.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_85"
       elif (
@@ -37151,7 +37158,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_86"
       elif (
@@ -37159,14 +37166,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_87"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -18.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_10_88"
@@ -37181,7 +37188,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -37200,7 +37207,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_92"
@@ -37238,7 +37245,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_96"
       elif (
@@ -37255,12 +37262,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_98"
       elif (
         (last_rsi_3 > 62.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
@@ -37316,7 +37323,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 74.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -37339,7 +37346,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_109"
-      elif (last_rsi_3 > 74.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 74.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
         (last_rsi_3 > 52.0)
@@ -37354,7 +37361,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 35.0)
         and (last_rsi_3_4h < 35.0)
         and (last_rsi_3_1d < 60.0)
@@ -37365,7 +37372,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -37374,7 +37381,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_10_114"
@@ -37382,8 +37389,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_115"
       elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -37406,7 +37413,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_120"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_121"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_10_122"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_10_123"
@@ -37425,11 +37432,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_10_125"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_10_126"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_10_127"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
       elif (
         (last_rsi_3 > 88.0)
@@ -37444,7 +37451,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_10_130"
-      elif (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_10_131"
       elif (
         (last_rsi_3 > 82.0)
@@ -37507,9 +37514,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 70.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
@@ -37531,7 +37538,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_9"
       elif (
         (last_willr_14 > -2.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -37547,7 +37554,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_11"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -37586,13 +37593,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_19"
       elif (last_rsi_3 > 80.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_11_20"
-      elif (last_rsi_3 > 98.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 98.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_11_21"
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
@@ -37602,7 +37609,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_rsi_14 > 76.0)
         and (last_willr_14 > -5.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_24"
@@ -37618,17 +37625,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_27"
-      elif (last_rsi_3 > 90.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 90.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -37638,7 +37645,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_30"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -37651,7 +37658,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -37663,15 +37670,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -5.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_36"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_37"
       elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -37681,7 +37688,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -5.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -37689,7 +37696,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 97.0)
         and (last_willr_14 > -4.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -37704,7 +37711,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_42"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -37713,7 +37720,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -37733,9 +37740,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_48"
       elif (
@@ -37748,7 +37755,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_49"
       elif (last_rsi_3 > 85.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_11_50"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
         (last_rsi_3 > 84.0)
@@ -37760,17 +37767,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_53"
       elif (
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 42.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -37780,13 +37787,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_55"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -37801,10 +37808,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_58"
       elif (
@@ -37819,7 +37826,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 85.0)
         and (last_rsi_14 < 36.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_60"
@@ -37828,7 +37835,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -37840,14 +37847,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_64"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_11_65"
-      elif (last_rsi_3 > 86.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 86.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_11_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -37865,7 +37872,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
-        (last_rsi_3 > 98.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 98.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_11_69"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 36.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -37887,12 +37894,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -37902,24 +37909,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_78"
-      elif (last_rsi_3 > 96.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 96.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -37935,7 +37942,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -6.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -37944,18 +37951,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_83"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_11_84"
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -4.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_85"
       elif (
@@ -37963,7 +37970,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_86"
       elif (
@@ -37971,14 +37978,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 40.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_87"
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -16.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_11_88"
@@ -37993,7 +38000,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -38012,7 +38019,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_92"
@@ -38050,7 +38057,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_96"
       elif (
@@ -38067,7 +38074,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_98"
       elif (
@@ -38128,7 +38135,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 76.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -38151,7 +38158,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_109"
-      elif (last_rsi_3 > 76.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 76.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
         (last_rsi_3 > 54.0)
@@ -38177,7 +38184,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -38186,7 +38193,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_11_114"
@@ -38194,8 +38201,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_115"
       elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -38218,7 +38225,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_120"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_121"
-      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_11_122"
       elif (last_rsi_3 > 92.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_11_123"
@@ -38237,11 +38244,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_11_125"
-      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_11_126"
-      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_11_127"
-      elif (last_rsi_3 > 98.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 98.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
       elif (
         (last_rsi_3 > 90.0)
@@ -38256,7 +38263,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_11_130"
-      elif (last_rsi_14 < 34.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 34.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_11_131"
       elif (
         (last_rsi_3 > 84.0)
@@ -38319,9 +38326,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_6"
       elif (
-        (last_rsi_14 < 50.0)
+        (last_rsi_14_lt_50)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_7"
@@ -38343,7 +38350,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_9"
       elif (
         (last_willr_14 > -1.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_roc_9_1h < -10.0)
         and (last_roc_9_4h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -38359,7 +38366,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_11"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
@@ -38398,13 +38405,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_19"
       elif (last_rsi_3 > 90.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_12_20"
-      elif (last_rsi_3 > 99.0) and (last_rsi_14 < 50.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
         return True, f"exit_{mode_name}_d_12_21"
       elif (
         (last_rsi_3 > 99.0)
         and (last_willr_14 > -1.0)
         and (last_change_pct_4h < -5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
@@ -38414,7 +38421,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_rsi_14 > 78.0)
         and (last_willr_14 > -1.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_24"
@@ -38430,17 +38437,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_27"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 50.0) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3 > 95.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_4h < 20.0)
         and (last_stochrsi_k_1h > 30.0)
@@ -38450,7 +38457,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_30"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
         and (last_stochrsi_k_1h > 25.0)
@@ -38463,7 +38470,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
@@ -38475,15 +38482,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -1.0)
         and (last_roc_9_4h < -25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_36"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 20.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_37"
       elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
@@ -38493,7 +38500,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
@@ -38501,7 +38508,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
@@ -38516,7 +38523,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_42"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 40.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -38525,7 +38532,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
@@ -38545,9 +38552,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 80.0)
         and (last_rsi_14 < 38.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_48"
       elif (
@@ -38560,7 +38567,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_49"
       elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_12_50"
-      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
         (last_rsi_3 > 86.0)
@@ -38572,17 +38579,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_52"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_53"
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
@@ -38592,13 +38599,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -8.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_55"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 50.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_14_lt_50)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
@@ -38613,10 +38620,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_58"
       elif (
@@ -38631,7 +38638,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 34.0)
         and (last_rsi_14_4h > 65.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_60"
@@ -38640,7 +38647,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
@@ -38652,14 +38659,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_rsi_3_1h < 30.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_1h_lt_30)
+        and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_64"
       elif (last_rsi_3 > 74.0) and (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
         return True, f"exit_{mode_name}_d_12_65"
-      elif (last_rsi_3 > 88.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 88.0) and (last_rsi_14 < 42.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_12_66"
       elif (
         (last_rsi_3 > 50.0)
@@ -38677,7 +38684,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
-        (last_rsi_3 > 99.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h > 50.0) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 99.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_12_69"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 34.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
@@ -38699,12 +38706,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -10.0)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
@@ -38714,24 +38721,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
         (last_rsi_3 > 92.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_78"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 30.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 98.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 40.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h > 25.0)
       ):
@@ -38747,7 +38754,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -4.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
       ):
@@ -38756,18 +38763,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 40.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_83"
-      elif (last_rsi_3 > 96.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 96.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_12_84"
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 30.0)
+        and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_85"
       elif (
@@ -38775,7 +38782,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_86"
       elif (
@@ -38783,14 +38790,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 38.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_87"
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -14.0)
         and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_12_88"
@@ -38805,7 +38812,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -38824,7 +38831,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 40.0)
         and (last_stochrsi_k_1h > 25.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_92"
@@ -38862,7 +38869,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 40.0)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_1d < 45.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_96"
       elif (
@@ -38879,7 +38886,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_rsi_3_1d > 80.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_98"
       elif (
@@ -38913,7 +38920,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_102"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_14_4h > 70.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
@@ -38940,7 +38947,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 78.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
         and (last_roc_9_4h > 40.0)
       ):
@@ -38963,7 +38970,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_109"
-      elif (last_rsi_3 > 78.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h > 50.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 78.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
         (last_rsi_3 > 56.0)
@@ -38989,7 +38996,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1d < 30.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
@@ -38998,7 +39005,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 30.0)
+        and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 30.0)
       ):
         return True, f"exit_{mode_name}_d_12_114"
@@ -39006,8 +39013,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_15m < 30.0)
-        and (last_stochrsi_k_1h > 50.0)
-        and (last_stochrsi_k_4h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
+        and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_115"
       elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
@@ -39030,7 +39037,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_120"
       elif (last_rsi_3 > 66.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_121"
-      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 38.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_1h > 50.0):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14 < 38.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_12_122"
       elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_12_123"
@@ -39049,11 +39056,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_12_125"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_12_126"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h < 30.0) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_12_127"
-      elif (last_rsi_3 > 99.0) and (last_rsi_3_4h < 30.0) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
       elif (
         (last_rsi_3 > 92.0)
@@ -39068,7 +39075,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_12_130"
-      elif (last_rsi_14 < 32.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 30.0) and (last_stochrsi_k_4h > 50.0):
+      elif (last_rsi_14 < 32.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_12_131"
       elif (
         (last_rsi_3 > 86.0)


### PR DESCRIPTION
## Summary
- Adds named threshold results for the five most repeated long_exit_dec scalar comparisons.
- Keeps the branch independent on latest upstream main.

## Safety
- Only existing scalar comparisons against last_candle-derived values are reused inside long_exit_dec.
- No thresholds, condition order, return labels, candle selection, indicators, order classification, or profit arithmetic are changed.
- This touches the active long_exit_dec runtime path, so the diff was reviewed specifically for guarded isinstance checks and no guarded comparison was hoisted.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required for this plumbing patch because the same last_candle scalar threshold comparisons are reused under new names; trading conditions, thresholds, return paths, and formulas are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `guarded isinstance comparison diff scan`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
