### PR TITLE
Reuse X7 entry AROON threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12707,6 +12707,11 @@ class NostalgiaForInfinityX7(IStrategy):
     # if BTC/ETH stake
     is_btc_stake = config["stake_currency"] in self.btc_stakes
     allowed_empty_candles_288 = 144 if is_btc_stake else 60
+    aroonu_14_1d_lt_100 = aroonu_14_1d < 100.0
+    aroonu_14_1h_lt_70 = aroonu_14_1h < 70.0
+    aroonu_14_4h_lt_100 = aroonu_14_4h < 100.0
+    aroonu_14_1h_lt_80 = aroonu_14_1h < 80.0
+    aroonu_14_4h_lt_80 = aroonu_14_4h < 80.0
 
     ###############################################################################################
 
@@ -12745,7 +12750,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 5h high
             & ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (rsi_14_4h < 60.0))
             # 5m & 15m down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 10.0) | aroonu_14_4h_lt_100)
             # 5m & 1h down move
             & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0))
             # 5m & 1h down move, 15m still not low enough
@@ -12765,7 +12770,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h downtrend, 1h high
-            & ((rsi_3_15m > 1.0) | (cmf_20_1h > -0.1) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 1.0) | (cmf_20_1h > -0.1) | aroonu_14_1h_lt_70)
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 1h still high
@@ -12779,15 +12784,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
             # 15m & 4h down move, 4h high
@@ -12869,9 +12874,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
             # 15m down move & downtrend, 4h high
-            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.3) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.3) | aroonu_14_4h_lt_100)
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_80)
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d downtrend
@@ -12889,7 +12894,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((rsi_3_15m > 10.0) | (roc_9_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (rsi_14_15m < 50.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m & 1h high
@@ -12899,11 +12904,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 40.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 15m down move, 1d overbought
             & ((rsi_3_15m > 30.0) | (roc_9_1d < 80.0))
             # 15m & 4h down move, 15m high
@@ -12915,7 +12920,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_1d_lt_100)
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d overbought
@@ -12979,11 +12984,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_4h < 90.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15n downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_15m > -20.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (roc_9_15m > -20.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -12999,15 +13004,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h > 40.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -15.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 20.0))
             # 1h down move, 1h still high, 4h high
@@ -13037,7 +13042,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 45.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h high, 1d overbought
@@ -13049,7 +13054,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h still high, 4h high
             & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
             # 1d down move, 1d high
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
             # 1d down move, 4h still high, 1d overbought
@@ -13071,11 +13076,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought, 1d downtrend
             & ((aroonu_14_1h < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
-            & ((aroonu_14_4h < 80.0) | (roc_9_1h > -15.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
-            & ((aroonu_14_4h < 80.0) | (roc_9_1d > -40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1d > -40.0))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
@@ -13089,7 +13094,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -40.0))
             # 5m down move, 15m still not low enough, 1h high
-            & ((roc_2 > -10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
+            & ((roc_2 > -10.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80)
             # 5m down move, 15m still high
             & ((roc_2 > -10.0) | (aroonu_14_15m < 50.0))
             # 5m down move, 15m & 1h down move, 15m still high
@@ -13097,7 +13102,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h down move, 15m downtrend, 1h high
             & ((roc_9 > -15.0) | (rsi_3_4h > 45.0) | (cmf_20_15m > -0.3) | (aroonu_14_1h < 60.0))
             # 1h downtrend, 4h high & overbought
-            & ((roc_9_1h > -25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 80.0))
+            & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
             & ((roc_9_1h < 20.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
             # 1d P&D, 1d downtrend
@@ -13105,7 +13110,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green with top wick, 1h down move
             & ((change_pct_1d < 20.0) | (top_wick_pct_1d < 15.0) | rsi_3_1h_gt_20)
             # 1d green with top wick, 4h high
-            & ((change_pct_1d < 25.0) | (top_wick_pct_1d < 25.0) | (aroonu_14_4h < 80.0))
+            & ((change_pct_1d < 25.0) | (top_wick_pct_1d < 25.0) | aroonu_14_4h_lt_80)
             # 1d green, 1h down move, 1d downtrend
             & ((change_pct_1d < 40.0) | (rsi_3_1h > 25.0) | (cmf_20_1d > -0.2))
             # 1d green with top wick, 4h overbought
@@ -13117,7 +13122,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 24 hours,  1h still high
             & ((close > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 4 days, 1h high
-            & ((close > (high_max_24_4h * 0.20)) | (aroonu_14_1h < 70.0))
+            & ((close > (high_max_24_4h * 0.20)) | aroonu_14_1h_lt_70)
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -13140,11 +13145,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 35.0) | aroonu_14_1d_lt_100)
             # 5m & 4h down move, 15m still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 5m & 4h down move, 1d downtrend
@@ -13162,11 +13167,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high
-            & ((rsi_3 > 3.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3 > 3.0) | aroonu_14_1h_lt_80)
             # 5m down move, 4h high, 1d overbought
-            & ((rsi_3 > 3.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3 > 3.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
             # 5m down move, 4h high & overbought
-            & ((rsi_3 > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 5m down move, 4h & 1d overbought
             & ((rsi_3 > 3.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
             # 5m down move, 1d downtrend
@@ -13180,7 +13185,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 20.0))
             # 5m down move, 4h high, 1h overbought
-            & ((rsi_3 > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
+            & ((rsi_3 > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 1.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h down move
@@ -13206,7 +13211,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
@@ -13220,7 +13225,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -13244,7 +13249,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h still high
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h high, 1d overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
             # 15m down move, 4h still high, 15m downtrend
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
             # 15m down move, 4h high, 1d overbought
@@ -13266,7 +13271,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 15m still not low enough
@@ -13336,7 +13341,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
@@ -13360,11 +13365,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | aroonu_14_1h_lt_80)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 15m down move, 15m still not low enough, 4h high
@@ -13380,9 +13385,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 4h high
@@ -13400,7 +13405,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_70)
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h still high, 4h overbought
@@ -13408,13 +13413,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
@@ -13430,17 +13435,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
@@ -13456,13 +13461,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
@@ -13470,15 +13475,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 80.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 40.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 40.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 1.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -10.0))
             # 1h down move, 15m downtrend, 1h still high
@@ -13584,13 +13589,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h down move, 1h high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
             # 1h down move, 1h high, 1h still not low enough
             & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
@@ -13610,13 +13615,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
             # 1h down move, 4h & 1d downtrend
@@ -13626,29 +13631,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1d downtrend
@@ -13660,7 +13665,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 4h & 1d down move, 1d still high
@@ -13718,9 +13723,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 35.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 40.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d downtrend
@@ -13728,7 +13733,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
@@ -13740,7 +13745,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h overbought
@@ -13750,7 +13755,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h overbought, 1d downtrend
@@ -13758,7 +13763,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 25.0))
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h high & overbought
@@ -13768,25 +13773,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | roc_9_1d_lt_50)
+            & (aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0) | roc_9_1d_lt_50)
             # 1h & 4h high, 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d > -40.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4high, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -20.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d < 80.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 1h high, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 40.0))
             # 4h still high, 5m downtrend
@@ -13794,9 +13799,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high & overbought
             & (aroonu_14_4h_lt_70 | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1d high, 1d downtrend
             & ((aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
             # 1d high, 1h & 4h downtrend
@@ -13804,7 +13809,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # 1d high, 1h & 4h down move
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 15m high, 1d overbought
             & ((stochrsi_k_15m < 70.0) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
@@ -13824,7 +13829,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
             & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
           )
@@ -13859,9 +13864,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h high
             & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 5m down move, 15m & 1d high
-            & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100)
             # 5m down move, 1h & 1d high
-            & ((rsi_3 > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3 > 15.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0))
             # 15m & 1h dowbn move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 1h high
@@ -13897,7 +13902,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 15m & 1d down move, 15m high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 4h downtrend. 15m high
@@ -13911,11 +13916,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_1h_lt_70)
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 1d overbought
@@ -13931,9 +13936,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | aroonu_14_1d_lt_100)
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 15m high
@@ -13973,7 +13978,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h downtrend
@@ -13997,7 +14002,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 100.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 25.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 75.0))
             # 15m & 1d down move, 1d high
@@ -14009,23 +14014,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70)
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h high, 1d high
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m > 25.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 1h high, 4h high
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 25.0) | (roc_9_4h < 50.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 40.0))
             # 15m & 4h down move, 4h high
@@ -14053,7 +14058,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 100.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 200.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
@@ -14089,13 +14094,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high, 1d downtrend
@@ -14109,7 +14114,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 30.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h & 1h overbought
@@ -14117,7 +14122,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 35.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 15m still high, 4h  high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_80)
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 15m still high, 4h high
@@ -14125,15 +14130,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 80.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0))
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h > 35.0) | (cmf_20_1h > -0.30) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 1h high
@@ -14151,11 +14156,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -60.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.20))
             # 1h down move, 4h & 1d overbought
