### PR TITLE
Reuse X7 short exit decision thresholds

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -51622,6 +51622,13 @@ class NostalgiaForInfinityX7(IStrategy):
     last_change_pct_1h = last_candle["change_pct_1h"]
     last_close = last_candle["close"]
     last_low_min_30_1d = last_candle["low_min_30_1d"]
+    # Reused short exit decision thresholds
+    last_stochrsi_k_4h_lt_50 = last_stochrsi_k_4h < 50.0
+    last_rsi_14_gt_50 = last_rsi_14 > 50.0
+    last_rsi_3_1h_gt_70 = last_rsi_3_1h > 70.0
+    last_stochrsi_k_1h_lt_50 = last_stochrsi_k_1h < 50.0
+    last_rsi_3_4h_gt_70 = last_rsi_3_4h > 70.0
+
     if 0.01 > current_profit >= 0.001:
       if (
         (last_willr_14 < -99.0)
@@ -51668,9 +51675,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_7"
@@ -51692,7 +51699,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
         (last_willr_14 < -99.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -51708,7 +51715,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -51753,7 +51760,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
@@ -51763,7 +51770,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 1.0)
         and (last_rsi_14 < 22.0)
         and (last_willr_14 < -95.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_24"
@@ -51779,17 +51786,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_27"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -51799,7 +51806,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -51812,7 +51819,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -51824,15 +51831,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_37"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -51842,7 +51849,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -51850,7 +51857,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -95.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -51865,7 +51872,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -51874,7 +51881,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -51894,9 +51901,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
@@ -51909,7 +51916,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_0_50"
-      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
         (last_rsi_3 < 5.0)
@@ -51921,17 +51928,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -95.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 56.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -51941,13 +51948,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -88.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -51962,10 +51969,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
@@ -51980,7 +51987,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 62.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_60"
@@ -51989,7 +51996,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -99.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -52001,14 +52008,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
       elif (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_65"
-      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -52026,7 +52033,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
-        (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -52053,7 +52060,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -52063,24 +52070,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -52096,7 +52103,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -52105,18 +52112,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_0_83"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -94.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
@@ -52124,7 +52131,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
@@ -52132,14 +52139,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -98.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_0_88"
@@ -52154,7 +52161,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -52173,7 +52180,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_92"
@@ -52211,7 +52218,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
@@ -52228,12 +52235,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
@@ -52289,7 +52296,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -52312,7 +52319,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
         (last_rsi_3 < 5.0)
@@ -52327,7 +52334,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
         and (last_rsi_3_1d > 40.0)
@@ -52338,7 +52345,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -99.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -52347,7 +52354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_0_114"
@@ -52355,8 +52362,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_115"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -52377,7 +52384,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_120"
       elif (last_rsi_3 < 5.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_0_121"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_122"
       elif (last_rsi_3 < 5.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_0_123"
@@ -52396,11 +52403,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_0_125"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
         (last_rsi_3 < 5.0)
@@ -52415,7 +52422,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_0_130"
-      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
         (last_rsi_3 < 5.0)
@@ -52478,9 +52485,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
@@ -52502,7 +52509,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_9"
       elif (
         (last_willr_14 < -80.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -52518,7 +52525,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_11"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -52557,13 +52564,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_19"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_1_20"
-      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_1_21"
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
@@ -52573,7 +52580,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 5.0)
         and (last_rsi_14 < 25.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_1_24"
@@ -52589,17 +52596,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_27"
-      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_1_28"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -52609,7 +52616,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_30"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -52622,7 +52629,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -98.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -52634,15 +52641,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -85.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_36"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_37"
       elif (last_rsi_3 < 15.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -52652,7 +52659,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -85.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -52660,7 +52667,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -52675,7 +52682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -52684,7 +52691,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_willr_14 < -95.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -52704,9 +52711,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_48"
       elif (
@@ -52719,7 +52726,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_1_50"
-      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
         (last_rsi_3 < 20.0)
@@ -52731,17 +52738,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_53"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 54.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -52751,13 +52758,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -86.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -52772,10 +52779,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_58"
       elif (
@@ -52790,7 +52797,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_60"
@@ -52799,7 +52806,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -52811,14 +52818,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_63"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_64"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_65"
-      elif (last_rsi_3 < 18.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 18.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_1_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -52836,7 +52843,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
-        (last_rsi_3 < 4.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 4.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_1_69"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -52863,34 +52870,34 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_75"
-      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 50.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14_gt_50) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -84.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_78"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -52906,7 +52913,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -52915,18 +52922,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_1_83"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_1_84"
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_85"
       elif (
@@ -52934,7 +52941,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_86"
       elif (
@@ -52942,14 +52949,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_87"
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -80.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_1_88"
@@ -52964,7 +52971,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -52983,13 +52990,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_92"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 50.0)
         and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
@@ -53000,7 +53007,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_93"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
         and (last_aroond_14_1h > 75.0)
@@ -53021,7 +53028,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_96"
       elif (
@@ -53038,7 +53045,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_98"
       elif (
@@ -53099,7 +53106,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -53122,7 +53129,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_109"
-      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
         (last_rsi_3 < 50.0)
@@ -53148,16 +53155,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_113"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_1_114"
@@ -53165,8 +53172,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_115"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -53189,7 +53196,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_120"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_1_121"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_1_122"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_1_123"
@@ -53208,11 +53215,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_1_125"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_1_126"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_1_127"
-      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
       elif (
         (last_rsi_3 < 14.0)
@@ -53227,7 +53234,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_1_130"
-      elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_1_131"
       elif (
         (last_rsi_3 < 20.0)
@@ -53290,9 +53297,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
@@ -53314,7 +53321,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_9"
       elif (
         (last_willr_14 < -80.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -53330,7 +53337,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_11"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -53369,13 +53376,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_19"
       elif (last_rsi_3 < 52.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_2_20"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_2_21"
       elif (
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -96.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
@@ -53385,7 +53392,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_24"
@@ -53401,17 +53408,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_27"
-      elif (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_2_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -53421,7 +53428,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_30"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -53434,7 +53441,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -96.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -53446,15 +53453,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_36"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_37"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -53464,7 +53471,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -53472,7 +53479,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -85.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -53487,7 +53494,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -53496,7 +53503,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 40.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -53516,9 +53523,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_48"
       elif (
@@ -53531,7 +53538,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_2_50"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
         (last_rsi_3 < 22.0)
@@ -53543,17 +53550,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_53"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 52.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -53563,13 +53570,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -84.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -53584,10 +53591,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_58"
       elif (
@@ -53602,7 +53609,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_60"
@@ -53611,7 +53618,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -96.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -53623,14 +53630,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_63"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_64"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_65"
-      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_2_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -53641,14 +53648,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_67"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 75.0)
         and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
-        (last_rsi_3 < 5.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 5.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_2_69"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -53675,7 +53682,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -53685,24 +53692,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -82.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_78"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -53718,7 +53725,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -88.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -53727,18 +53734,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_83"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_2_84"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_85"
       elif (
@@ -53746,7 +53753,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_86"
       elif (
@@ -53754,14 +53761,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_87"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -78.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_2_88"
@@ -53776,7 +53783,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -53792,10 +53799,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_91"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_92"
@@ -53833,7 +53840,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_96"
       elif (
@@ -53850,7 +53857,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
@@ -53875,7 +53882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_101"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h > 70.0)
@@ -53892,7 +53899,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_103"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
@@ -53901,7 +53908,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
@@ -53909,22 +53916,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
         and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_2_107"
-      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
         (last_rsi_3 < 26.0)
@@ -53934,7 +53941,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_109"
-      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
         (last_rsi_3 < 52.0)
@@ -53960,7 +53967,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -96.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -53969,16 +53976,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_2_114"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_115"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -53997,11 +54004,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_2_119"
-      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_2_120"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_2_121"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_2_122"
       elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_2_123"
@@ -54020,11 +54027,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_2_125"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_2_126"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_2_127"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
       elif (
         (last_rsi_3 < 16.0)
@@ -54039,7 +54046,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_2_130"
-      elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_2_131"
       elif (
         (last_rsi_3 < 22.0)
@@ -54102,9 +54109,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
@@ -54126,7 +54133,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
         (last_willr_14 < -80.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -54142,7 +54149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_11"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -54181,13 +54188,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_19"
       elif (last_rsi_3 < 54.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_3_20"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -94.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
@@ -54197,7 +54204,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_24"
@@ -54213,17 +54220,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_27"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -54233,7 +54240,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -54246,7 +54253,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -94.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -54258,15 +54265,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_37"
       elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -54276,7 +54283,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -54284,7 +54291,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -54299,7 +54306,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -54308,7 +54315,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 45.0)
         and (last_willr_14 < -85.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -54328,9 +54335,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 45.0)
         and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
@@ -54343,7 +54350,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_3_50"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
         (last_rsi_3 < 24.0)
@@ -54355,17 +54362,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_rsi_14_gt_50)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -54375,13 +54382,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -82.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -54396,10 +54403,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
@@ -54414,7 +54421,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_60"
@@ -54423,7 +54430,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -94.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -54435,14 +54442,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_65"
-      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -54460,7 +54467,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
-        (last_rsi_3 < 6.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 6.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_3_69"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -54487,7 +54494,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -54496,25 +54503,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -54530,27 +54537,27 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_3_83"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -88.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
@@ -54558,7 +54565,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
@@ -54566,14 +54573,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_87"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -76.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_3_88"
@@ -54588,14 +54595,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_90"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (last_aroonu_14_4h < 50.0)
@@ -54607,7 +54614,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_92"
@@ -54642,15 +54649,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 65.0)
         and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
@@ -54662,7 +54669,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
@@ -54723,7 +54730,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -54746,7 +54753,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
-      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 < 54.0)
@@ -54772,7 +54779,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -54781,7 +54788,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_3_114"
@@ -54789,8 +54796,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_115"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -54811,9 +54818,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_119"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_3_120"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_3_121"
-      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_122"
       elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_3_123"
@@ -54832,11 +54839,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_3_125"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_3_126"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
         (last_rsi_3 < 18.0)
@@ -54851,7 +54858,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_3_130"
-      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
         (last_rsi_3 < 24.0)
@@ -54914,9 +54921,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
@@ -54938,7 +54945,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_9"
       elif (
         (last_willr_14 < -80.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -54954,7 +54961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_11"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -54993,13 +55000,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_19"
       elif (last_rsi_3 < 56.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_4_20"
-      elif (last_rsi_3 < 45.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 45.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_4_21"
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -92.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
@@ -55009,7 +55016,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
         and (last_willr_14 < -70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_4_24"
@@ -55025,17 +55032,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_27"
-      elif (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_4_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -55045,7 +55052,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_30"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -55058,7 +55065,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -92.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -55070,15 +55077,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -70.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_36"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_37"
       elif (last_rsi_3 < 30.0) and (last_willr_14 < -70.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -55088,7 +55095,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -70.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -55096,7 +55103,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -55111,7 +55118,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -55120,7 +55127,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -55139,10 +55146,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_47"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_48"
       elif (
@@ -55155,7 +55162,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_4_50"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
         (last_rsi_3 < 26.0)
@@ -55167,17 +55174,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_53"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 48.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -55187,13 +55194,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -55208,10 +55215,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_58"
       elif (
@@ -55226,7 +55233,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_4_60"
@@ -55235,7 +55242,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -55247,14 +55254,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_63"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_64"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_65"
-      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_4_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -55272,12 +55279,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
-        (last_rsi_3 < 7.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 7.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_4_69"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_4_70"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_4_71"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_4_72"
@@ -55299,7 +55306,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -55309,24 +55316,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_77"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -78.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_78"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -55342,7 +55349,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_willr_14 < -84.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -55351,18 +55358,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_4_83"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_4_84"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_85"
       elif (
@@ -55370,22 +55377,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_86"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_87"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -74.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_4_88"
@@ -55400,7 +55407,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -55419,7 +55426,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_92"
@@ -55457,7 +55464,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_96"
       elif (
@@ -55474,7 +55481,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_98"
       elif (
@@ -55535,7 +55542,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -55558,11 +55565,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_109"
-      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
         (last_rsi_3 < 56.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_14_4h < 30.0)
         and (last_aroond_14_1h > 75.0)
@@ -55584,7 +55591,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -92.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -55593,7 +55600,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_4_114"
@@ -55601,8 +55608,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_115"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -55625,7 +55632,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_120"
       elif (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_4_121"
-      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_4_122"
       elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_4_123"
@@ -55644,11 +55651,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_4_125"
-      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_4_126"
-      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_4_127"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
       elif (
         (last_rsi_3 < 20.0)
@@ -55663,7 +55670,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_4_130"
-      elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_4_131"
       elif (
         (last_rsi_3 < 26.0)
@@ -55726,9 +55733,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
@@ -55750,7 +55757,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_9"
       elif (
         (last_willr_14 < -80.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -55766,7 +55773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_11"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -55805,13 +55812,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_19"
       elif (last_rsi_3 < 58.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_5_20"
-      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -90.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
@@ -55821,7 +55828,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 < 36.0)
         and (last_willr_14 < -65.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_24"
@@ -55837,17 +55844,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_27"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -55857,7 +55864,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -55870,7 +55877,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -55882,15 +55889,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -65.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_37"
       elif (last_rsi_3 < 35.0) and (last_willr_14 < -65.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -55900,7 +55907,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_willr_14 < -65.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -55908,7 +55915,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -70.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -55923,7 +55930,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -55932,7 +55939,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -55952,9 +55959,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 55.0)
         and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
@@ -55967,7 +55974,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_5_50"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 46.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 46.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
         (last_rsi_3 < 28.0)
@@ -55979,17 +55986,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 46.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -55999,13 +56006,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -78.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -56020,10 +56027,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_58"
       elif (
@@ -56038,7 +56045,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_60"
@@ -56047,7 +56054,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -56059,18 +56066,18 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_65"
-      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 44.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 44.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -56084,14 +56091,14 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
-        (last_rsi_3 < 8.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 8.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_70"
       elif (last_rsi_3 < 44.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_5_71"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
         (last_rsi_3 < 30.0)
@@ -56111,7 +56118,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -56121,24 +56128,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -76.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -56154,7 +56161,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_willr_14 < -82.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -56163,18 +56170,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_83"
-      elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -84.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
@@ -56182,7 +56189,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
@@ -56190,14 +56197,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_87"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -72.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_5_88"
@@ -56212,7 +56219,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -56231,7 +56238,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_92"
@@ -56269,7 +56276,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
@@ -56286,7 +56293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_98"
       elif (
@@ -56347,7 +56354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 36.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -56370,7 +56377,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
-      elif (last_rsi_3 < 36.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 < 58.0)
@@ -56396,7 +56403,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_willr_14 < -90.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -56405,7 +56412,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_114"
@@ -56413,8 +56420,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_115"
       elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -56437,7 +56444,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_120"
       elif (last_rsi_3 < 48.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_5_121"
-      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_5_122"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_5_123"
@@ -56456,11 +56463,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_5_125"
-      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_5_126"
-      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
         (last_rsi_3 < 22.0)
@@ -56475,7 +56482,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_5_130"
-      elif (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
         (last_rsi_3 < 28.0)
@@ -56538,9 +56545,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
@@ -56562,7 +56569,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_9"
       elif (
         (last_willr_14 < -85.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -56578,7 +56585,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_11"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -56617,13 +56624,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_19"
       elif (last_rsi_3 < 56.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_6_20"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -92.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
@@ -56633,7 +56640,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
         and (last_willr_14 < -70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_24"
@@ -56649,17 +56656,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_27"
-      elif (last_rsi_3 < 35.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -56669,7 +56676,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -56682,7 +56689,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -92.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -56694,15 +56701,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -70.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_37"
       elif (last_rsi_3 < 30.0) and (last_willr_14 < -70.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -56712,7 +56719,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -70.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -56720,7 +56727,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -56735,7 +56742,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -56744,7 +56751,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 45.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -56763,10 +56770,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_47"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
@@ -56779,7 +56786,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_6_50"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
         (last_rsi_3 < 26.0)
@@ -56791,17 +56798,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 48.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -56811,13 +56818,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -56832,10 +56839,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
@@ -56850,7 +56857,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_60"
@@ -56859,7 +56866,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -56871,14 +56878,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_65"
-      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 24.0) and (last_rsi_14 > 46.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -56896,12 +56903,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
-        (last_rsi_3 < 7.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 7.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_70"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_6_71"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_72"
@@ -56923,7 +56930,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -56933,24 +56940,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -78.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -56966,7 +56973,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_willr_14 < -84.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -56975,18 +56982,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_83"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
@@ -56994,22 +57001,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_87"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -74.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_6_88"
@@ -57024,7 +57031,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -57043,7 +57050,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_92"
@@ -57081,7 +57088,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
@@ -57098,7 +57105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_98"
       elif (
@@ -57159,7 +57166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 34.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -57182,11 +57189,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
-      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 < 56.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_14_4h < 30.0)
         and (last_aroond_14_1h > 75.0)
@@ -57208,7 +57215,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -92.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -57217,7 +57224,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_114"
@@ -57225,8 +57232,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_115"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -57249,7 +57256,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_120"
       elif (last_rsi_3 < 46.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_6_121"
-      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_6_122"
       elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_6_123"
@@ -57268,11 +57275,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_6_125"
-      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_6_126"
-      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
         (last_rsi_3 < 20.0)
@@ -57287,7 +57294,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_6_130"
-      elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
         (last_rsi_3 < 26.0)
@@ -57350,9 +57357,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
@@ -57374,7 +57381,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_9"
       elif (
         (last_willr_14 < -90.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -57390,7 +57397,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_11"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -57429,13 +57436,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_19"
       elif (last_rsi_3 < 54.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_7_20"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_7_21"
       elif (
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -94.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
@@ -57445,7 +57452,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_24"
@@ -57461,17 +57468,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_27"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_7_28"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -57481,7 +57488,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_30"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -57494,7 +57501,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -94.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -57506,15 +57513,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -75.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_36"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_37"
       elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -57524,7 +57531,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -57532,7 +57539,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -57547,7 +57554,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -57556,7 +57563,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 40.0)
         and (last_willr_14 < -85.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -57576,9 +57583,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 45.0)
         and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_48"
       elif (
@@ -57591,7 +57598,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_7_50"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 50.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
         (last_rsi_3 < 24.0)
@@ -57603,17 +57610,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_53"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_rsi_14_gt_50)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -57623,13 +57630,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -82.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_55"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -57644,10 +57651,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_58"
       elif (
@@ -57662,7 +57669,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_7_60"
@@ -57671,7 +57678,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -94.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -57683,14 +57690,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_63"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_64"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_65"
-      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_7_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -57708,7 +57715,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
-        (last_rsi_3 < 6.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 6.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_7_69"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -57735,7 +57742,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -57744,25 +57751,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_78"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -57778,27 +57785,27 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_82"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_83"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_7_84"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -88.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_85"
       elif (
@@ -57806,7 +57813,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_86"
       elif (
@@ -57814,14 +57821,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_87"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -76.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_7_88"
@@ -57836,14 +57843,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_90"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (last_aroonu_14_4h < 50.0)
@@ -57855,7 +57862,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_92"
@@ -57890,15 +57897,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
         (last_rsi_3 < 42.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_96"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 65.0)
         and (last_aroond_14_4h > 50.0)
         and (last_stochrsi_k_4h < 70.0)
@@ -57910,7 +57917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
@@ -57971,7 +57978,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 32.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -57994,7 +58001,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_109"
-      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
         (last_rsi_3 < 54.0)
@@ -58020,7 +58027,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -94.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -58029,7 +58036,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_7_114"
@@ -58037,8 +58044,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_115"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -58059,9 +58066,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_119"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_7_120"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_7_121"
-      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_7_122"
       elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_7_123"
@@ -58080,11 +58087,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_7_125"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_7_126"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_7_127"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
       elif (
         (last_rsi_3 < 18.0)
@@ -58099,7 +58106,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_7_130"
-      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_7_131"
       elif (
         (last_rsi_3 < 24.0)
@@ -58162,9 +58169,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
@@ -58186,7 +58193,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_9"
       elif (
         (last_willr_14 < -92.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -58202,7 +58209,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_11"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -58241,13 +58248,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_19"
       elif (last_rsi_3 < 52.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_8_20"
-      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_8_21"
       elif (
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -96.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
@@ -58257,7 +58264,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_24"
@@ -58273,17 +58280,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_27"
-      elif (last_rsi_3 < 25.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 25.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_8_28"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -58293,7 +58300,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_30"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -58306,7 +58313,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -96.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -58318,15 +58325,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -80.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_36"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_37"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -58336,7 +58343,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -58344,7 +58351,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -85.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -58359,7 +58366,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -58368,7 +58375,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -58388,9 +58395,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 40.0)
         and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_48"
       elif (
@@ -58403,7 +58410,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_8_50"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
         (last_rsi_3 < 22.0)
@@ -58415,17 +58422,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_53"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 52.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -58435,13 +58442,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -84.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_55"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -58456,10 +58463,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_58"
       elif (
@@ -58474,7 +58481,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_60"
@@ -58483,7 +58490,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -96.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -58495,14 +58502,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_63"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_64"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_65"
-      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_8_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -58513,14 +58520,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_67"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 75.0)
         and (last_roc_2_4h > 30.0)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
-        (last_rsi_3 < 5.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 5.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_8_69"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -58547,7 +58554,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -58557,24 +58564,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -82.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_78"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -58590,7 +58597,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -88.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -58599,18 +58606,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_83"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_8_84"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_85"
       elif (
@@ -58618,7 +58625,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_86"
       elif (
@@ -58626,14 +58633,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_87"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -78.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_8_88"
@@ -58648,7 +58655,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -58664,10 +58671,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_91"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_92"
@@ -58705,7 +58712,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_96"
       elif (
@@ -58722,7 +58729,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
@@ -58747,7 +58754,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_101"
       elif (
         (last_rsi_3 < 34.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h > 70.0)
@@ -58764,7 +58771,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_103"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
@@ -58773,7 +58780,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -25.0)
@@ -58781,22 +58788,22 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h < 30.0)
         and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_8_107"
-      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
         (last_rsi_3 < 26.0)
@@ -58806,7 +58813,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_109"
-      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
         (last_rsi_3 < 52.0)
@@ -58832,7 +58839,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -96.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -58841,16 +58848,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_8_114"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_115"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -58869,11 +58876,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_119"
-      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_8_120"
       elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_8_121"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_8_122"
       elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_8_123"
@@ -58892,11 +58899,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_8_125"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_8_126"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_8_127"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
       elif (
         (last_rsi_3 < 16.0)
@@ -58911,7 +58918,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_8_130"
-      elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_8_131"
       elif (
         (last_rsi_3 < 22.0)
@@ -58974,9 +58981,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
@@ -58998,7 +59005,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_9"
       elif (
         (last_willr_14 < -94.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -59014,7 +59021,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_11"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -59053,13 +59060,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_19"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_9_20"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_9_21"
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
@@ -59069,7 +59076,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 8.0)
         and (last_rsi_14 < 28.0)
         and (last_willr_14 < -85.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_24"
@@ -59085,17 +59092,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_27"
-      elif (last_rsi_3 < 20.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_9_28"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -59105,7 +59112,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_30"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -59118,7 +59125,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -98.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -59130,15 +59137,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -85.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_36"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_37"
       elif (last_rsi_3 < 15.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -59148,7 +59155,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -85.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -59156,7 +59163,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -59171,7 +59178,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_42"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -59180,7 +59187,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_willr_14 < -95.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -59200,9 +59207,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 35.0)
         and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_48"
       elif (
@@ -59215,7 +59222,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_9_50"
-      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
         (last_rsi_3 < 20.0)
@@ -59227,17 +59234,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_53"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 54.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -59247,13 +59254,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -86.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_55"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -59268,10 +59275,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_58"
       elif (
@@ -59286,7 +59293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_60"
@@ -59295,7 +59302,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -59307,14 +59314,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_63"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_64"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_65"
-      elif (last_rsi_3 < 18.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 18.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_9_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -59332,7 +59339,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
-        (last_rsi_3 < 4.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 4.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_9_69"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -59359,34 +59366,34 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_75"
-      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 50.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14_gt_50) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -84.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_78"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -59402,7 +59409,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -59411,18 +59418,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_83"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_9_84"
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_85"
       elif (
@@ -59430,7 +59437,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_86"
       elif (
@@ -59438,14 +59445,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_87"
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -80.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_9_88"
@@ -59460,7 +59467,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -59479,13 +59486,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_92"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 50.0)
         and (last_aroond_14_1h > 75.0)
         and (last_stochrsi_k_1h < 30.0)
@@ -59496,7 +59503,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_93"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 55.0)
         and (last_aroond_14_1h > 75.0)
@@ -59517,7 +59524,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_96"
       elif (
@@ -59534,7 +59541,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_98"
       elif (
@@ -59595,7 +59602,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -59618,7 +59625,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_109"
-      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
         (last_rsi_3 < 50.0)
@@ -59644,16 +59651,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_113"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_9_114"
@@ -59661,8 +59668,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_115"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -59685,7 +59692,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_120"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_9_121"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_9_122"
       elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_9_123"
@@ -59704,11 +59711,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_9_125"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_9_126"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_9_127"
-      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
       elif (
         (last_rsi_3 < 14.0)
@@ -59723,7 +59730,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_9_130"
-      elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_9_131"
       elif (
         (last_rsi_3 < 20.0)
@@ -59786,9 +59793,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
@@ -59810,7 +59817,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_9"
       elif (
         (last_willr_14 < -96.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -59826,7 +59833,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_11"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -59865,13 +59872,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_19"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_10_20"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_10_21"
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
@@ -59881,7 +59888,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 6.0)
         and (last_rsi_14 < 26.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_24"
@@ -59897,17 +59904,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_27"
-      elif (last_rsi_3 < 15.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 15.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_10_28"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -59917,7 +59924,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_30"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -59930,7 +59937,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -59942,15 +59949,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_36"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_37"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -59960,7 +59967,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -59968,7 +59975,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -59983,7 +59990,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_42"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -59992,7 +59999,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -60012,9 +60019,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_48"
       elif (
@@ -60027,7 +60034,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_10_50"
-      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
         (last_rsi_3 < 18.0)
@@ -60039,17 +60046,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_53"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 56.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -60059,13 +60066,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -88.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_55"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -60080,10 +60087,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_58"
       elif (
@@ -60098,7 +60105,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 62.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_60"
@@ -60107,7 +60114,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -60119,14 +60126,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_63"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_64"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_65"
-      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_10_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -60144,7 +60151,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
-        (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_10_69"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -60171,7 +60178,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -60181,24 +60188,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_78"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -60214,7 +60221,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -60223,18 +60230,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_83"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_10_84"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -94.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_85"
       elif (
@@ -60242,7 +60249,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_86"
       elif (
@@ -60250,14 +60257,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_87"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -82.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_10_88"
@@ -60272,7 +60279,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -60291,7 +60298,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_92"
@@ -60329,7 +60336,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_96"
       elif (
@@ -60346,12 +60353,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_98"
       elif (
         (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
@@ -60407,7 +60414,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -60430,7 +60437,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_109"
-      elif (last_rsi_3 < 26.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 26.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
         (last_rsi_3 < 48.0)
@@ -60445,7 +60452,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_willr_14 < -80.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 65.0)
         and (last_rsi_3_4h > 65.0)
         and (last_rsi_3_1d > 40.0)
@@ -60456,7 +60463,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -99.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -60465,7 +60472,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_10_114"
@@ -60473,8 +60480,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_115"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -60497,7 +60504,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_120"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_10_121"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_10_122"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_10_123"
@@ -60516,11 +60523,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_10_125"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_10_126"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_10_127"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
       elif (
         (last_rsi_3 < 12.0)
@@ -60535,7 +60542,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_10_130"
-      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_10_131"
       elif (
         (last_rsi_3 < 18.0)
@@ -60598,9 +60605,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 30.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
@@ -60622,7 +60629,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_9"
       elif (
         (last_willr_14 < -98.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -60638,7 +60645,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_11"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -60677,13 +60684,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_19"
       elif (last_rsi_3 < 20.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_11_20"
-      elif (last_rsi_3 < 2.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_11_21"
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
@@ -60693,7 +60700,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 4.0)
         and (last_rsi_14 < 24.0)
         and (last_willr_14 < -95.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_24"
@@ -60709,17 +60716,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_27"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_11_28"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -60729,7 +60736,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_30"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -60742,7 +60749,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -60754,15 +60761,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -95.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_36"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_37"
       elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -60772,7 +60779,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 5.0)
         and (last_willr_14 < -95.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -60780,7 +60787,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 3.0)
         and (last_willr_14 < -96.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -60795,7 +60802,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_42"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -60804,7 +60811,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -60824,9 +60831,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 25.0)
         and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_48"
       elif (
@@ -60839,7 +60846,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_49"
       elif (last_rsi_3 < 15.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_11_50"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
         (last_rsi_3 < 16.0)
@@ -60851,17 +60858,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_53"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 58.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -60871,13 +60878,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -90.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_55"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -60892,10 +60899,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_58"
       elif (
@@ -60910,7 +60917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 15.0)
         and (last_rsi_14 > 64.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_11_60"
@@ -60919,7 +60926,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -60931,14 +60938,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_63"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_64"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_65"
-      elif (last_rsi_3 < 14.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_11_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -60956,7 +60963,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
-        (last_rsi_3 < 2.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 2.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_11_69"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -60983,7 +60990,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -60993,24 +61000,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -88.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_78"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -61026,7 +61033,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -94.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -61035,18 +61042,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_83"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_11_84"
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -96.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_85"
       elif (
@@ -61054,7 +61061,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_86"
       elif (
@@ -61062,14 +61069,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_87"
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -84.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_11_88"
@@ -61084,7 +61091,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -61103,7 +61110,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_92"
@@ -61141,7 +61148,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_96"
       elif (
@@ -61158,7 +61165,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_98"
       elif (
@@ -61219,7 +61226,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -61242,7 +61249,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_109"
-      elif (last_rsi_3 < 24.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 24.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
         (last_rsi_3 < 46.0)
@@ -61268,7 +61275,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -99.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -61277,7 +61284,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_11_114"
@@ -61285,8 +61292,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_115"
       elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -61309,7 +61316,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_120"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_11_121"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_11_122"
       elif (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_11_123"
@@ -61328,11 +61335,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_11_125"
-      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_11_126"
-      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_11_127"
-      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
       elif (
         (last_rsi_3 < 10.0)
@@ -61347,7 +61354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_11_130"
-      elif (last_rsi_14 > 66.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 66.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_11_131"
       elif (
         (last_rsi_3 < 16.0)
@@ -61410,9 +61417,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_6"
       elif (
-        (last_rsi_14 > 50.0)
+        (last_rsi_14_gt_50)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_12_7"
@@ -61434,7 +61441,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_9"
       elif (
         (last_willr_14 < -99.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -61450,7 +61457,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_11"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
@@ -61489,13 +61496,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_19"
       elif (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_12_20"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 > 50.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
         return True, f"exit_{mode_name}_d_12_21"
       elif (
         (last_rsi_3 < 1.0)
         and (last_willr_14 < -99.0)
         and (last_change_pct_4h > 5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
@@ -61505,7 +61512,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_rsi_14 < 22.0)
         and (last_willr_14 < -99.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_24"
@@ -61521,17 +61528,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_4h < 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_27"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 50.0) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_12_28"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 80.0)
         and (last_rsi_3_4h > 80.0)
         and (last_stochrsi_k_1h < 70.0)
@@ -61541,7 +61548,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_30"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
         and (last_stochrsi_k_1h < 75.0)
@@ -61554,7 +61561,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
@@ -61566,15 +61573,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -99.0)
         and (last_roc_9_4h > 25.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_36"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_37"
       elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
@@ -61584,7 +61591,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
@@ -61592,7 +61599,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
@@ -61607,7 +61614,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_42"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 60.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -61616,7 +61623,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 15.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -61636,9 +61643,9 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 62.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_48"
       elif (
@@ -61651,7 +61658,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_49"
       elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_12_50"
-      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
         (last_rsi_3 < 14.0)
@@ -61663,17 +61670,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_52"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_53"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
@@ -61683,13 +61690,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -92.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_55"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 50.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_14_gt_50)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
@@ -61704,10 +61711,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_58"
       elif (
@@ -61722,7 +61729,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 66.0)
         and (last_rsi_14_4h < 35.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_12_60"
@@ -61731,7 +61738,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
         and (last_change_pct_1d > 5.0)
@@ -61743,14 +61750,14 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_63"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_rsi_3_1h > 70.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_1h_gt_70)
+        and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_64"
       elif (last_rsi_3 < 26.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_65"
-      elif (last_rsi_3 < 12.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_12_66"
       elif (
         (last_rsi_3 < 50.0)
@@ -61768,7 +61775,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
-        (last_rsi_3 < 1.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h < 50.0) and (last_change_pct_4h > 5.0)
+        (last_rsi_3 < 1.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_12_69"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 66.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
@@ -61795,7 +61802,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
@@ -61805,24 +61812,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
         (last_rsi_3 < 8.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_78"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 70.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 2.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
         and (last_stochrsi_k_4h < 75.0)
       ):
@@ -61838,7 +61845,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -96.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
       ):
@@ -61847,18 +61854,18 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_83"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_12_84"
       elif (
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 70.0)
+        and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_85"
       elif (
@@ -61866,7 +61873,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_86"
       elif (
@@ -61874,14 +61881,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 62.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_87"
       elif (
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -86.0)
         and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_12_88"
@@ -61896,7 +61903,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 2.0)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -61915,7 +61922,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 60.0)
         and (last_stochrsi_k_1h < 75.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_92"
@@ -61953,7 +61960,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 60.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_96"
       elif (
@@ -61970,7 +61977,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_98"
       elif (
@@ -62004,7 +62011,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_102"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 50.0)
+        and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_14_4h < 30.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
@@ -62031,7 +62038,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
         and (last_roc_9_4h < -40.0)
       ):
@@ -62054,7 +62061,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_109"
-      elif (last_rsi_3 < 22.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h < 50.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 22.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
         (last_rsi_3 < 44.0)
@@ -62080,7 +62087,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_willr_14 < -99.0)
         and (last_rsi_3_1d > 70.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
@@ -62089,7 +62096,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 70.0)
+        and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 70.0)
       ):
         return True, f"exit_{mode_name}_d_12_114"
@@ -62097,8 +62104,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_15m > 70.0)
-        and (last_stochrsi_k_1h < 50.0)
-        and (last_stochrsi_k_4h < 50.0)
+        and (last_stochrsi_k_1h_lt_50)
+        and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_115"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
@@ -62119,7 +62126,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_120"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_12_121"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_1h < 50.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_12_122"
       elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_12_123"
@@ -62138,11 +62145,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_12_125"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_12_126"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h > 70.0) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_12_127"
-      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 70.0) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
       elif (
         (last_rsi_3 < 8.0)
@@ -62157,7 +62164,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_12_130"
-      elif (last_rsi_14 > 68.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 70.0) and (last_stochrsi_k_4h < 50.0):
+      elif (last_rsi_14 > 68.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_12_131"
       elif (
         (last_rsi_3 < 14.0)


### PR DESCRIPTION
## Summary
- Adds named threshold results for the five most repeated short_exit_dec scalar comparisons.
- Keeps the branch independent on latest upstream main.

## Safety
- Only existing scalar comparisons against last_candle-derived values are reused inside short_exit_dec.
- No thresholds, condition order, return labels, candle selection, indicators, order classification, or profit arithmetic are changed.
- This touches the active short_exit_dec runtime path, so the diff was reviewed specifically for guarded isinstance checks and no guarded comparison was hoisted.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required for this plumbing patch because the same last_candle scalar threshold comparisons are reused under new names; trading conditions, thresholds, return paths, and formulas are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `guarded isinstance comparison diff scan`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