@@ -14165,11 +14170,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
@@ -14177,17 +14182,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 70.0) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
@@ -14275,7 +14280,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 4h high, 1d downtrend
@@ -14287,7 +14292,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 1d downtrend, 1d overbought
@@ -14305,11 +14310,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
@@ -14319,9 +14324,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h & 4h high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_80)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h > 40.0) | (stochrsi_k_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high, 1d overbought
@@ -14337,7 +14342,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 30.0))
             # 4h down move, 1d high, 1d downtrend
@@ -14381,7 +14386,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 65.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 15m still high, 4h high
@@ -14405,7 +14410,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m high, 4h downtrend
             & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 1d down move, 1h & 1d high
-            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0))
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 1d high & overbought
@@ -14413,11 +14418,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 20.0))
             # 1d down move, 1h & 1d high
-            & ((rsi_3_1d > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1d > 35.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
@@ -14435,7 +14440,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 4h downtrend
             & ((aroonu_14_15m < 60.0) | (roc_9_4h > -30.0))
             # 15m & 1h & 4h high
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 15m & 4h & 1d high
             & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
             # 15m & 4h high, 4h overbought
@@ -14449,17 +14454,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 1h high, 1d high & overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 1h high, 4h downtrend
             & ((aroonu_14_1h < 90.0) | (roc_9_4h > -20.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
             # 4h & 1d high, 1d downtrend
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1d high, 1h & 4h downtrend
@@ -14469,7 +14474,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h > -30.0) | (roc_9_1d < 70.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 15m & 1h high, 1d overbought
             & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 15m & 1d high
@@ -14489,13 +14494,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, 15m high
             & ((change_pct_1d > -20.0) | (change_pct_1d.shift(288) < 20.0) | (aroonu_14_15m < 70.0))
             # 1d red with top wick, 4h high
-            & ((change_pct_1d > -20.0) | (top_wick_pct_1d < 20.0) | (aroonu_14_4h < 80.0))
+            & ((change_pct_1d > -20.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d red, previous 1d top wick, 15m high
             & ((change_pct_1d > -10.0) | (top_wick_pct_1d.shift(288) < 40.0) | (aroonu_14_15m < 70.0))
             # 1d green with top wick, 4h overbought
             & ((change_pct_1d < 15.0) | (top_wick_pct_1d < 15.0) | (roc_9_4h < 20.0))
             # 1d green, 15m down move, 1h high
-            & ((change_pct_1d < 50.0) | (rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0))
+            & ((change_pct_1d < 50.0) | (rsi_3_15m > 25.0) | aroonu_14_1h_lt_70)
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
             # 1d top wick, 4h down move, 1d overbought
@@ -14532,9 +14537,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_1d < 80.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | aroonu_14_1h_lt_70)
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1d downtrend
@@ -14548,7 +14553,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m down move, 4h high, 1h overbought
-            & ((rsi_3 > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
+            & ((rsi_3 > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d still high
@@ -14562,9 +14567,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 15m stil high
@@ -14578,11 +14583,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high
@@ -14598,11 +14603,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m & 4h down move, 4h high
@@ -14620,7 +14625,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 3.0) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 80.0))
             # 1h down move, 15m still high
             & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 50.0))
             # 1h down move, 1h still high, 4h overbought
@@ -14678,15 +14683,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
             # 1h down move, 1h high
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h & 4h down move, 1d overbought
@@ -14704,7 +14709,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
@@ -14714,7 +14719,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
@@ -14764,13 +14769,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 80.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 80.0))
             # 1h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_1d < 70.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1d < 70.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0) | (roc_9_1h < 30.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
             # 4h still high, 5m downtrend
@@ -14778,11 +14783,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h high, 1h & 1d overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h high
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
             # 1d high, 1h & 1d overbought
@@ -14796,7 +14801,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
           )
 
           # Logic
@@ -14815,7 +14820,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
             # 5m & 4h down move, 15m still high
@@ -14829,7 +14834,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
@@ -14843,7 +14848,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 85.0))
             # 15m down move, 15m still high, 1d high
@@ -14851,13 +14856,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h downtrend
             & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m high, 4h overbought
@@ -14865,7 +14870,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m still high, 1h high
@@ -14941,7 +14946,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 15m high
@@ -14955,11 +14960,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 85.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
             # 1h down move, 15m still high, 1h high
@@ -14973,21 +14978,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h > -20.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
@@ -14999,7 +15004,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
@@ -15007,7 +15012,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
@@ -15019,7 +15024,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 40.0))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1h still not low enough
@@ -15063,15 +15068,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 40.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1d down move, 1d high, 1d downtrend
@@ -15089,33 +15094,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 85.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
             # 4h high, 1h & 1d overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1d high, 1h & 4h down move
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 1h downtrend, 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 15m high, 4h & 1d downtrend
             & ((stochrsi_k_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 1h high, 4h & 1d overbought
@@ -15135,7 +15140,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
             & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
           )
@@ -15184,7 +15189,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 4h high
             & ((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 60.0))
             # 5m & 1h down move, 1h high
-            & ((rsi_3 > 5.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h > 60.0) | aroonu_14_1h_lt_80)
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3 > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still high
@@ -15194,13 +15199,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d overbought
             & ((rsi_3 > 5.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 60.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
             # 5m down move, 15m still not low enough, 4h high
             & ((rsi_3 > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
             # 5m down move, 1h & 1d high
-            & ((rsi_3 > 5.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 5.0) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
             # 5m down move, 4h high & overbought
-            & ((rsi_3 > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 25.0))
+            & ((rsi_3 > 5.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
             # 5m down move, 1h high
             & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0))
             # 5m & 1d down move, 1d still high
@@ -15248,7 +15253,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 55.0) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
@@ -15258,7 +15263,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 1d high
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
             # 15m down move, 15m & 1h still not low enough
             & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h still high
@@ -15288,7 +15293,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 4h still not low enough
@@ -15362,7 +15367,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 1d high
@@ -15376,7 +15381,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 40.0))
             # 15m & 4h down move, 1d overbought
@@ -15398,21 +15403,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 85.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 25.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 4h downtrend
@@ -15428,9 +15433,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 35.0) | aroonu_14_1d_lt_100)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 90.0))
             # 15m & 1h down move, 4h high
@@ -15442,29 +15447,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | aroonu_14_1h_lt_70)
             # 15m & 1d down move, 15m still high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | aroonu_14_1h_lt_70)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1d high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 15m down move, 1d high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
@@ -15482,13 +15487,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h < 90.0))
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
@@ -15496,15 +15501,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high & overbought
@@ -15512,7 +15517,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 15m high
@@ -15522,35 +15527,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 35.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 65.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 65.0) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 1m still high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 70.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 40.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 40.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0))
             # 1h & 4h down move, 1d high
@@ -15594,7 +15599,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h downtrend, 1d overbought
@@ -15622,13 +15627,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h & 1d down move
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h > -30.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d downtrend
@@ -15654,9 +15659,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -15.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high, 4h overbought
@@ -15682,13 +15687,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 55.0) | (rsi_3_4h > 55.0) | (stochrsi_k_1h < 70.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | aroonu_14_1h_lt_70)
             # 1h down move, 4 high, 1h overbought
-            & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
             # 1h down move, 1d high, 1h overbought
             & ((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
@@ -15696,7 +15701,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 65.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h > 65.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 65.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -15750,19 +15755,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 35.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
@@ -15772,7 +15777,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
@@ -15784,65 +15789,65 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 4h down move, 4h still high, 4h overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 75.0) | (roc_9_1d < 30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 65.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
             # 1d down move, 1d still not low enough, 1d downtrend
             & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 20.0) | (roc_9_1d > -20.0))
             # 1d down move, 15m still high
             & ((rsi_3_1d > 5.0) | (stochrsi_k_15m < 40.0))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70)
             # 1d down move, 4h downtrend, 4h high
             & ((rsi_3_1d > 20.0) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1d > 60.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
             # 4h downtrend, 4h high & over
-            & ((cmf_20_4h > -0.10) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
+            & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
             # 15m still high, 4h high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 15m still high, 4h high, 1h overbought
-            & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & ((aroonu_14_15m < 40.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 15.0) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4h & 1d high
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d < 30.0))
             # 1h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
             # 1h & 1d high, 4h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h &1d overbought
             & ((aroonu_14_1h < 85.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 15.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 4h high, 4h overbought, 1d downtrend
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
             # 1d high, 4h & 1d overbought
@@ -15856,9 +15861,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
             # 15m still not low enough, 4h high, 1d overbought
-            & ((stochrsi_k_15m < 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 30.0))
+            & ((stochrsi_k_15m < 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 30.0))
             # 15m still high, 4h high & overbought
             & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h high, 1d overbought
@@ -15890,7 +15895,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
             & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
           )
@@ -15913,13 +15918,13 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m down move, 4h high, 1h overbought
-            ((rsi_3 > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
+            ((rsi_3 > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 80.0))
             # 15m & 1h down move, 4h overbought
@@ -15929,7 +15934,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
@@ -15941,9 +15946,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 40.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
@@ -15953,7 +15958,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0))
             # 15m down move, 4h & 1d overbought
@@ -15965,11 +15970,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -25.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 4h overbought
@@ -15983,39 +15988,39 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought, 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1h still high
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h & 4h high
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0) | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h still high, 1d overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 25.0))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_1d > -25.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
@@ -16023,15 +16028,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h > 50.0) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_1h < 10.0) | (roc_9_1d < 250.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 65.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 65.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 30.0))
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 65.0) | (roc_9_1h < 40.0))
             # 4h down move, 1h high & overbought
@@ -16039,25 +16044,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 5.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 50.0))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70)
             # 1d down move, 4h high, 1h overbought
-            & ((rsi_3_1d > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 25.0))
+            & ((rsi_3_1d > 20.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 25.0))
             # 1d down move, 4h high, 4h overbought
-            & ((rsi_3_1d > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1d > 20.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
             # 1d down move, 1h & 4h overbought
             & ((rsi_3_1d > 30.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1d > 35.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 75.0) | (roc_9_1d < 20.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 65.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 65.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m not low enough, 1h high, 1d overbought
@@ -16065,31 +16070,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 1h & 4h overbought
             & ((aroonu_14_1h < 50.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
             # 1h & 1d high, 4h overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 30.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 80.0) | (stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0))
+            & (aroonu_14_1h_lt_80 | (stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0))
             # 1h high & overbought
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 80.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 80.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h high, 4h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_80 | (roc_9_4h < 10.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 15m downtrend
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -40.0))
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 10.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_4h < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (cmf_20_4h > -0.30))
+            & ((aroonu_14_4h < 85.0) | aroonu_14_1d_lt_100 | (cmf_20_4h > -0.30))
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 20.0))
             # 4h & 1d high, 4h overbought
@@ -16097,15 +16102,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 85.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h high, 1d high & overbought
-            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
             # 1d high, 1h & 4h overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h < 60.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1h high, 1h overbought
@@ -16173,7 +16178,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 75.0))
             # 15m & 4h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m still high, 1d high
@@ -16183,9 +16188,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 1d high
             & (rsi_3_15m_gt_3 | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 4h & 1d high
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 4h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
@@ -16201,7 +16206,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still high
@@ -16213,7 +16218,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -70.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h still high, 1d downtrend
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -40.0))
             # 5m down move, 4h high, 1d downtrend
@@ -16243,7 +16248,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_100)
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m still high, 1d overbought
@@ -16251,23 +16256,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 1h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_15m > -10.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_1h_lt_80 | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -25.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.00) | (roc_9_15m > -30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
@@ -16283,11 +16288,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_100)
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 15m still high, 1h high
@@ -16295,11 +16300,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -30.0))
             # 15m down move, 4h high & overbought
@@ -16313,11 +16318,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | aroonu_14_1d_lt_100)
             # 15m &4h down move, 4h still high
             & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
             # 15m & 4h down move, 1d overbought
@@ -16325,13 +16330,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_4h > -15.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 60.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
             # 15m & 1d down move, 1h high
@@ -16347,7 +16352,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1d still high
@@ -16361,7 +16366,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1h downtrend
             & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (roc_9_1h > -20.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 3.0) | aroonu_14_1h_lt_70)
             # 1h down move, 4h high
             & ((rsi_3_1h > 3.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high
@@ -16389,9 +16394,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h & 1d downtrend
@@ -16493,15 +16498,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 1h & 1d down move, 1h high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_70)
             # 1h & 1d down move, 4h overbought
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h still high, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
@@ -16517,11 +16522,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high
@@ -16545,33 +16550,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h > 30.0) | (cmf_20_1h > -0.25) | (stochrsi_k_1h < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 30.0) | (cmf_20_4h > -0.50) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 30.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -60.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -40.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h downtrend, 4h overbought
@@ -16579,9 +16584,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 70.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15m downtrend
@@ -16641,9 +16646,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_80)
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_1h > -40.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still high, 1d overbought
@@ -16661,7 +16666,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d overbought
@@ -16675,7 +16680,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 1d downtrend
             & ((rsi_3_1d > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -80.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -30.0))
             # 1d down move, 1h still high, 4h downtrend
@@ -16683,45 +16688,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m downtrend, 4h & 1d high
-            & ((cmf_20_15m > -0.30) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((cmf_20_15m > -0.30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h high, 1h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h & 4h high, 1h downtrend
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (cmf_20_1h > -0.30))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (cmf_20_1h > -0.30))
             # 1h high, 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
             # 1h high, 1d high & overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 1h high, 1h & 1d overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
             # 1h high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
             # 1h high, 1h & 1d overbought
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d > -40.0))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h < 85.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 4h high, 15m downtrend, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_15m > -30.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_15m > -30.0) | (roc_9_4h < 30.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 30.0) | (roc_9_4h < 70.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_4h < 70.0))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1h < 50.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h < 50.0))
             # 1d still high, 4h & 1d downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
@@ -16809,7 +16814,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1d high
@@ -16839,17 +16844,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -10.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 1h & 4h down move
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0))
             # 1h & 4h down move, 1d still high
@@ -16875,7 +16880,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1d overbought
@@ -16979,9 +16984,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 15m high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d overbought
@@ -16991,15 +16996,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
             # 1h & 1d down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | aroonu_14_1d_lt_100)
             # 1h & 1d down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 15m high
@@ -17007,7 +17012,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_80)
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 4h downtrend, 4h high
@@ -17021,9 +17026,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d downtrend
@@ -17035,7 +17040,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 80.0))
             # 1h & 1d down move, 1d overbought
@@ -17043,9 +17048,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
             # 1h down move, 4h & 1d overbought
@@ -17059,9 +17064,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high & overbought
@@ -17075,9 +17080,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d overbought
@@ -17155,7 +17160,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 4h downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h high
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 100.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d < 70.0))
             # 4h down move, 1d high, 4h downtrend
@@ -17181,7 +17186,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d downtrend
@@ -17191,27 +17196,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 60.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 4h down move, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | (roc_9_1d > -20.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -17221,7 +17226,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
             # 4h down move, 4h high & overbought
@@ -17243,23 +17248,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h downtrend, 4h high
-            & ((cmf_20_1h > -0.40) | (cmf_20_4h > -0.40) | (aroonu_14_4h < 80.0))
+            & ((cmf_20_1h > -0.40) | (cmf_20_4h > -0.40) | aroonu_14_4h_lt_80)
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 15m & 1d high, 4h overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d downtrend
             & ((aroonu_14_15m < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_1d > -20.0))
             # 1h still high, 1h & 4h downtrend
             & ((aroonu_14_1h < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 4h high, 4h & 1d downtrend
             & ((aroonu_14_4h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 1d high, 4h & 1d overbought
@@ -17267,11 +17272,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 15m still high, 1h & 4h downtrend
             & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 4h high, 1h & 4h overbought
@@ -17312,9 +17317,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d still not low enough
             & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 30.0))
             # 5m down move, 1h & 4h high
-            & ((rsi_3 > 3.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 > 3.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 5m down move, 4h high & overbought
-            & ((rsi_3 > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 5m down move, 1d high & overbought
@@ -17374,7 +17379,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
             # 15m down move, 1d high & overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 1d downtrend
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high & overbought
@@ -17396,7 +17401,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h downtrend
@@ -17412,13 +17417,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h still high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 50.0))
             # 15m down move, 1d still high, 1d downtrend
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
             # 15m down move, 1d downtrend
@@ -17438,7 +17443,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 1h down move, 1d overbought
@@ -17476,17 +17481,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_80)
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -10.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -40.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 4h still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d overbought
@@ -17498,21 +17503,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 15m down move. 15m still high, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 40.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -30.0))
             # 15m down move, 4h high & overbought
@@ -17534,17 +17539,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (roc_9_1h > -30.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m > 30.0) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
@@ -17564,7 +17569,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 4h high, 1d downtrend
@@ -17622,9 +17627,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d high
@@ -17632,17 +17637,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 20.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -40.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -70.0))
             # 1h down move, 4h high, 1d downtrend
@@ -17650,17 +17655,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 25.0) | (roc_9_4h > -30.0) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1h & 4h down move, 1d high
@@ -17668,17 +17673,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 40.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 4h overbought
@@ -17686,11 +17691,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
@@ -17742,7 +17747,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 4h downtrend, 1h & 4h high
-            & ((cmf_20_4h > -0.30) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((cmf_20_4h > -0.30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m still high, 1h & 4h overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 15m & 1d high, 1d overbought
@@ -17750,37 +17755,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h & 4h high, 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d < 20.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0) | (roc_9_1d < 200.0))
             # 1h high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
             # 1h high, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_1d > -60.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1d > -60.0))
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h < 100.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend, 4h overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 100.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h overbought
@@ -17829,7 +17834,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (aroonu_14_4h < 40.0))
             # 15m & 4h down move, 15m downtrend
@@ -17843,7 +17848,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 1d overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1h < 40.0) | (roc_9_1d < 70.0))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 100.0) | (roc_9_4h < 100.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
             # 15m down move, 1h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 70.0))
             # 15m down move, 4h high, 15m downtrend
@@ -17991,9 +17996,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down ove, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 80.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_80 | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
@@ -18003,11 +18008,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
             # 4h down move, 1d still high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0))
             # 4h down move, 1d overbought
@@ -18037,9 +18042,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 4h down move, 1h high & overbought
             & ((rsi_3_4h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18057,25 +18062,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 1h & 4h downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h downtrend
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h > -40.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0))
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h & 1d high, 1h downtrend
-            & ((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1h > -20.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h > -20.0))
             # 4h & 1d high, 1h downtrend
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1h > -30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h > -30.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
             # 4h high, 1h downtrend
-            & ((aroonu_14_4h < 80.0) | (roc_9_1h > -40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
             # 4h high & overbought
-            & ((aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 4h high, 1d downtrend
-            & ((aroonu_14_4h < 80.0) | (roc_9_1d > -30.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1d > -30.0))
             # 1d still high, 1d downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 1d high, 15m downtrend
@@ -18089,7 +18094,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high & overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h still high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
@@ -18152,7 +18157,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 4h still not low enough
@@ -18162,27 +18167,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
           # 15m down move, 1h high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
           # 15m down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
           # 15m down move, 4h high, 1h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
           # 15m & 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
           # 15m down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
           # 1h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h > 3.0) | (aroonu_14_4h < 30.0))
           # 1h & 4h down move, 1h still not low enough
@@ -18246,7 +18251,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
           # 1h & 1d down move, 1h still high
@@ -18254,9 +18259,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_14_4h < 80.0))
           # 14 down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80)
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0))
           # 1h down move, 4h & 1d high
@@ -18264,11 +18269,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | roc_9_1d_lt_50)
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 4h down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | aroonu_14_1d_lt_100)
           # 4h & 1d down move, 1d still high
           long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
           # 4h downmove, 4h still high
@@ -18284,13 +18289,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d high
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
           # 4h down move, 1d high
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1d < 90.0))
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 25.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
           # 4h down move, 1h high
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 70.0))
           # 4h down move, 4h still high
@@ -18308,15 +18313,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h high & overbought
           long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
           # 15m still high, 1h & 4h high
-          long_entry_logic.append((rsi_14_15m < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
           # 1h & 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append(aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
           # 4h high, 1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 80.0))
           # 4h high, 1h & 1d downtrend
           long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h high, 1h & 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
           # 1d high, 4h & 1d downtrend
@@ -18435,7 +18440,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 15.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
           # 1h down move, 1h still not low enough, 1d high
           long_entry_logic.append((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0) | (aroonu_14_1d < 90.0))
           # 1h & 4h down move
@@ -18519,7 +18524,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 1d high
           long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
           # 1h down move, 4h & 1d high
@@ -18535,27 +18540,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | aroonu_14_4h_lt_80)
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d > -30.0))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | aroonu_14_4h_lt_80)
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
           # 1h down move, 4h high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.30))
           # 1h down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 1h down move, 1h overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (roc_9_1h < 40.0))
           # 4h & 1d down move, 1d high
@@ -18583,7 +18588,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
           # 4h down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_4h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
           # 4h down move, 4h overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 40.0))
           # 1d down move, 4h & 1d downtrend
@@ -18593,11 +18598,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1d high, 1d downtrend
           long_entry_logic.append((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
           # 4h high, 1h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_1h < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_1h < 40.0))
           # 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_4h < 40.0))
           # 4h high, 1h overbought
           long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h < 40.0))
           # 4h high, 4h overbought
@@ -18658,7 +18663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             ((rsi_3 > 3.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
             # 5m down move, 1d high & overbought
@@ -18688,7 +18693,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h still high
@@ -18698,7 +18703,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0))
             # 15m down move, 4h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 80.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_80)
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
@@ -18716,7 +18721,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1d high
@@ -18740,7 +18745,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
@@ -18754,11 +18759,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | aroonu_14_1h_lt_80)
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 1d high, 4h overbought
@@ -18772,7 +18777,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 1h high
@@ -18788,7 +18793,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 50.0) | aroonu_14_4h_lt_100)
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 1h & 4h high
@@ -18814,7 +18819,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 15m downtrend
@@ -18848,13 +18853,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_80)
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 1d downtrend
@@ -18862,7 +18867,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h > -40.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
@@ -18870,13 +18875,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 25.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
@@ -18922,7 +18927,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 1d overbought
@@ -18930,13 +18935,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
             # 1d down move, 1h still high, 1d downtrend
             & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
             # 1d down move, 1h high & overbought
@@ -18946,21 +18951,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 1h high, 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
             # 1h & 4h high, 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -80.0))
+            & ((aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100 | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
@@ -19077,9 +19082,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 15m still not low enough, 1d overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 30.0) | (roc_9_1d < 80.0))
             # 15m & 4h down move, 15m stil high
@@ -19087,13 +19092,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
@@ -19167,11 +19172,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h high
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high
@@ -19191,7 +19196,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
             # 1h down move, 4h high & overbought
@@ -19213,7 +19218,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
@@ -19223,15 +19228,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 50.0) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -19243,7 +19248,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 5.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -20.0))
             # 4h down move, 4h high
             & ((rsi_3_4h > 5.0) | (aroonu_14_4h < 60.0))
             # 4h & 1d down move, 1d still not low enough
@@ -19271,7 +19276,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_80)
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -19281,17 +19286,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 40.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
             # 4h down move, 15m & 4h still high
             & ((rsi_3_4h > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_100)
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -19311,11 +19316,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
@@ -19387,7 +19392,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 60.0))
             # 15m down move, 4h high, 1d overbought
@@ -19399,7 +19404,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (rsi_3_4h > 15.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1d high
@@ -19409,13 +19414,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_100)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 4h & 1d overbought
@@ -19433,7 +19438,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h overbought
             & ((rsi_3_15m > 20.0) | (roc_9_4h < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
             # 15m & 4h down move, 4h high
@@ -19443,11 +19448,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m downtrend, 4h high
-            & ((rsi_3_15m > 30.0) | (cmf_20_15m > -0.30) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 30.0) | (cmf_20_15m > -0.30) | aroonu_14_4h_lt_100)
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
@@ -19575,7 +19580,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 4h still high
             & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -19583,7 +19588,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 1d overbought
@@ -19607,13 +19612,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1d high & overbought
@@ -19621,7 +19626,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 50.0))
             # 1h down move, 1h highm 1d overbought
@@ -19631,25 +19636,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d downtrend
             & ((rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 40.0) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h overbought
@@ -19657,13 +19662,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
@@ -19711,7 +19716,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d high
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 15m still high, 4h high
@@ -19721,11 +19726,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h dowqn move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
@@ -19747,9 +19752,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1h downtrend, 1h high
-            & ((cmf_20_1h > -0.20) | (aroonu_14_1h < 80.0))
+            & ((cmf_20_1h > -0.20) | aroonu_14_1h_lt_80)
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 60.0))
             # 1d downtrend, 1d high & overbought
@@ -19769,27 +19774,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 1h high, 4h high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
             # 1h & 1d high, 1h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
             # 1h high, 1d downtrend
-            & ((aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
             # 4h still high, 1d high, 4h downtrend
-            & ((aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100 | (roc_9_4h > -30.0))
             # 4h high, 1h & 1d downtrend
             & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1d high, 1h & 4h downtrend
@@ -19797,9 +19802,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d < 100.0))
             # 1d high, 1h & 4h down move
-            & ((aroonu_14_1d < 100.0) | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 4h still high, 4h & 1d downtrend
@@ -19819,13 +19824,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought
             & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
             # 1d green with top wick, 4h high
-            & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | (aroonu_14_4h < 80.0))
+            & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d top wick, 4h down move, 1d overbought
             & ((top_wick_pct_1d < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # drop in last 20 days, 4h high
             & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
             # drop in last 20 days, 1h high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
+            & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -19908,7 +19913,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
           # 15m down move, 1h high & overbought
           long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h still high
@@ -19922,7 +19927,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 15m still not low enough
@@ -19966,7 +19971,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 40.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 85.0))
           # 15m & 1h down move, 4h high
@@ -19974,7 +19979,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1d down move, 1h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 70.0))
           # 15m down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
           # 15m down move, 1h high, 1d downtrend
           long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
           # 15m down move, 1d high & overbought
@@ -19986,9 +19991,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 60.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_70)
           # 1h & 4h down move, 15m downtrend
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
           # 1h & 4h & 1d down move
@@ -20024,7 +20029,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1d high & overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
           # 1h down move, 1h still not low enough, 4h high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | aroonu_14_4h_lt_80)
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 1d high
@@ -20036,13 +20041,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
           # 1h down move, 15m high
           long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_15m < 80.0))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
           # 1h down move, 1h high & overbought
           long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
           # 1h down move, 4h high
@@ -20068,7 +20073,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h dowqn move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
           # 4h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 50.0))
           # 4h down move, 4h high, 1d downtrend
@@ -20090,7 +20095,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
           # 1h high, 4h downtrend
           long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
           # 1h high, 4h overbought
@@ -20113,7 +20118,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (aroonu_14_4h < 80.0) | (close > (high_max_6_4h * 0.85)) | (close < (low_min_24_4h * 1.25))
+            aroonu_14_4h_lt_80 | (close > (high_max_6_4h * 0.85)) | (close < (low_min_24_4h * 1.25))
           )
           # 1h down move, drop but not yet near the previous lows
           long_entry_logic.append(
@@ -20175,13 +20180,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3 > 3.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 40.0))
           # 5m down move, 1h high
-          long_entry_logic.append((rsi_3 > 3.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3 > 3.0) | aroonu_14_1h_lt_70 | (stochrsi_k_1h < 50.0))
           # 5m & 1h down move, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
           # 5m & 4h down move, 4h high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 5m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_14_15m < 40.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_14_15m < 40.0) | aroonu_14_1h_lt_80)
           # 5m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
           # 5m down move, 15m & 4h high
@@ -20241,7 +20246,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 1h high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 50.0))
           # 15m down move, 1d high & overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
           # 15m & 1h down move, 1h still high
@@ -20251,7 +20256,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 50.0))
           # 15m & 4h & 1d down move
@@ -20287,7 +20292,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
           # 15m & 1d down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 90.0))
           # 15m down move, 15m still not low enough, 4h high
@@ -20303,9 +20308,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0))
           # 15m & 1h down move, 1d high
@@ -20327,11 +20332,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 85.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 60.0))
           # 15m down move, 15m high, 4h still high
@@ -20349,7 +20354,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h < 20.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_14_15m < 50.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_14_15m < 50.0) | aroonu_14_1h_lt_80)
           # 15m down move, 15m high, 1h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 15m down move, 15m high
@@ -20383,7 +20388,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h < 80.0))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
           # 1h down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (rsi_14_4h < 75.0) | (roc_9_1d < 100.0))
           # 1h down move, 1h still high, 1d high
@@ -20409,7 +20414,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -30.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
           # 4h down move, 15m high, 4h overbought
@@ -20425,7 +20430,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 4h high & overbought
           long_entry_logic.append((aroonu_14_15m < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
           # 15m & 1h & 4h high
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
           # 15m & 1h high, 4h overbought
           long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
           # 15m & 1d high, 1d overbought
@@ -20443,21 +20448,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h still high, 4h high & overbought
           long_entry_logic.append((aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
           # 1h & 4h high, 1h overbought
-          long_entry_logic.append((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 40.0))
+          long_entry_logic.append(aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1h < 40.0))
           # 1h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
           # 1h high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 5m red, 1h still high
@@ -20511,7 +20516,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
           # 15m down move, 4h high & overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0))
           # 15m & 1h down move, 15m high
@@ -20525,7 +20530,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m & 1h still high
@@ -20533,7 +20538,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (roc_9_4h < 70.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_1h_lt_80)
           # 15m down move, 4h & 1d high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 90.0) | (stochrsi_k_1d < 90.0))
           # 15m down move, 1h & 1d high
@@ -20549,7 +20554,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
           # 15m down move, 15m & 1h high
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
           # 15m down move, 1h high, 4h overbought
@@ -20565,7 +20570,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | aroonu_14_4h_lt_80)
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h high & overbought
@@ -20581,15 +20586,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 1h high, 4h overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
           # 1h down move, 1h overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
           # 1h down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
           # 4h down move, 1h & 4h downtrend
@@ -20605,11 +20610,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_15m < 30.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h high, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
           # 4h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
           # 4h down move, 15m still high, 1h high
@@ -20617,7 +20622,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 30.0))
           # 1d down move, 1h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
           # 1d down move, 4h high
           long_entry_logic.append((rsi_3_1d > 10.0) | (stochrsi_k_4h < 80.0))
           # 1d down move, 15m still high, 1h high
@@ -20625,7 +20630,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h & 1d overbought
           long_entry_logic.append((rsi_3_1d > 45.0) | (roc_9_1h < 80.0) | (roc_9_1d < 80.0))
           # 15m still high, 1h & 4h high
-          long_entry_logic.append((rsi_14_15m < 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
           # 15m & 1h still high, 4h high
           long_entry_logic.append((rsi_14_15m < 45.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 70.0))
           # 15m still high, 4h high & overbought
@@ -20641,15 +20646,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d high, 4h downtrend
           long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h & 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append(aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
           # 1h high, 1h & 1d overbought
           long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 15m still high, 1h high
           long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_1h < 90.0))
           # 15m still high, 1d high
@@ -20733,7 +20738,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (roc_9_4h < 50.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
           # 15m & 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
           # 15m & 4h down move, 4h still not low enough
@@ -20751,7 +20756,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 20.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
           # 15m & 1h down move, 4h high
@@ -20763,7 +20768,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
           # 15m down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
           # 15m & 3h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
           # 15m & 1h down move, 1h still high
@@ -20827,13 +20832,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_80)
           # 1h & dh down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
           # 1h down move, 4h still not low enough, 1d overbought
@@ -20877,21 +20882,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
           # 4h down move, 4h high, 1h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h > -30.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1h > -30.0))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
           # 4h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1d down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 20.0))
           # 1h & 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
+          long_entry_logic.append((aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
           # 4h & 1d high,1d overbought
-          long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
+          long_entry_logic.append(aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
           # 1d red, 4h down move, 1h still high
           long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
           # pump, drop but not yet near the previous lows
@@ -20943,8 +20948,8 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(rsi_14_1d < 80.0)
           long_entry_logic.append(aroonu_14_15m < 70.0)
           long_entry_logic.append(aroonu_14_1h < 100.0)
-          long_entry_logic.append(aroonu_14_4h < 100.0)
-          long_entry_logic.append(aroonu_14_1d < 100.0)
+          long_entry_logic.append(aroonu_14_4h_lt_100)
+          long_entry_logic.append(aroonu_14_1d_lt_100)
           long_entry_logic.append(stochrsi_k_1d < 90.0)
 
           # Logic
@@ -20987,9 +20992,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h high
             & ((rsi_3 > 3.0) | (stochrsi_k_1h < 90.0))
             # 5m down move, 15m & 1d high
-            & ((rsi_3 > 5.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_15m < 60.0) | aroonu_14_1d_lt_100)
             # 5m down move, 1h & 1d high
-            & ((rsi_3 > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 10.0) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h still not low enough
@@ -21021,7 +21026,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
             # 15m down move, 1d high & overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 4h still high
@@ -21037,9 +21042,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
             # 15m down move, 15m downtrend, 1d high
-            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.40) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1d high
@@ -21053,7 +21058,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1d overbought
@@ -21131,11 +21136,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high, 1d downtrend
@@ -21217,9 +21222,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 1d downtrend
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
             # 1h down move, 15m still high, 1d high
@@ -21229,7 +21234,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | aroonu_14_1h_lt_80)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d high
@@ -21245,19 +21250,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_80)
             # 1h down move, 1h high , 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | aroonu_14_1h_lt_70)
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (rsi_14_1d < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -21341,7 +21346,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_80)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 1d high & overbought
@@ -21349,7 +21354,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -40.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 10.0))
             # 1d down move, 1d high & overbought
@@ -21365,19 +21370,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 15m high, 1h high, 1d downtrend
             & ((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100 | roc_9_1d_lt_50)
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_1h < 100.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
             # 4h & 1d overbought
@@ -21402,7 +21407,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 15m high
             & ((rsi_3 > 10.0) | (rsi_3_1d > 30.0) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h & 1d high
-            & ((rsi_3 > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3 > 10.0) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 5m down move, 15m & 1h high
             & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h down move
@@ -21428,7 +21433,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 90.0))
             # 15m down move, 1h high, 1d overbought
@@ -21450,7 +21455,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1h still high
@@ -21510,7 +21515,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
             # 15m & 4h down move, 15m high
@@ -21530,9 +21535,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 10.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 15m high
@@ -21542,13 +21547,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 15m & 4h down mve, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0))
             # 15m & 4h down move, 4h high
@@ -21616,9 +21621,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
@@ -21636,13 +21641,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
@@ -21694,7 +21699,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
             # 4h down move, 4h high
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 80.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_80)
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -21728,7 +21733,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_80)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h high, 1d downtrend
@@ -21748,7 +21753,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m & 1h high, 4h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
@@ -21756,9 +21761,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h high, 1d downtrend
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
             # 15m & 4h & 1d high
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 15m high, 1h & 4h overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 15m high, 4h overbought, 1d downtrend
@@ -21766,23 +21771,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h high
             & ((aroonu_14_15m < 90.0) | (aroonu_14_1h < 100.0))
             # 15m & 4h high
-            & ((aroonu_14_15m < 90.0) | (aroonu_14_4h < 100.0))
+            & ((aroonu_14_15m < 90.0) | aroonu_14_4h_lt_100)
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+            & ((aroonu_14_1h < 100.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
+            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 100.0) | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m < 70.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h high, 1h & 1d overbought
@@ -21857,7 +21862,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
             # 15m down move, 15m still high, 1d downtrend
@@ -21869,7 +21874,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1h high
@@ -21887,9 +21892,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1h still high, 1d downtrend
@@ -21921,19 +21926,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1h high
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 70.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_100)
             # 1h & 1d down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 1d downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 1h high
@@ -21941,7 +21946,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
             # 4h & 1d down move, 15m still not low enough
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 20.0))
             # 4h & 1d down move, 1d high
@@ -21993,13 +21998,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_80)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 40.0))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h high, 4h & 1d overbought
@@ -22046,25 +22051,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (rsi_14_4h < 20.0))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 40.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 4h high, 1d downtrend
@@ -22078,9 +22083,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h high, 1d downtrend
@@ -22088,7 +22093,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 25.0) | (roc_9_1h < 10.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 1h downtrend
@@ -22146,19 +22151,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 70.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_4h < 70.0))
             # 1h down move, 1h high, 1h still not low enough
             & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 15m high
@@ -22172,17 +22177,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80 | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_4h_lt_80 | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 15m high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 15m still not low enough
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 20.0))
             # 4h & 1d down move, 1d still high
@@ -22246,13 +22251,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1d > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h < 70.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 100.0) | (roc_9_1h < 10.0))
+            & ((aroonu_14_4h < 85.0) | aroonu_14_1d_lt_100 | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 15m high, 4h & 1d overbought
@@ -22300,7 +22305,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 30.0))
             # 15m & 1h down move, 1h high
@@ -22336,7 +22341,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 30.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 35.0) | (roc_9_4h < 30.0) | (roc_9_1d < 80.0))
             # 1h & 4h down move, 4h still high
@@ -22396,27 +22401,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
             # 1h down move, 15m still high, 1h high
-            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 80.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 60.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 85.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 30.0))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 35.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h still high, 1d overbought
@@ -22426,13 +22431,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 4h down move, 4h & 1d downtrend
@@ -22486,17 +22491,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d > 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
             & ((aroonu_14_15m < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d > -30.0))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
             # 1h high, 1d overbought
             & ((aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h < 100.0) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
           )
@@ -22532,13 +22537,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 60.0) | aroonu_14_4h_lt_80)
           # 15m & 4h down move, 15m high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 50.0))
           # 15m & 4h down move, 15m high
@@ -22595,7 +22600,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 15m high
           long_entry_logic.append((rsi_3_1h > 50.0) | (rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
           # 1h down move, 15m high, 1h still high
           long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 40.0))
           # 1h down move, 15m still high, 4h high
@@ -22603,7 +22608,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 90.0))
           # 1h down move, 1h still high, 1d high
@@ -22611,13 +22616,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h overbought
           long_entry_logic.append((rsi_3_1h > 50.0) | (roc_9_4h < 40.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 55.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 1h down move, 5m up move, 1h still high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3 < 60.0) | (stochrsi_k_1h < 50.0))
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 90.0))
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_70)
           # 1h down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 60.0))
           # 1h down move, 15m & 4h still high
@@ -22627,7 +22632,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 90.0))
           # 1h down move, 1h high, 4h still high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h & 1d high
@@ -22661,7 +22666,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h high, 4h still high
-          long_entry_logic.append((rsi_3_4h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 45.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 50.0))
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 40.0))
           # 4h down move, 15m still high, 1h high
@@ -22681,7 +22686,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 80.0) | (aroonu_14_4h < 40.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | aroonu_14_1h_lt_70)
           # 4h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 70.0))
           # 4h down move, 15m & 4h high
@@ -22691,17 +22696,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 15m still high, 1d high & overbought
-          long_entry_logic.append((aroonu_14_15m < 50.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m < 50.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
           # 15m high, 4h high
           long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_4h < 85.0))
           # 15m & 1d high, 1d overbought
           long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
           # 15m & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
           # 15m high, 4h still high
           long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h < 50.0))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append(aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
           # 4h high, 4h overbought
           long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_4h < 40.0))
           # 4h high, 1d overbought
@@ -22709,7 +22714,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
           # 1d high & overbought
-          long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
           # 15m high, 1h still high
           long_entry_logic.append((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 40.0))
           # 15m & 4h high
@@ -22763,13 +22768,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | aroonu_14_1h_lt_80)
             # 15m down move, 15m high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m & 1h down move, 15m still not low enough
@@ -22777,7 +22782,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down nove, 1h still high
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 4h high, 4h downtrend
@@ -22785,7 +22790,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m & 1h down move, 4h high
@@ -22793,7 +22798,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 150.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (rsi_14_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_1h_lt_80 | (rsi_14_4h < 80.0))
             # 1h & 4h down move, 15m stil high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still high
@@ -22869,21 +22874,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high, 1h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 70.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
             # 1d down move, 4h high
             & ((rsi_3_1d > 20.0) | (rsi_14_4h < 80.0))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 20.0))
             # 1h & 4h high
-            & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d still high, 1h & 4h downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 1h high, 1h overbought
@@ -22947,11 +22952,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m & 4h down mnove, 4h high
-            ((rsi_3 > 15.0) | (rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            ((rsi_3 > 15.0) | (rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
             # 5m & 15m & 1d down move, 1h high
             & ((rsi_3 > 15.0) | (rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 5m & 1h down move, 15m still high, 4h high
-            & ((rsi_3 > 20.0) | (rsi_3_1h > 40.0) | (rsi_14_15m < 40.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 > 20.0) | (rsi_3_1h > 40.0) | (rsi_14_15m < 40.0) | aroonu_14_4h_lt_100)
             # 5m & 1h & 15m down move, 1h still not low enough
             & ((rsi_3 > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 30.0))
             # 15m & 4h down move, 4h high
@@ -22963,13 +22968,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h & 1d down move
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
             # 15m & 1h down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 15m & 1h & 4h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 40.0))
             # 15m & 1h & 4h down move, 1h downtrend, 4h high
-            & (
-              (rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 55.0) | (cmf_20_1h > -0.10) | (aroonu_14_4h < 80.0)
-            )
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 55.0) | (cmf_20_1h > -0.10) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 4h high
@@ -22977,7 +22980,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
             # 15m & 1h down move, 1d overbought
@@ -22992,11 +22995,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 85.0))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
-              (rsi_3_15m > 15.0)
-              | (rsi_3_1h > 40.0)
-              | (aroonu_14_15m < 30.0)
-              | (aroonu_14_1h < 80.0)
-              | (aroonu_14_4h < 80.0)
+              (rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80
             )
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
@@ -23005,7 +23004,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 40.0))
             # 15m & 4h down move, 1d high
@@ -23031,7 +23030,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 60.0) | (stochrsi_k_1d < 80.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_80)
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 75.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 1h high, 1d overbought
@@ -23041,7 +23040,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m & 1h high
@@ -23061,7 +23060,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h < 90.0) | (ema_9 < (ema_26 * 0.972)))
             # 15m down move, 4h high and downtrend
-            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.2) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.2) | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 4h & 1d downtrend
@@ -23085,15 +23084,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (rsi_14_4h < 75.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (rsi_14_4h < 75.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h downtrend, 4h overbought
             & ((rsi_3_15m > 20.0) | (cmf_20_4h > -0.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h & 4h high, 1f overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 85.0) | (rsi_14_4h < 70.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 15m & 1d down move, 1d high
@@ -23109,7 +23108,7 @@ class NostalgiaForInfinityX7(IStrategy):
               | (rsi_14_4h < 70.0)
               | (aroonu_14_15m < 20.0)
               | (aroonu_14_1h < 60.0)
-              | (aroonu_14_4h < 100.0)
+              | aroonu_14_4h_lt_100
             )
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 60.0) | (roc_9_4h < 60.0))
@@ -23122,7 +23121,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 65.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 65.0) | aroonu_14_1d_lt_100)
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
             # 1h down move, 15m downtrend, 4h still high
@@ -23132,7 +23131,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
             # 1h down move, 4h high & overbought
@@ -23154,35 +23153,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
             # 1h down move, 1h highm 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1h still high, 4h high
             & ((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
             # 1h down move, 15m still not low enough, 1h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 30.0) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 40.0) | (rsi_3_1d > 55.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h > 40.0) | (rsi_3_1d > 55.0) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 15m downtrend
@@ -23196,13 +23195,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1h & 4h high
-            & ((rsi_3_1h > 50.0) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h > 50.0) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h down move, 15m & 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
@@ -23234,11 +23233,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 20.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d overbought
@@ -23256,7 +23255,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_4h < 75.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 70.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h > 70.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
             # 1d down move, 4h high
             & ((rsi_3_1d > 3.0) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1h high
@@ -23264,7 +23263,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m & 1h still high
             & ((rsi_3_1d > 10.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
             # 1d down move, 1h & 4h still high
             & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 40.0))
             # 1d down move, 1h high & overbought
@@ -23272,9 +23271,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 60.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 80.0))
             # 1d down move, 15m still high, 1d overbought
             & ((rsi_3_1d > 65.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 100.0))
             # 1d down move, 4h & 1d high
@@ -23284,7 +23283,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m still high, 15m high
             & ((rsi_3 < 45.0) | (aroonu_14_15m < 70.0))
             # 5m still high, 1h down move, 4h high
-            & ((rsi_3 < 50.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3 < 50.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high
             & ((rsi_14_15m > 25.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h & 1d high
@@ -23294,17 +23293,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
             # 1d still high, 4h & 1d downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h top wick, 15m & 1h down move
             & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_15m > 15.0) | (rsi_3_1h > 40.0))
             # 4h top wick, 1h down move, 1h high
-            & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
+            & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
             # 1d red, 1h down move, 1h still high
             & ((change_pct_1d > -15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
             # 1d P&D, 1h high
@@ -23316,7 +23315,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, 1h high
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (stochrsi_k_1h < 70.0))
             # 1d red with top wick, 1h high
-            & ((change_pct_1d > -10.0) | (top_wick_pct_1d < 10.0) | (aroonu_14_1h < 80.0))
+            & ((change_pct_1d > -10.0) | (top_wick_pct_1d < 10.0) | aroonu_14_1h_lt_80)
             # 1d green, 4m down move, 4h high
             & ((change_pct_1d < 25.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
             # 1d green with top wick, 1d low
@@ -23328,7 +23327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 1h down move
             & ((top_wick_pct_1d < 50.0) | (rsi_3_1h > 30.0))
             # big drop in the last 12 days, 1h down move, 1h high
-            & ((close > (high_max_12_1d * 0.35)) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((close > (high_max_12_1d * 0.35)) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_70)
             # big drop in the last 20 days, 1h down move, 1h high
             & ((close > (high_max_20_1d * 0.30)) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 75.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -23591,19 +23590,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m uptrend, 1h low
           short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1h > 20.0))
           # 1h & 4h uptrend
-          short_entry_logic.append((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
+          short_entry_logic.append((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
           # 1h uptrend, 4h uptrend
           short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
           # 4h uptrend, 1d uptrend
-          short_entry_logic.append((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
+          short_entry_logic.append(aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
           # 4h uptrend, 15m uptrend
-          short_entry_logic.append((aroonu_14_4h < 100.0) | (roc_9_15m < 10.0))
+          short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_15m < 10.0))
           # 4h uptrend, 1h uptrend
-          short_entry_logic.append((aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+          short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
           # 1d uptrend, 15m uptrend
-          short_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_15m < 20.0))
+          short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_15m < 20.0))
           # 1d uptrend, 1h uptrend
-          short_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_1h < 20.0))
+          short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1h < 20.0))
           # 15m still not high enough, 1h & 4h overbought
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
           # 1h & 4h overbought, 1h uptrend
@@ -24218,7 +24217,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h high, 4h uptrend
           short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
           # 15m & 4h high, 1h uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
           # 15m high, 1d low
           short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1d > 20.0))
           # 15m high & uptrend


### PR DESCRIPTION
## Summary
- Adds reusable AROONU threshold masks for repeated entry-condition comparisons in X7.
- Keeps the branch independent on latest upstream main and avoids lines already touched by the open RSI entry-mask PRs.

## Safety
- Only replaces repeated Series comparisons with same-call boolean masks; indicator inputs, thresholds, condition order, candle selection, and return values are unchanged.
- Touched function: populate_entry_trend. No v3 grind-entry code, CMF formula, order classification, profit arithmetic, stake sizing, or leverage logic is touched.
- Conflict simulation also checked the path where the open RSI entry-mask PRs are merged first.

## Backtest scope
- A full backtest was not required for this plumbing patch because it reuses already-read Series comparison results inside the same populate_entry_trend call without changing any trading condition values or ordering.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `temporary merge simulation with perf/x7-entry-rsi3-threshold-masks and perf/x7-short-entry-threshold-masks applied first`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
